### PR TITLE
Update mesh task container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ additional containers known as sidecar containers to your task definition.
 Specifically, it adds the following containers:
 
 * `discover-servers` – Runs at startup to discover the IP address of the Consul server.
-* `mesh-init` – Runs at startup to set up initial configuration for Consul and Envoy.
+* `consul-ecs-mesh-init` – Runs at startup to set up initial configuration for Consul and Envoy.
 * `consul-client` – Runs for the full lifecycle of the task. This container runs a
   [Consul client](https://www.consul.io/docs/architecture) that connects with
   Consul servers and configures the sidecar proxy.

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -27,7 +27,7 @@ locals {
   }
 
   // container_defs_with_depends_on is the app's container definitions with their dependsOn keys
-  // modified to add in dependencies on mesh-init and sidecar-proxy.
+  // modified to add in dependencies on consul-ecs-mesh-init and sidecar-proxy.
   // We add these dependencies in so that the app containers don't start until the proxy
   // is ready to serve traffic.
   container_defs_with_depends_on = [for def in var.container_definitions :
@@ -39,7 +39,7 @@ locals {
             lookup(def, "dependsOn", []),
             [
               {
-                containerName = "mesh-init"
+                containerName = "consul-ecs-mesh-init"
                 condition     = "SUCCESS"
               },
               {
@@ -75,7 +75,7 @@ resource "aws_ecs_task_definition" "this" {
         local.container_defs_with_depends_on,
         [
           {
-            name             = "mesh-init"
+            name             = "consul-ecs-mesh-init"
             image            = var.consul_ecs_image
             essential        = false
             logConfiguration = var.log_configuration
@@ -164,7 +164,7 @@ resource "aws_ecs_task_definition" "this" {
             ]
             dependsOn = [
               {
-                containerName = "mesh-init"
+                containerName = "consul-ecs-mesh-init"
                 condition     = "SUCCESS"
               },
             ]


### PR DESCRIPTION
Indicate which container is leveraging [`consul-ecs`](https://github.com/hashicorp/consul-ecs)

## Testing

* running `terraform plan` after this change shows replacements where expected
<img width="338" alt="replace_mesh_init" src="https://user-images.githubusercontent.com/34254888/123492257-e4e29a80-d5cd-11eb-88e6-4df917924cd5.PNG">

* `terraform apply` succeeds, test server and app visible

![image](https://user-images.githubusercontent.com/34254888/123492411-4440aa80-d5ce-11eb-8e6e-d595763f214d.png)

