### PR TITLE
Use output from setup-terraform by default to create config to run acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,20 +108,7 @@ jobs:
           working_directory: test/acceptance/tests
           no_output_timeout: 1h
           command: |
-            export ecs_cluster_arn=$(terraform output -state ../setup-terraform/terraform.tfstate -json | jq -rc .ecs_cluster_arn.value | tee /dev/tty)
-            export private_subnets=$(terraform output -state ../setup-terraform/terraform.tfstate -json | jq -rc .private_subnets.value | tee /dev/tty)
-            export suffix=$(terraform output -state ../setup-terraform/terraform.tfstate -json | jq -rc .suffix.value | tee /dev/tty)
-            export region=$(terraform output -state ../setup-terraform/terraform.tfstate -json | jq -rc .region.value | tee /dev/tty)
-            export log_group_name=$(terraform output -state ../setup-terraform/terraform.tfstate -json | jq -rc .log_group_name.value | tee /dev/tty)
-            export tags=$(terraform output -state ../setup-terraform/terraform.tfstate -json | jq -rc .tags.value | tee /dev/tty)
-
-            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 30m -v -failfast \
-              -ecs-cluster-arn="$ecs_cluster_arn" \
-              -subnets="$private_subnets" \
-              -suffix="$suffix" \
-              -region="$region" \
-              -log-group-name="$log_group_name" \
-              -tf-tags="$tags"
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 30m -v -failfast
 
       - store_test_results:
           path: /tmp/test-results

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -17,35 +17,10 @@ These tests run the Terraform code.
 
    Switch back to the `test/acceptance` directory:
 
-   ```sh
-   cd ..
-   ```
-
-   Then export the necessary data from the Terraform state into environment variables:
-   
-   ```sh
-   export ecs_cluster_arn=$(terraform output -state ./setup-terraform/terraform.tfstate -json | jq -rc .ecs_cluster_arn.value | tee /dev/tty)
-   export private_subnets=$(terraform output -state ./setup-terraform/terraform.tfstate -json | jq -rc .private_subnets.value | tee /dev/tty)
-   export suffix=$(terraform output -state ./setup-terraform/terraform.tfstate -json | jq -rc .suffix.value | tee /dev/tty)
-   export region=$(terraform output -state ./setup-terraform/terraform.tfstate -json | jq -rc .region.value | tee /dev/tty)
-   export log_group_name=$(terraform output -state ./setup-terraform/terraform.tfstate -json | jq -rc .log_group_name.value | tee /dev/tty)
-   export tags=$(terraform output -state ./setup-terraform/terraform.tfstate -json | jq -rc .tags.value | tee /dev/tty)
-   ```
-
-   **NOTE:** If you see an empty line in the output from this command then
-   something wasn't exported properly.
-
-   Now you're ready to run the acceptance tests.
 1. To run the tests, use `go test` from the `test/acceptance` directory:
 
    ```sh
-   go test ./... -p 1 -timeout 30m -v -failfast \
-     -ecs-cluster-arn="$ecs_cluster_arn" \
-     -subnets="$private_subnets" \
-     -suffix="$suffix" \
-     -region="$region" \
-     -log-group-name="$log_group_name" \
-     -tf-tags="$tags"
+   go test ./... -p 1 -timeout 30m -v -failfast
    ```
 
    You may want to add the `-no-cleanup-on-failure` flag if you're debugging

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -1,21 +1,20 @@
 package config
 
-// TestConfig holds configuration for the test suite
+// TestConfig holds configuration for the test suite.
 type TestConfig struct {
 	NoCleanupOnFailure bool
-	ECSClusterARN      string
-	Subnets            string
+	ECSClusterARN      string `json:"ecs_cluster_arn"`
+	Subnets            interface{}
 	Suffix             string
 	Region             string
-	LogGroupName       string
-	Tags               string
+	LogGroupName       string `json:"log_group_name"`
+	Tags               interface{}
 }
 
 func (t TestConfig) TFVars() map[string]interface{} {
 	vars := map[string]interface{}{
 		"ecs_cluster_arn": t.ECSClusterARN,
 		"subnets":         t.Subnets,
-		"suffix":          t.Suffix,
 		"region":          t.Region,
 		"log_group_name":  t.LogGroupName,
 	}

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -1,7 +1,10 @@
 package flags
 
 import (
+	"encoding/json"
 	"flag"
+	"fmt"
+	"os/exec"
 	"sync"
 
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/config"
@@ -11,22 +14,24 @@ const (
 	flagNoCleanupOnFailure = "no-cleanup-on-failure"
 	flagECSClusterARN      = "ecs-cluster-arn"
 	flagSubnets            = "subnets"
-	flagSuffix             = "suffix"
 	flagRegion             = "region"
 	flagLogGroupName       = "log-group-name"
 	// flagTFTags is named to disambiguate from the --tags flags used
 	// by go test to specify build tags.
-	flagTFTags = "tf-tags"
+	flagTFTags      = "tf-tags"
+	flagTFOutputDir = "tf-output-dir"
+
+	setupTerraformDir = "../../setup-terraform"
 )
 
 type TestFlags struct {
 	flagNoCleanupOnFailure bool
 	flagECSClusterARN      string
 	flagSubnets            string
-	flagSuffix             string
 	flagRegion             string
 	flagLogGroupName       string
 	flagTFTags             string
+	flagTFOutputDir        string
 
 	once sync.Once
 }
@@ -44,10 +49,10 @@ func (t *TestFlags) init() {
 			"Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.")
 	flag.StringVar(&t.flagECSClusterARN, flagECSClusterARN, "", "ECS Cluster ARN.")
 	flag.StringVar(&t.flagSubnets, flagSubnets, "", "Subnets to deploy into. In TF var form, e.g. '[\"sub1\",\"sub2\"]'.")
-	flag.StringVar(&t.flagSuffix, flagSuffix, "", "Resource suffix.")
 	flag.StringVar(&t.flagRegion, flagRegion, "", "Region.")
 	flag.StringVar(&t.flagLogGroupName, flagLogGroupName, "", "CloudWatch log group name.")
 	flag.StringVar(&t.flagTFTags, flagTFTags, "", "Tags to add to resources. In TF var form, e.g. '{key=val,key2=val2}'.")
+	flag.StringVar(&t.flagTFOutputDir, flagTFOutputDir, setupTerraformDir, "The directory of the setup terraform state for the tests.")
 }
 
 func (t *TestFlags) Validate() error {
@@ -55,14 +60,54 @@ func (t *TestFlags) Validate() error {
 	return nil
 }
 
-func (t *TestFlags) TestConfigFromFlags() *config.TestConfig {
-	return &config.TestConfig{
-		NoCleanupOnFailure: t.flagNoCleanupOnFailure,
-		ECSClusterARN:      t.flagECSClusterARN,
-		Subnets:            t.flagSubnets,
-		Suffix:             t.flagSuffix,
-		Region:             t.flagRegion,
-		LogGroupName:       t.flagLogGroupName,
-		Tags:               t.flagTFTags,
+type tfOutputItem struct {
+	Value interface{}
+	Type  interface{}
+}
+
+func (t *TestFlags) TestConfigFromFlags() (*config.TestConfig, error) {
+	var cfg config.TestConfig
+
+	if t.flagTFOutputDir != "" {
+		var tfOutput map[string]tfOutputItem
+		testConfigMap := make(map[string]interface{})
+		cmd := exec.Command("terraform", "output", "-state", fmt.Sprintf("%s/terraform.tfstate", t.flagTFOutputDir), "-json")
+		cmdOutput, err := cmd.CombinedOutput()
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(cmdOutput, &tfOutput)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range tfOutput {
+			if k == "private_subnets" {
+				testConfigMap["subnets"] = v.Value
+			} else {
+				testConfigMap[k] = v.Value
+			}
+		}
+		testConfigJSON, err := json.Marshal(testConfigMap)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(testConfigJSON, &cfg)
+		if err != nil {
+			fmt.Println("error unmarshalling", err)
+		}
+	} else {
+		cfg = config.TestConfig{
+			NoCleanupOnFailure: t.flagNoCleanupOnFailure,
+			ECSClusterARN:      t.flagECSClusterARN,
+			Subnets:            t.flagSubnets,
+			Region:             t.flagRegion,
+			LogGroupName:       t.flagLogGroupName,
+			Tags:               t.flagTFTags,
+		}
 	}
+
+	cfg.NoCleanupOnFailure = t.flagNoCleanupOnFailure
+
+	return &cfg, nil
 }

--- a/test/acceptance/framework/suite/suite.go
+++ b/test/acceptance/framework/suite/suite.go
@@ -25,11 +25,8 @@ func NewSuite(m *testing.M) Suite {
 
 	flag.Parse()
 
-	testConfig := flags.TestConfigFromFlags()
-
 	return &suite{
 		m:     m,
-		cfg:   testConfig,
 		flags: flags,
 	}
 }
@@ -40,6 +37,13 @@ func (s *suite) Run() int {
 		fmt.Printf("Flag validation failed: %s\n", err)
 		return 1
 	}
+
+	testConfig, err := s.flags.TestConfigFromFlags()
+	if err != nil {
+		fmt.Printf("Failed to create test config: %s\n", err)
+		return 1
+	}
+	s.cfg = testConfig
 
 	return s.m.Run()
 }

--- a/test/acceptance/setup-terraform/outputs.tf
+++ b/test/acceptance/setup-terraform/outputs.tf
@@ -2,7 +2,7 @@ output "ecs_cluster_arn" {
   value = aws_ecs_cluster.this.arn
 }
 
-output "private_subnets" {
+output "subnets" {
   value = module.vpc.private_subnets
 }
 

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -61,7 +61,7 @@ func TestBasic(t *testing.T) {
 			})
 
 			defer func() {
-				if suite.Config().NoCleanupOnFailure {
+				if suite.Config().NoCleanupOnFailure && t.Failed() {
 					logger.Log(t, "skipping resource cleanup because -no-cleanup-on-failure=true")
 				} else {
 					terraform.Destroy(t, terraformOptions)


### PR DESCRIPTION
Since we use `setup-terraform` template to set up our acceptance tests, I thought it'd be nice if tests just took the output of that terraform and parsed them into the test config. This makes running tests locally much easier. Let me know what you think!

This PR also adds a few other minor changes:
- Skip cleanup if both `-no-cleanup-on-failure` is set and if test has failed.
- Removes `-suffix` flag. We were no longer using it after the change to generate random ids for each test in #19 