### PR TITLE
"Proper" CI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,15 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
 executors:
-  go:
+  consul-ecs-test:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.14
+      - image: ghcr.io/pglass/consul-ecs-test:latest
     environment:
-      TEST_RESULTS: /tmp/test-results # path to where test results are saved
-      CONSUL_VERSION: 1.9.4 # Consul's OSS version to use in tests
+      TEST_RESULTS: &TEST_RESULTS /tmp/test-results # path to where test results are saved
 
 jobs:
   go-fmt-and-lint-acceptance:
-    executor: go
+    executor: consul-ecs-test
     steps:
       - checkout
 
@@ -34,6 +33,7 @@ jobs:
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
           name: check go fmt
+          working_directory: test/acceptance
           command: |
             files=$(go fmt ./...)
             if [ -n "$files" ]; then
@@ -51,9 +51,8 @@ jobs:
           name: lint-consul-retry
           working_directory: test/acceptance
           command: |
-            go get -u github.com/hashicorp/lint-consul-retry && lint-consul-retry
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
-            golangci-lint run
+            go get -u github.com/hashicorp/lint-consul-retry
+            lint-consul-retry
 
       - run:
           name: golangci-lint
@@ -63,17 +62,13 @@ jobs:
             golangci-lint run
 
   terraform-fmt:
-    docker:
-      - image: ghcr.io/lkysow/consul-ecs-test:0.1.0
+    executor: consul-ecs-test
     steps:
       - checkout
       - run: terraform fmt -check -recursive .
 
   acceptance:
-    environment:
-      - TEST_RESULTS: /tmp/test-results
-    docker:
-      - image: ghcr.io/lkysow/consul-ecs-test:0.1.0
+    executor: consul-ecs-test
     steps:
       - checkout
 
@@ -111,9 +106,9 @@ jobs:
             gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 30m -v -failfast
 
       - store_test_results:
-          path: /tmp/test-results
+          path: *TEST_RESULTS
       - store_artifacts:
-          path: /tmp/test-results
+          path: *TEST_RESULTS
 
       - run:
           name: terraform destroy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   consul-ecs-test:
     docker:
-      - image: ghcr.io/pglass/consul-ecs-test:latest
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.2.0
     environment:
       TEST_RESULTS: &TEST_RESULTS /tmp/test-results # path to where test results are saved
 
@@ -73,6 +73,7 @@ jobs:
       - checkout
 
       - run:
+          # Environment variables for IAM roles are unsupported: https://github.com/aws/aws-cli/issues/5639
           name: configure aws
           command: |
             aws configure --profile ecs_user set aws_access_key_id "$AWS_ACCESS_KEY_ID"

--- a/examples/dev-server-ec2/main.tf
+++ b/examples/dev-server-ec2/main.tf
@@ -61,7 +61,7 @@ module "example_client_app" {
   log_configuration = local.example_client_app_log_config
   container_definitions = [{
     name             = "example-client-app"
-    image            = "ghcr.io/lkysow/fake-service:v0.21.0"
+    image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential        = true
     logConfiguration = local.example_client_app_log_config
     environment = [
@@ -112,7 +112,7 @@ module "example_server_app" {
   log_configuration        = local.example_server_app_log_config
   container_definitions = [{
     name             = "example-server-app"
-    image            = "ghcr.io/lkysow/fake-service:v0.21.0"
+    image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential        = true
     logConfiguration = local.example_server_app_log_config
     environment = [

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -59,7 +59,7 @@ module "example_client_app" {
   log_configuration = local.example_client_app_log_config
   container_definitions = [{
     name             = "example-client-app"
-    image            = "ghcr.io/lkysow/fake-service:v0.21.0"
+    image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential        = true
     logConfiguration = local.example_client_app_log_config
     environment = [
@@ -108,7 +108,7 @@ module "example_server_app" {
   log_configuration = local.example_server_app_log_config
   container_definitions = [{
     name             = "example-server-app"
-    image            = "ghcr.io/lkysow/fake-service:v0.21.0"
+    image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential        = true
     logConfiguration = local.example_server_app_log_config
     environment = [

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -106,7 +106,7 @@ module "test_client" {
   family = "test_client_${var.suffix}"
   container_definitions = [{
     name      = "basic"
-    image     = "ghcr.io/lkysow/fake-service:v0.21.0"
+    image     = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential = true
     environment = [
       {
@@ -160,7 +160,7 @@ module "test_server" {
   family = "test_server_${var.suffix}"
   container_definitions = [{
     name      = "basic"
-    image     = "ghcr.io/lkysow/fake-service:v0.21.0"
+    image     = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential = true
   }]
   retry_join = module.consul_server.server_dns

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -1,0 +1,36 @@
+# This Dockerfile includes the dependencies for unit and acceptance tests
+# run in CircleCI.
+FROM circleci/golang:1.16
+
+# change the user to root so we can install stuff
+USER root
+
+ENV TERRAFORM_VERSION "1.0.5"
+
+# base packages
+RUN apt-get install -y \
+    openssl \
+    jq
+
+# terraform
+RUN curl -sSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o /tmp/tf.zip \
+    && unzip /tmp/tf.zip  \
+    && mv ./terraform /usr/local/bin/terraform \
+    && rm -f /tmp/tf.zip \
+    && terraform --version
+
+# AWS CLI
+RUN curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install --bin-dir /usr/local/bin \
+    && rm awscliv2.zip \
+    && rm -rf ./aws \
+    && aws --version
+
+# session-manager-plugin for 'aws ecs execute-command'
+RUN curl -sSL https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb -o session-manager-plugin.deb \
+    && sudo dpkg -i session-manager-plugin.deb  \
+    && rm session-manager-plugin.deb
+
+# change the user back to what circleci/golang image has
+USER circleci


### PR DESCRIPTION
* Add a `Test.dockerfile` to build the `consul-ecs-test` image. I manually built and pushed `hashicorpdev/consul-ecs-test:0.2.0`
* Switch to HashiCorp mirror URLs
* Tidy the Circle CI config