### PR TITLE
fix: added support for adding custom tags that append to existing value

### DIFF
--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -168,9 +168,11 @@ resource "aws_ecs_task_definition" "this" {
   volume {
     name = local.consul_data_volume_name
   }
-  tags = {
+
+  tags = merge(var.tags, {
     "consul.hashicorp.com/mesh" = "true"
-  }
+  })
+
   container_definitions = jsonencode(
     flatten(
       concat(

--- a/modules/mesh-task/outputs.tf
+++ b/modules/mesh-task/outputs.tf
@@ -1,3 +1,8 @@
 output "task_definition_arn" {
   value = aws_ecs_task_definition.this.arn
 }
+
+output "task_tags" {
+  value = aws_ecs_task_definition.this.tags_all
+}
+


### PR DESCRIPTION
This PR adds support for custom tags while retaining the default value of `"consul.hashicorp.com/mesh" = "true"`. In addition, the output for displaying all provided tags is also added. 

Closes #29 
