### PR TITLE
Update the changelog + docker image for the 0.2.0-beta2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.2.0-beta2 (Sep 30, 2021) 
+
 FEATURES
 * modules/mesh-task: Add `checks` variable to define Consul native checks.
   [[GH-41](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/41)]

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -1,7 +1,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.2.0-beta1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.2.0-beta2"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -54,7 +54,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.2.0-beta1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.2.0-beta2"
 }
 
 variable "envoy_image" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Update the changelog for the 0.2.0-beta2 release
- Update the default docker images for the acl controller and mesh task to the 0.2.0-beta2 one

## How I've tested this PR:
On CI

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added