### PR TITLE
Run mesh-init as a non root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ FEATURES
   ECS health checks are defined and there aren't any Consul health checks
   [[GH-45](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/45)]
 
+IMPROVEMENTS
+* modules/mesh-task: Run the `consul-ecs-mesh-init` container with the
+  `consul-ecs` user instead of `root`
+  [[GH-52](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/52)]
+
 ## 0.2.0-beta2 (Sep 30, 2021)
 
 FEATURES


### PR DESCRIPTION
## Changes proposed in this PR:
- Run mesh-init container with the `consul-ecs` user. This currently is just being used to bring in the changes from https://github.com/hashicorp/consul-ecs/pull/37
- switches all of the non-root sidecar containers to have read only access to /consul


## How I've tested this PR:
- Tests
- The examples after updating the consul ecs image to the latest one

## How I expect reviewers to test this PR:
Verify the tests.

## Checklist:
- [ ] Tests added (The existing tests should verify this)
- [X] CHANGELOG entry added