### PR TITLE
Inject Consul Binary into mesh-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ IMPROVEMENTS
 * modules/mesh-task: Run the `consul-ecs-mesh-init` container with the
   `consul-ecs` user instead of `root`
   [[GH-52](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/52)]
+* modules/mesh-task: The Consul binary is now inserted into
+  `consul-ecs-mesh-init` from the `consul-client` container. This means that
+  each release of `consul-ecs` will work with multiple Consul versions.
+  [[GH-53](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/53)]
 
 ## 0.2.0-beta2 (Sep 30, 2021)
 

--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -1,3 +1,5 @@
+cp /bin/consul /bin/consul-inject/consul
+
 ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
 
 %{ if tls }


### PR DESCRIPTION
## Changes proposed in this PR:
Inject the consul binary from the `consul-client` container into the `consul-ecs-mesh-init` container. This makes it possible for users to choose a Consul version rather than using the bundled Consul binary.

This works by:
1. [In the consul-ecs PR it adds /bin/consul-inject to `PATH`](https://github.com/hashicorp/consul-ecs/pull/40/files#diff-6893ac12af1d710fd632a552b4730959c03f4c65951aa1f24abefed1d2ed8dbbR31)
2. [Creating the `consul_binary` volume](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/53/files#diff-d199811c704b41ad0c92ffa5d1f81f20acfb3a7347efad8099bb7b47d044a1edR16)
3. Mounting the volume from the [`consul-client` container](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/53/files#diff-d199811c704b41ad0c92ffa5d1f81f20acfb3a7347efad8099bb7b47d044a1edR282-R285) and [`consul-ecs-mesh-init` container](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/53/files#diff-d199811c704b41ad0c92ffa5d1f81f20acfb3a7347efad8099bb7b47d044a1edR234-R238)
4. [Copying the `consul` binary to the volume from the `consul-client` container](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/53/files#diff-1c8da966aeb50d584523e5bfcf01139fdc628cc3bdc5168673f1e912926427a0R1)

## How I've tested this PR:
I updated the consul-ecs container images to reference the ones created in [the associated consul-ecs PR](https://github.com/hashicorp/consul-ecs/pull/40) to ensure the tests pass and examples continue running as expected.

Merge process:
1. Merge https://github.com/hashicorp/consul-ecs/pull/40
2. Undo all of the changes to `consul_ecs_image` and ensure the tests pass
3. Merge this

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added 