### PR TITLE
Spread NAT gateways across AZs

### DIFF
--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -18,13 +18,24 @@ resource "random_string" "suffix" {
   special = false
 }
 
+resource "random_shuffle" "azs" {
+  input = data.aws_availability_zones.available.names
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.78.0"
 
-  name                 = local.name
-  cidr                 = "10.0.0.0/16"
-  azs                  = data.aws_availability_zones.available.names
+  name = local.name
+  cidr = "10.0.0.0/16"
+  // The NAT gateway limit is per AZ. With `single_nat_gateway = true`, the NAT gateway is created
+  // in the first public subnet. Shuffling AZs helps spread NAT gateways across AZs to help with this.
+  azs = [
+    // Silly, but avoids this error: `"count" value depends on resource attributes that cannot be determined until apply`
+    random_shuffle.azs.result[0],
+    random_shuffle.azs.result[1],
+    random_shuffle.azs.result[2],
+  ]
   private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
   enable_nat_gateway   = true


### PR DESCRIPTION
## Changes proposed in this PR:
Shuffle availability zone list to avoid always creating NAT gateways in the same AZ. 

This should help avoid running into the "NAT Gateways per Availability Zone" limit in AWS.

## How I've tested this PR:
- Acceptance tests in CI
- Manual test and checking before/after:

  * Before: <img width="1405" alt="Screen Shot 2021-10-25 at 5 38 02 PM" src="https://user-images.githubusercontent.com/1077740/138780788-bd44cbe0-dd8c-44d1-aca6-6986c73a8782.png">
  * After: <img width="1389" alt="Screen Shot 2021-10-25 at 5 42 23 PM" src="https://user-images.githubusercontent.com/1077740/138780794-6ffcccb5-8087-4b6e-80ae-0b567b093c79.png">
  * NAT gateway _not_ in us-west-2a: 
  <img width="386" alt="Screen Shot 2021-10-25 at 5 53 48 PM" src="https://user-images.githubusercontent.com/1077740/138781712-44717339-38f7-4ed3-9318-26654fef7ca4.png">

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] ~Tests added~ Existing tests are enough
- [ ] ~CHANGELOG entry added~ None, test-only change

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::