### PR TITLE
Add the Ability to Set More Consul Service Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ FEATURES
 * modules/mesh-task: Run a health-sync container for essential containers when
   ECS health checks are defined and there aren't any Consul health checks
   [[GH-45](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/45)]
+* modules/mesh-task: Add `consul_service_tags`, `consul_service_meta` and
+  `consul_service_name` input variables to the mesh-task. When
+  `consul_service_name` is unset, the ECS task family name is used for the
+  Consul service name.
+  [[GH-58](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/58)]
 
 IMPROVEMENTS
 * modules/mesh-task: Run the `consul-ecs-mesh-init` container with the

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -3,6 +3,24 @@ variable "family" {
   type        = string
 }
 
+variable "consul_service_name" {
+  description = "The name the service will be registered as in Consul. Defaults to the Task family name."
+  type        = string
+  default     = ""
+}
+
+variable "consul_service_tags" {
+  description = "A list of tags included in the Consul service registration."
+  type        = list(string)
+  default     = []
+}
+
+variable "consul_service_meta" {
+  description = "A map of metadata that will be used for the Consul service registration"
+  type        = map(string)
+  default     = {}
+}
+
 variable "requires_compatibilities" {
   description = "Set of launch types required by the task."
   type        = list(string)

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -12,6 +12,8 @@ type TestConfig struct {
 	RouteTableIDs      []string `json:"route_table_ids"`
 	LogGroupName       string   `json:"log_group_name"`
 	Tags               interface{}
+	ClientServiceName  string
+	ServerServiceName  string
 }
 
 func (t TestConfig) TFVars(ignoreVars ...string) map[string]interface{} {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -52,6 +52,11 @@ variable "consul_ecs_image" {
   default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
 }
 
+variable "server_service_name" {
+  description = "The service name for the test_server"
+  type        = string
+}
+
 provider "aws" {
   region = var.region
 }
@@ -199,7 +204,7 @@ EOT
   retry_join = module.consul_server.server_dns
   upstreams = [
     {
-      destination_name = "test_server_${var.suffix}"
+      destination_name = "${var.server_service_name}_${var.suffix}"
       local_bind_port  = 1234
     }
   ]
@@ -231,8 +236,9 @@ resource "aws_ecs_service" "test_server" {
 }
 
 module "test_server" {
-  source = "../../../../../../modules/mesh-task"
-  family = "test_server_${var.suffix}"
+  source              = "../../../../../../modules/mesh-task"
+  family              = "test_server_${var.suffix}"
+  consul_service_name = "${var.server_service_name}_${var.suffix}"
   container_definitions = [{
     name             = "basic"
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"


### PR DESCRIPTION
## Changes proposed in this PR:
- Add `service_tags`, `service_meta` and `service_name` input variables to the mesh-task. When `service_name` is set, it is used as the Consul service name rather than the ECS task's family name in the mesh-init container, the health-sync container and the ACL controller.

## How I've tested this PR:
Tests

## How I expect reviewers to test this PR:
👁️ 

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added 