### PR TITLE
Support Multiple Consul Nodes with `retry_join`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## UNRELEASED
 
+BREAKING CHANGES
+* modules/mesh-task: The retry_join variable was updated to take a list of
+  members rather than a single member.
+  [[GH-59](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/59)]
+
 FEATURES
 * modules/mesh-task: Run a health-sync container for essential containers when
   ECS health checks are defined and there aren't any Consul health checks

--- a/examples/dev-server-ec2/main.tf
+++ b/examples/dev-server-ec2/main.tf
@@ -85,7 +85,7 @@ module "example_client_app" {
     mountPoints = []
     volumesFrom = []
   }]
-  retry_join = module.dev_consul_server.server_dns
+  retry_join = [module.dev_consul_server.server_dns]
 }
 
 # The server app is part of the service mesh. It's called
@@ -122,7 +122,7 @@ module "example_server_app" {
       }
     ]
   }]
-  retry_join = module.dev_consul_server.server_dns
+  retry_join = [module.dev_consul_server.server_dns]
 }
 
 resource "aws_lb" "example_client_app" {

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -83,7 +83,7 @@ module "example_client_app" {
     mountPoints = []
     volumesFrom = []
   }]
-  retry_join = module.dev_consul_server.server_dns
+  retry_join = [module.dev_consul_server.server_dns]
 }
 
 # The server app is part of the service mesh. It's called
@@ -118,7 +118,7 @@ module "example_server_app" {
       }
     ]
   }]
-  retry_join = module.dev_consul_server.server_dns
+  retry_join = [module.dev_consul_server.server_dns]
 }
 
 resource "aws_lb" "example_client_app" {

--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -17,7 +17,9 @@ exec consul agent \
   -hcl 'addresses = { dns = "127.0.0.1" }' \
   -hcl 'addresses = { grpc = "127.0.0.1" }' \
   -hcl 'addresses = { http = "127.0.0.1" }' \
-  -retry-join "${retry_join}" \
+%{ for j in retry_join ~}
+  -retry-join "${j}" \
+%{ endfor ~}
   -hcl 'telemetry { disable_compat_1.9 = true }' \
   -hcl 'leave_on_terminate = true' \
   -hcl 'ports { grpc = 8502 }' \

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -98,8 +98,8 @@ variable "checks" {
 }
 
 variable "retry_join" {
-  description = "Argument to pass to -retry-join (https://www.consul.io/docs/agent/options#_retry_join). This or consul_server_service_name must be set."
-  type        = string
+  description = "Arguments to pass to -retry-join (https://www.consul.io/docs/agent/options#_retry_join). This or consul_server_service_name must be set."
+  type        = list(string)
 }
 
 variable "tags" {

--- a/test/acceptance/tests/basic/terraform/acl-secret-name-prefix-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/acl-secret-name-prefix-validate/main.tf
@@ -9,7 +9,7 @@ module "test_client" {
     name = "basic"
   }]
   outbound_only                  = true
-  retry_join                     = "test"
+  retry_join                     = ["test"]
   acls                           = true
   consul_client_token_secret_arn = "foo"
 }

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -196,7 +196,7 @@ EOT
       ]
     }
   ]
-  retry_join = module.consul_server.server_dns
+  retry_join = [module.consul_server.server_dns]
   upstreams = [
     {
       destination_name = "test_server_${var.suffix}"
@@ -239,7 +239,7 @@ module "test_server" {
     essential        = true
     logConfiguration = local.test_server_log_configuration
   }]
-  retry_join        = module.consul_server.server_dns
+  retry_join        = [module.consul_server.server_dns]
   log_configuration = local.test_server_log_configuration
   checks = [
     {

--- a/test/acceptance/tests/basic/terraform/ca-cert-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/ca-cert-validate/main.tf
@@ -9,6 +9,6 @@ module "test_client" {
     name = "basic"
   }]
   outbound_only = true
-  retry_join    = "test"
+  retry_join    = ["test"]
   tls           = true
 }

--- a/test/acceptance/tests/basic/terraform/consul-client-token-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/consul-client-token-validate/main.tf
@@ -9,7 +9,7 @@ module "test_client" {
     name = "basic"
   }]
   outbound_only          = true
-  retry_join             = "test"
+  retry_join             = ["test"]
   acls                   = true
   acl_secret_name_prefix = "foo"
 }

--- a/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
@@ -133,7 +133,7 @@ module "test_client" {
       initProcessEnabled = true
     }
   }]
-  retry_join = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["retry_join"][0]
+  retry_join = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["retry_join"]
   upstreams = [
     {
       destination_name = "test_server_${var.suffix}"
@@ -182,7 +182,7 @@ module "test_server" {
     image     = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential = true
   }]
-  retry_join = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["retry_join"][0]
+  retry_join = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["retry_join"]
   log_configuration = {
     logDriver = "awslogs"
     options = {


### PR DESCRIPTION
## Changes proposed in this PR:
- modules/mesh-task: The `retry_join`variable was updated to take a list of members rather than a single member. This is a breaking change.

## How I've tested this PR:
- I tried these changes out with [a "standard" tier deployment](https://github.com/hashicorp/terraform-aws-consul-ecs/commit/89ae81e659185477937af5b67ce134ddb0816731) and confirmed that the tests pass. A standard tier deployment runs on three nodes.

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added - Not needed
- [x] CHANGELOG entry added 