### PR TITLE
Allow passing volumes into mesh-task

### DIFF
--- a/examples/dev-server-ec2/main.tf
+++ b/examples/dev-server-ec2/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.53.0"
+      version = "3.63.0"
     }
   }
 }

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.42.0"
+      version = "3.63.0"
     }
   }
 }

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -207,6 +207,70 @@ resource "aws_ecs_task_definition" "this" {
     name = local.consul_binary_volume_name
   }
 
+  dynamic "volume" {
+    for_each = var.volumes
+    content {
+      name      = volume.value["name"]
+      host_path = lookup(volume.value, "host_path", null)
+
+      dynamic "docker_volume_configuration" {
+        for_each = contains(keys(volume.value), "docker_volume_configuration") ? [
+          volume.value["docker_volume_configuration"]
+        ] : []
+        content {
+          autoprovision = lookup(docker_volume_configuration.value, "autoprovision", null)
+          driver_opts   = lookup(docker_volume_configuration.value, "driver_opts", null)
+          driver        = lookup(docker_volume_configuration.value, "driver", null)
+          labels        = lookup(docker_volume_configuration.value, "labels", null)
+          scope         = lookup(docker_volume_configuration.value, "scope", null)
+        }
+      }
+
+      dynamic "efs_volume_configuration" {
+        for_each = contains(keys(volume.value), "efs_volume_configuration") ? [
+          volume.value["efs_volume_configuration"]
+        ] : []
+        content {
+          file_system_id          = efs_volume_configuration.value["file_system_id"]
+          root_directory          = lookup(efs_volume_configuration.value, "root_directory", null)
+          transit_encryption      = lookup(efs_volume_configuration.value, "transit_encryption", null)
+          transit_encryption_port = lookup(efs_volume_configuration.value, "transit_encryption_port", null)
+          dynamic "authorization_config" {
+            for_each = contains(keys(efs_volume_configuration.value), "authorization_config") ? [
+              efs_volume_configuration.value["authorization_config"]
+            ] : []
+            content {
+              access_point_id = lookup(authorization_config.value, "access_point_id", null)
+              iam             = lookup(authorization_config.value, "iam", null)
+            }
+          }
+        }
+      }
+
+      dynamic "fsx_windows_file_server_volume_configuration" {
+        for_each = contains(keys(volume.value), "fsx_windows_file_server_volume_configuration") ? [
+          volume.value["fsx_windows_file_server_volume_configuration"]
+        ] : []
+
+        content {
+          // All fields required.
+          file_system_id = fsx_windows_file_server_volume_configuration.value["file_system_id"]
+          root_directory = fsx_windows_file_server_volume_configuration.value["root_directory"]
+          dynamic "authorization_config" {
+            for_each = contains(keys(fsx_windows_file_server_volume_configuration.value), "authorization_config") ? [
+              fsx_windows_file_server_volume_configuration.value["authorization_config"]
+            ] : []
+            content {
+              // All fields required.
+              credentials_parameter = authorization_config.value["credentials_parameter"]
+              domain                = authorization_config.value["domain"]
+            }
+          }
+        }
+      }
+    }
+  }
+
   tags = merge(
     var.tags,
     { "consul.hashicorp.com/mesh" = "true" },

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -39,6 +39,12 @@ variable "memory" {
   default     = 512
 }
 
+variable "volumes" {
+  description = "List of volumes to include in the aws_ecs_task_definition resource."
+  type        = any
+  default     = []
+}
+
 variable "additional_task_role_policies" {
   description = "List of additional policy ARNs to attach to the task role."
   type        = list(string)

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -60,6 +60,59 @@ func TestValidation_ACLSecretNamePrefixIsRequiredIfACLsIsEnabled(t *testing.T) {
 	require.Contains(t, err.Error(), "ERROR: acl_secret_name_prefix must be set if acls is true")
 }
 
+// TestVolumeVariable tests passing a list of volumes to mesh-task.
+// This validates a big nested dynamic block in mesh-task.
+func TestVolumeVariable(t *testing.T) {
+	// terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+	volumes := []map[string]interface{}{
+		{
+			"name": "my-vol1",
+		},
+		{
+			"name":      "my-vol2",
+			"host_path": "/tmp/fake/path",
+		},
+		{
+			"name":                        "no-optional-fields",
+			"docker_volume_configuration": map[string]interface{}{},
+			"efs_volume_configuration": map[string]interface{}{
+				"file_system_id": "fakeid123",
+			},
+		},
+		{
+			"name": "all-the-fields",
+			"docker_volume_configuration": map[string]interface{}{
+				"scope":         "shared",
+				"autoprovision": true,
+				"driver":        "local",
+				"driver_opts": map[string]interface{}{
+					"type":   "nfs",
+					"device": "host.example.com:/",
+					"o":      "addr=host.example.com,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport",
+				},
+			},
+			"fsx_windows_file_server_volume_configuration": map[string]interface{}{
+				"file_system_id": "fakeid456",
+				"root_directory": `\\data`,
+				"authorization_config": map[string]interface{}{
+					"credentials_parameter": "arn:aws:secretsmanager:us-east-1:000000000000:secret:fake-fake-fake-fake",
+					"domain":                "domain-name",
+				},
+			},
+		},
+	}
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "./terraform/volume-variable",
+		Vars:         map[string]interface{}{"volumes": volumes},
+		NoColor:      true,
+	}
+	t.Cleanup(func() {
+		_, _ = terraform.DestroyE(t, terraformOptions)
+	})
+	terraform.InitAndPlan(t, terraformOptions)
+}
+
 func TestBasic(t *testing.T) {
 	randomSuffix := strings.ToLower(random.UniqueId())
 	tfVars := suite.Config().TFVars("route_table_ids")

--- a/test/acceptance/tests/basic/terraform/volume-variable/main.tf
+++ b/test/acceptance/tests/basic/terraform/volume-variable/main.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "volumes" {
+  type = any
+}
+
+module "test_client" {
+  source  = "../../../../../../modules/mesh-task"
+  family  = "family"
+  volumes = var.volumes
+  container_definitions = [{
+    name = "basic"
+  }]
+  retry_join    = "test"
+  outbound_only = true
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Add a `volumes` variable to mesh-task so that users can define additional volumes for the ECS task

## How I've tested this PR:
Unit test included

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::