### PR TITLE
Fix a secrets manager deletion and recreation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ IMPROVEMENTS
   shut down gracefully. [[GH-48](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/48)]
   [[GH-61](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/61)]
 
+BUG FIXES
+* modules/acl-controller and modules/mesh-task: Fix a bug that results in
+  AWS Secrets Manager secrets failing to be created.
+  [[GH-63](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/63)]
+
 ## 0.2.0-beta2 (Sep 30, 2021)
 
 FEATURES

--- a/modules/acl-controller/main.tf
+++ b/modules/acl-controller/main.tf
@@ -1,5 +1,6 @@
 resource "aws_secretsmanager_secret" "client_token" {
-  name = "${var.name_prefix}-consul-client-token"
+  name                    = "${var.name_prefix}-consul-client-token"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "client_token" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -181,8 +181,9 @@ resource "aws_iam_role_policy_attachment" "additional_execution_policies" {
 }
 
 resource "aws_secretsmanager_secret" "service_token" {
-  count = var.acls ? 1 : 0
-  name  = "${var.acl_secret_name_prefix}-${var.family}"
+  count                   = var.acls ? 1 : 0
+  name                    = "${var.acl_secret_name_prefix}-${var.family}"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "service_token" {


### PR DESCRIPTION
## Changes proposed in this PR:
Since the ACL-controller/mesh task rely on deterministic secret names, we need the ability to delete a secret and then recreate it. Without this change deleting and recreating a secrete got this error: "Error: error creating Secrets Manager Secret: InvalidRequestException: You can't create this secret because a secret with this name is already scheduled for deletion."

## How I've tested this PR:
With the ACLs enabled:
1. Create a mesh task service
2. Delete a mesh task service
3. Recreate the mesh task service

## How I expect reviewers to test this PR:
👁️ 

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 