### PR TITLE
Allow assigning public ip to ACL controller task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## UNRELEASED
+
+FEATURES
+* modules/acl-controller: Add `assign_public_ip` variable to the ACL controller
+  to support running on public subnets.
+  [[GH-64](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/64)]
+
 ## 0.2.0 (Nov 16, 2021)
 
 BREAKING CHANGES

--- a/modules/acl-controller/main.tf
+++ b/modules/acl-controller/main.tf
@@ -14,7 +14,8 @@ resource "aws_ecs_service" "this" {
   task_definition = aws_ecs_task_definition.this.arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets          = var.subnets
+    assign_public_ip = var.assign_public_ip
   }
   launch_type            = var.launch_type
   enable_execute_command = true

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -57,3 +57,9 @@ variable "consul_server_ca_cert_arn" {
   type        = string
   default     = ""
 }
+
+variable "assign_public_ip" {
+  description = "Configure the ECS Service to assign a public IP to the task. This is required if running tasks on a public subnet."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Changes proposed in this PR:
Add [`assign_public_ip`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#assign_public_ip) to ACL controller, which is passed through to the ECS service.

## How I've tested this PR:
Manually:
- Create VPC with public subnets only
- Run the dev-server in secure config with `assign_public_ip = true`
- Run the consul-acl-controller with `assign_public_ip = true`
- Validate the ACL controller service shows `Auto-assign public IP   ENABLED` ![Screen Shot 2021-11-11 at 2 34 04 PM](https://user-images.githubusercontent.com/1077740/141365200-26d06082-b2f0-4f0d-bee4-111b5713c803.png)
- Validate the ACL controller was able to start and is assigned a public ip: ![Screen Shot 2021-11-11 at 2 36 35 PM](https://user-images.githubusercontent.com/1077740/141365498-367f6828-4892-4069-ac53-8fb8cf194762.png)

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::