### PR TITLE
Default `accessor_id` and `token` on mesh-task service tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BREAKING CHANGES
 * modules/mesh-task: The retry_join variable was updated to take a list of
   members rather than a single member.
   [[GH-59](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/59)]
+* modules/mesh-task: Default the `accessor_id` and `token` stored on the
+  service token. This change allows `consul-ecs` to fix a number of small bugs
+  related to ACL token creation and deletion.
+  [[GH-65](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/65)]
 
 FEATURES
 * modules/mesh-task: Run a health-sync container for essential containers when

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -186,10 +186,16 @@ resource "aws_secretsmanager_secret" "service_token" {
   recovery_window_in_days = 0
 }
 
+resource "random_uuid" "accessor_id" {}
+resource "random_uuid" "token" {}
+
 resource "aws_secretsmanager_secret_version" "service_token" {
-  count         = var.acls ? 1 : 0
-  secret_id     = aws_secretsmanager_secret.service_token[count.index].id
-  secret_string = jsonencode({})
+  count     = var.acls ? 1 : 0
+  secret_id = aws_secretsmanager_secret.service_token[count.index].id
+  secret_string = jsonencode({
+    accessor_id = random_uuid.accessor_id.result
+    token       = random_uuid.token.result
+  })
 }
 
 resource "aws_ecs_task_definition" "this" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -49,7 +49,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:9afa0c9"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/volume-variable/main.tf
+++ b/test/acceptance/tests/basic/terraform/volume-variable/main.tf
@@ -13,6 +13,6 @@ module "test_client" {
   container_definitions = [{
     name = "basic"
   }]
-  retry_join    = "test"
+  retry_join    = ["test"]
   outbound_only = true
 }

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -48,5 +48,5 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:9afa0c9"
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Default `accessor_id` and `token` on mesh-task service tokens. See https://github.com/hashicorp/consul-ecs/pull/46 for more details

## How I've tested this PR:
Tests

## How I expect reviewers to test this PR:
This needs to be reviewed with https://github.com/hashicorp/consul-ecs/pull/46

## Checklist:
- [ ] Tests added - This should be covered by all of the existing tests that have ACLs enabled
- [X] CHANGELOG entry added 