### PR TITLE
Fix test that broke now that `retry_join` accepts an array of strings

### DIFF
--- a/test/acceptance/tests/basic/terraform/volume-variable/main.tf
+++ b/test/acceptance/tests/basic/terraform/volume-variable/main.tf
@@ -13,6 +13,6 @@ module "test_client" {
   container_definitions = [{
     name = "basic"
   }]
-  retry_join    = "test"
+  retry_join    = ["test"]
   outbound_only = true
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Fix test that broke now that `retry_join` accepts an array of strings

## How I've tested this PR:
CI

## How I expect reviewers to test this PR:
👁️ 

## Checklist:
- [ ] Tests added - Not needed
- [ ] CHANGELOG entry added - Not neede