### PR TITLE
Allow passing in IAM roles to mesh-task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ FEATURES
 * modules/acl-controller: Add `assign_public_ip` variable to the ACL controller
   to support running on public subnets.
   [[GH-64](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/64)]
+* modules/mesh-task: Add `task_role_arn` and `execution_role_arn` input variables
+  which specify the task and execution role to include in the task definition.
+  [[GH-71](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/71)]
 
 ## 0.2.0 (Nov 16, 2021)
 

--- a/modules/mesh-task/iam.tf
+++ b/modules/mesh-task/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "task" {
         Principal = {
           Service = "ecs-tasks.amazonaws.com"
         }
-      },
+      }
     ]
   })
 }
@@ -29,21 +29,19 @@ resource "aws_iam_role" "execution" {
   name  = "${var.family}-execution"
   path  = "/ecs/"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
 }
 
 resource "aws_iam_policy" "execution" {

--- a/modules/mesh-task/iam.tf
+++ b/modules/mesh-task/iam.tf
@@ -15,34 +15,6 @@ resource "aws_iam_role" "task" {
       },
     ]
   })
-
-  tags = var.tags
-}
-
-resource "aws_iam_policy" "exec" {
-  name   = "${var.family}-execute-command"
-  path   = "/"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ssmmessages:CreateControlChannel",
-        "ssmmessages:CreateDataChannel",
-        "ssmmessages:OpenControlChannel",
-        "ssmmessages:OpenDataChannel"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
-
-  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "additional_task_policies" {

--- a/modules/mesh-task/iam.tf
+++ b/modules/mesh-task/iam.tf
@@ -1,0 +1,142 @@
+// Create the task role
+resource "aws_iam_role" "task" {
+  count = var.task_role_arn == "" ? 1 : 0
+
+  name = "${var.family}-task"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_policy" "exec" {
+  name   = "${var.family}-execute-command"
+  path   = "/"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "additional_task_policies" {
+  count      = length(var.additional_task_role_policies)
+  role       = var.task_role_arn == "" ? aws_iam_role.task[0].id : var.task_role_arn
+  policy_arn = var.additional_task_role_policies[count.index]
+}
+
+// Create the execution role and attach policies
+resource "aws_iam_role" "execution" {
+  count = var.execution_role_arn == "" ? 1 : 0
+  name  = "${var.family}-execution"
+  path  = "/ecs/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "execution" {
+  name        = "${var.family}-execution"
+  path        = "/ecs/"
+  description = "${var.family} mesh-task execution policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+%{if var.tls~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${var.consul_server_ca_cert_arn}"
+      ]
+    },
+%{endif~}
+%{if var.acls~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${var.consul_client_token_secret_arn}",
+        "${aws_secretsmanager_secret.service_token[0].arn}"
+      ]
+    },
+%{endif~}
+%{if local.gossip_encryption_enabled~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${var.gossip_key_secret_arn}"
+      ]
+    },
+%{endif~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = var.execution_role_arn == "" ? aws_iam_role.execution[0].id : var.execution_role_arn
+  policy_arn = aws_iam_policy.execution.arn
+}
+
+resource "aws_iam_role_policy_attachment" "additional_execution_policies" {
+  count      = length(var.additional_execution_role_policies)
+  role       = var.execution_role_arn == "" ? aws_iam_role.execution[0].id : var.execution_role_arn
+  policy_arn = var.additional_execution_role_policies[count.index]
+}

--- a/modules/mesh-task/iam.tf
+++ b/modules/mesh-task/iam.tf
@@ -14,6 +14,12 @@ locals {
   // https://www.terraform.io/docs/language/expressions/splat.html#single-values-as-lists
   create_task_role      = length(var.task_role[*]) == 0
   create_execution_role = length(var.execution_role[*]) == 0
+
+  execution_role_id = local.create_execution_role ? aws_iam_role.execution[0].id : var.execution_role.id
+  task_role_id      = local.create_task_role ? aws_iam_role.task[0].id : var.task_role.id
+  // We need the ARN for the task definition.
+  execution_role_arn = local.create_execution_role ? aws_iam_role.execution[0].arn : var.execution_role.arn
+  task_role_arn      = local.create_task_role ? aws_iam_role.task[0].arn : var.task_role.arn
 }
 
 // Create the task role
@@ -37,7 +43,7 @@ resource "aws_iam_role" "task" {
 
 resource "aws_iam_role_policy_attachment" "additional_task_policies" {
   count      = length(var.additional_task_role_policies)
-  role       = local.create_task_role ? aws_iam_role.task[0].id : var.task_role.id
+  role       = local.task_role_id
   policy_arn = var.additional_task_role_policies[count.index]
 }
 
@@ -119,12 +125,12 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "execution" {
-  role       = local.create_execution_role ? aws_iam_role.execution[0].id : var.execution_role.id
+  role       = local.execution_role_id
   policy_arn = aws_iam_policy.execution.arn
 }
 
 resource "aws_iam_role_policy_attachment" "additional_execution_policies" {
   count      = length(var.additional_execution_role_policies)
-  role       = local.create_execution_role ? aws_iam_role.execution[0].id : var.execution_role.id
+  role       = local.execution_role_id
   policy_arn = var.additional_execution_role_policies[count.index]
 }

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -65,8 +65,8 @@ resource "aws_ecs_task_definition" "this" {
   network_mode             = "awsvpc"
   cpu                      = var.cpu
   memory                   = var.memory
-  execution_role_arn       = var.execution_role_arn == "" ? aws_iam_role.execution[0].arn : var.execution_role_arn
-  task_role_arn            = var.task_role_arn == "" ? aws_iam_role.task[0].arn : var.task_role_arn
+  execution_role_arn       = local.create_execution_role ? aws_iam_role.execution[0].arn : var.execution_role.arn
+  task_role_arn            = local.create_task_role ? aws_iam_role.task[0].arn : var.task_role.arn
   volume {
     name = local.consul_data_volume_name
   }

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -47,139 +47,6 @@ locals {
   upstreams_flag = join(",", [for upstream in var.upstreams : "${upstream["destination_name"]}:${upstream["local_bind_port"]}"])
 }
 
-resource "aws_iam_role" "task" {
-  name = "${var.family}-task"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "ecs-tasks.amazonaws.com"
-        }
-      },
-    ]
-  })
-
-  inline_policy {
-    name   = "exec"
-    policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ssmmessages:CreateControlChannel",
-        "ssmmessages:CreateDataChannel",
-        "ssmmessages:OpenControlChannel",
-        "ssmmessages:OpenDataChannel"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-EOF
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "additional_task_policies" {
-  count      = length(var.additional_task_role_policies)
-  role       = aws_iam_role.task.id
-  policy_arn = var.additional_task_role_policies[count.index]
-}
-
-resource "aws_iam_policy" "execution" {
-  name        = "${var.family}-execution"
-  path        = "/ecs/"
-  description = "${var.family} mesh-task execution policy"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-%{if var.tls~}
-    {
-      "Effect": "Allow",
-      "Action": [
-        "secretsmanager:GetSecretValue"
-      ],
-      "Resource": [
-        "${var.consul_server_ca_cert_arn}"
-      ]
-    },
-%{endif~}
-%{if var.acls~}
-    {
-      "Effect": "Allow",
-      "Action": [
-        "secretsmanager:GetSecretValue"
-      ],
-      "Resource": [
-        "${var.consul_client_token_secret_arn}",
-        "${aws_secretsmanager_secret.service_token[0].arn}"
-      ]
-    },
-%{endif~}
-%{if local.gossip_encryption_enabled~}
-    {
-      "Effect": "Allow",
-      "Action": [
-        "secretsmanager:GetSecretValue"
-      ],
-      "Resource": [
-        "${var.gossip_key_secret_arn}"
-      ]
-    },
-%{endif~}
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role" "execution" {
-  name = "${var.family}-execution"
-  path = "/ecs/"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ecs-tasks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "execution" {
-  role       = aws_iam_role.execution.id
-  policy_arn = aws_iam_policy.execution.arn
-}
-
-resource "aws_iam_role_policy_attachment" "additional_execution_policies" {
-  count      = length(var.additional_execution_role_policies)
-  role       = aws_iam_role.execution.id
-  policy_arn = var.additional_execution_role_policies[count.index]
-}
-
 resource "aws_secretsmanager_secret" "service_token" {
   count                   = var.acls ? 1 : 0
   name                    = "${var.acl_secret_name_prefix}-${var.family}"
@@ -198,8 +65,8 @@ resource "aws_ecs_task_definition" "this" {
   network_mode             = "awsvpc"
   cpu                      = var.cpu
   memory                   = var.memory
-  execution_role_arn       = aws_iam_role.execution.arn
-  task_role_arn            = aws_iam_role.task.arn
+  execution_role_arn       = var.execution_role_arn == "" ? aws_iam_role.execution[0].arn : var.execution_role_arn
+  task_role_arn            = var.task_role_arn == "" ? aws_iam_role.task[0].arn : var.task_role_arn
   volume {
     name = local.consul_data_volume_name
   }

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -65,8 +65,8 @@ resource "aws_ecs_task_definition" "this" {
   network_mode             = "awsvpc"
   cpu                      = var.cpu
   memory                   = var.memory
-  execution_role_arn       = local.create_execution_role ? aws_iam_role.execution[0].arn : var.execution_role.arn
-  task_role_arn            = local.create_task_role ? aws_iam_role.task[0].arn : var.task_role.arn
+  execution_role_arn       = local.execution_role_arn
+  task_role_arn            = local.task_role_arn
   volume {
     name = local.consul_data_volume_name
   }

--- a/modules/mesh-task/outputs.tf
+++ b/modules/mesh-task/outputs.tf
@@ -2,6 +2,14 @@ output "task_definition_arn" {
   value = aws_ecs_task_definition.this.arn
 }
 
+output "task_role_arn" {
+  value = var.task_role_arn != "" ? var.task_role_arn : aws_iam_role.task[0].arn
+}
+
+output "execution_role_arn" {
+  value = var.execution_role_arn != "" ? var.execution_role_arn : aws_iam_role.execution[0].arn
+}
+
 output "task_tags" {
   value = aws_ecs_task_definition.this.tags_all
 }

--- a/modules/mesh-task/outputs.tf
+++ b/modules/mesh-task/outputs.tf
@@ -2,12 +2,12 @@ output "task_definition_arn" {
   value = aws_ecs_task_definition.this.arn
 }
 
-output "task_role_arn" {
-  value = var.task_role_arn != "" ? var.task_role_arn : aws_iam_role.task[0].arn
+output "task_role_id" {
+  value = local.create_task_role ? aws_iam_role.task[0].id : var.task_role.id
 }
 
-output "execution_role_arn" {
-  value = var.execution_role_arn != "" ? var.execution_role_arn : aws_iam_role.execution[0].arn
+output "execution_role_id" {
+  value = local.create_execution_role ? aws_iam_role.execution[0].id : var.task_role.id
 }
 
 output "task_tags" {

--- a/modules/mesh-task/outputs.tf
+++ b/modules/mesh-task/outputs.tf
@@ -3,11 +3,11 @@ output "task_definition_arn" {
 }
 
 output "task_role_id" {
-  value = local.create_task_role ? aws_iam_role.task[0].id : var.task_role.id
+  value = local.task_role_id
 }
 
 output "execution_role_id" {
-  value = local.create_execution_role ? aws_iam_role.execution[0].id : var.task_role.id
+  value = local.execution_role_id
 }
 
 output "task_tags" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -45,16 +45,22 @@ variable "volumes" {
   default     = []
 }
 
-variable "task_role_arn" {
-  description = "ARN of the ECS task role to include in the task definition. If not provided, a role is created."
-  type        = string
-  default     = ""
+variable "task_role" {
+  description = "ECS task role to include in the task definition. If not provided, a role is created."
+  type = object({
+    id  = string
+    arn = string
+  })
+  default = null
 }
 
-variable "execution_role_arn" {
-  description = "ARN of the ECS execution role to include in the task definition. If not provided, a role is created."
-  type        = string
-  default     = ""
+variable "execution_role" {
+  description = "ECS execution role to include in the task definition. If not provided, a role is created."
+  type = object({
+    id  = string
+    arn = string
+  })
+  default = null
 }
 
 variable "additional_task_role_policies" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -45,6 +45,18 @@ variable "volumes" {
   default     = []
 }
 
+variable "task_role_arn" {
+  description = "ARN of the ECS task role to include in the task definition. If not provided, a role is created."
+  type        = string
+  default     = ""
+}
+
+variable "execution_role_arn" {
+  description = "ARN of the ECS execution role to include in the task definition. If not provided, a role is created."
+  type        = string
+  default     = ""
+}
+
 variable "additional_task_role_policies" {
   description = "List of additional policy ARNs to attach to the task role."
   type        = list(string)

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -20,6 +20,7 @@ import (
 
 // Test the validation that if TLS is enabled, Consul's CA certificate must also be provided.
 func TestValidation_CACertRequiredIfTLSIsEnabled(t *testing.T) {
+	t.Parallel()
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "./terraform/ca-cert-validate",
 		NoColor:      true,
@@ -34,6 +35,7 @@ func TestValidation_CACertRequiredIfTLSIsEnabled(t *testing.T) {
 
 // Test the validation that if ACLs are enabled, Consul client token must also be provided.
 func TestValidation_ConsulClientTokenIsRequiredIfACLsIsEnabled(t *testing.T) {
+	t.Parallel()
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "./terraform/consul-client-token-validate",
 		NoColor:      true,
@@ -48,6 +50,7 @@ func TestValidation_ConsulClientTokenIsRequiredIfACLsIsEnabled(t *testing.T) {
 
 // Test the validation that if ACLs are enabled, ACL secret name prefix must also be provided.
 func TestValidation_ACLSecretNamePrefixIsRequiredIfACLsIsEnabled(t *testing.T) {
+	t.Parallel()
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "./terraform/acl-secret-name-prefix-validate",
 		NoColor:      true,
@@ -63,6 +66,7 @@ func TestValidation_ACLSecretNamePrefixIsRequiredIfACLsIsEnabled(t *testing.T) {
 // TestVolumeVariable tests passing a list of volumes to mesh-task.
 // This validates a big nested dynamic block in mesh-task.
 func TestVolumeVariable(t *testing.T) {
+	t.Parallel()
 	// terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 	volumes := []map[string]interface{}{
 		{
@@ -105,6 +109,18 @@ func TestVolumeVariable(t *testing.T) {
 	terraformOptions := &terraform.Options{
 		TerraformDir: "./terraform/volume-variable",
 		Vars:         map[string]interface{}{"volumes": volumes},
+		NoColor:      true,
+	}
+	t.Cleanup(func() {
+		_, _ = terraform.DestroyE(t, terraformOptions)
+	})
+	terraform.InitAndPlan(t, terraformOptions)
+}
+
+func TestPassingExistingRoles(t *testing.T) {
+	t.Parallel()
+	terraformOptions := &terraform.Options{
+		TerraformDir: "./terraform/pass-existing-iam-roles",
 		NoColor:      true,
 	}
 	t.Cleanup(func() {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -219,7 +219,7 @@ EOT
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
 
-  additional_task_role_policies = [aws_iam_policy.exec.arn]
+  additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 }
 
 resource "aws_ecs_service" "test_server" {
@@ -272,8 +272,8 @@ module "test_server" {
   // Test passing both a role resource and role data source objects to make sure both
   // have the necessary fields ("arn" and "id").
   task_role                     = aws_iam_role.task
-  execution_role                = data.aws_iam_role.execution
-  additional_task_role_policies = [aws_iam_policy.exec.arn]
+  execution_role                = aws_iam_role.execution
+  additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 }
 
 // Testing passing task/execution role into mesh-task
@@ -295,7 +295,7 @@ resource "aws_iam_role" "task" {
 
 
 // Policy to allow `aws execute-command`
-resource "aws_iam_policy" "exec" {
+resource "aws_iam_policy" "execute-command" {
   name   = "ecs-execute-command-${var.suffix}"
   path   = "/"
   policy = <<EOF
@@ -338,12 +338,6 @@ resource "aws_iam_role" "execution" {
       }
     ]
   })
-}
-
-// Test using an "existing" role name. Users will add a data source,
-// and pass the data source object into mesh-task.
-data "aws_iam_role" "execution" {
-  name = aws_iam_role.execution.name
 }
 
 locals {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -218,6 +218,8 @@ EOT
   consul_client_token_secret_arn = var.secure ? module.acl_controller[0].client_token_secret_arn : ""
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
+
+  additional_task_role_policies = [aws_iam_policy.exec.arn]
 }
 
 resource "aws_ecs_service" "test_server" {
@@ -266,7 +268,38 @@ module "test_server" {
   consul_client_token_secret_arn = var.secure ? module.acl_controller[0].client_token_secret_arn : ""
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
+
+  additional_task_role_policies = [aws_iam_policy.exec.arn]
 }
+
+
+resource "aws_iam_policy" "exec" {
+  name   = "ecs-execute-command-${var.suffix}"
+  path   = "/"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+
+  # TODO: don't have permission to add tags
+  # tags = var.tags
+}
+
 
 locals {
   test_server_log_configuration = {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -269,8 +269,10 @@ module "test_server" {
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
 
-  task_role_arn                 = aws_iam_role.task.arn
-  execution_role_arn            = aws_iam_role.execution.arn
+  // Test passing both a role resource and role data source objects to make sure both
+  // have the necessary fields ("arn" and "id").
+  task_role                     = aws_iam_role.task
+  execution_role                = data.aws_iam_role.execution
   additional_task_role_policies = [aws_iam_policy.exec.arn]
 }
 
@@ -336,6 +338,12 @@ resource "aws_iam_role" "execution" {
       }
     ]
   })
+}
+
+// Test using an "existing" role name. Users will add a data source,
+// and pass the data source object into mesh-task.
+data "aws_iam_role" "execution" {
+  name = aws_iam_role.execution.name
 }
 
 locals {

--- a/test/acceptance/tests/basic/terraform/pass-existing-iam-roles/main.tf
+++ b/test/acceptance/tests/basic/terraform/pass-existing-iam-roles/main.tf
@@ -1,0 +1,64 @@
+// We test this with a Terraform plan only.
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "test_client" {
+  source = "../../../../../../modules/mesh-task"
+  family = "family"
+  container_definitions = [{
+    name = "basic"
+  }]
+  retry_join    = ["test"]
+  outbound_only = true
+
+  // Validate we can pass existing roles.
+  // Users will use a data source to retrieve the role, and pass it in.
+  task_role      = data.aws_iam_role.task
+  execution_role = data.aws_iam_role.execution
+}
+
+data "aws_iam_role" "task" {
+  name = aws_iam_role.task.name
+}
+
+data "aws_iam_role" "execution" {
+  name = aws_iam_role.execution.name
+}
+
+// Testing passing task/execution role into mesh-task
+resource "aws_iam_role" "task" {
+  name = "test-consul-ecs-iam-role-passing_task-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+
+resource "aws_iam_role" "execution" {
+  name = "test-consul-ecs-iam-role-passing_execution-role"
+  path = "/ecs/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}

--- a/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
@@ -157,6 +157,8 @@ module "test_client" {
   consul_client_token_secret_arn = module.acl_controller.client_token_secret_arn
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
+
+  additional_task_role_policies = [aws_iam_policy.exec.arn]
 }
 
 resource "aws_ecs_service" "test_server" {
@@ -210,4 +212,32 @@ module "test_server" {
   consul_client_token_secret_arn = module.acl_controller.client_token_secret_arn
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
+
+  additional_task_role_policies = [aws_iam_policy.exec.arn]
+}
+
+
+resource "aws_iam_policy" "exec" {
+  name   = "ecs-execute-command-${var.suffix}"
+  path   = "/"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+
 }

--- a/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
@@ -158,7 +158,7 @@ module "test_client" {
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
 
-  additional_task_role_policies = [aws_iam_policy.exec.arn]
+  additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 }
 
 resource "aws_ecs_service" "test_server" {
@@ -213,11 +213,11 @@ module "test_server" {
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
 
-  additional_task_role_policies = [aws_iam_policy.exec.arn]
+  additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 }
 
 
-resource "aws_iam_policy" "exec" {
+resource "aws_iam_policy" "execute-command" {
   name   = "ecs-execute-command-${var.suffix}"
   path   = "/"
   policy = <<EOF


### PR DESCRIPTION
## Changes proposed in this PR:
* Add `task_role_arn` and `execution_role_arn` variables to allow users to pass in an IAM role. If not provide, they are created.
* No longer add SSM permissions by default

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::