### PR TITLE
tests: Use ecs-cli to grab logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   consul-ecs-test:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.2.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.0
     environment:
       TEST_RESULTS: &TEST_RESULTS /tmp/test-results # path to where test results are saved
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 terraform.tfstate
 terraform.tfvars
 *.tfstate*
+*.tfvars*
 
 # OS X files
 .history

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -267,9 +267,7 @@ func TestBasic(t *testing.T) {
 
 	// Check logs to see that the application ignored the TERM signal and exited about 10s later.
 	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
-		appLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(),
-			fmt.Sprintf("test_client_%s/basic/%s", randomSuffix, testClientTaskID),
-		)
+		appLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "basic")
 		require.NoError(r, err)
 
 		appLogs = appLogs.Filter("TEST LOG:")
@@ -281,9 +279,7 @@ func TestBasic(t *testing.T) {
 
 	// Check that the Envoy entrypoint received the sigterm.
 	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
-		envoyLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(),
-			fmt.Sprintf("test_client_%s/sidecar-proxy/%s", randomSuffix, testClientTaskID),
-		)
+		envoyLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "sidecar-proxy")
 		require.NoError(r, err)
 
 		logMsg := "consul-ecs: waiting for application container(s) to stop"
@@ -294,8 +290,7 @@ func TestBasic(t *testing.T) {
 
 	// Retrieve "shutdown-monitor" logs to check outgoing requests succeeded.
 	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
-		monitorLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(),
-			fmt.Sprintf("test_client_%s/shutdown-monitor/%s", randomSuffix, testClientTaskID))
+		monitorLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "shutdown-monitor")
 		require.NoError(r, err)
 
 		// Check how long after shutdown the upstream was reachable.

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -1,11 +1,11 @@
 # This Dockerfile includes the dependencies for unit and acceptance tests
 # run in CircleCI.
-FROM circleci/golang:1.16
+FROM circleci/golang:1.17
 
 # change the user to root so we can install stuff
 USER root
 
-ENV TERRAFORM_VERSION "1.0.5"
+ENV TERRAFORM_VERSION "1.0.10"
 
 # base packages
 RUN apt-get install -y \
@@ -31,6 +31,11 @@ RUN curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "aws
 RUN curl -sSL https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb -o session-manager-plugin.deb \
     && sudo dpkg -i session-manager-plugin.deb  \
     && rm session-manager-plugin.deb
+
+# ecs-cli
+RUN curl -sSLo /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest \
+    && chmod +x /usr/local/bin/ecs-cli \
+    && ecs-cli --version
 
 # change the user back to what circleci/golang image has
 USER circleci


### PR DESCRIPTION
## Changes proposed in this PR:
Simplify grabbing Cloud Watch logs by using the ecs-cli (split off from https://github.com/hashicorp/terraform-aws-consul-ecs/pull/60 which was following up on some PR comments)

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] ~CHANGELOG entry added~ Test only change

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::