### PR TITLE
Add ecs security group allowing traffic from load balancer

### DIFF
--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -442,9 +442,9 @@ resource "aws_security_group" "ecs_service" {
 
   ingress {
     description     = "Access to Consul dev server from security group attached to load balancer"
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
     security_groups = [aws_security_group.load_balancer[0].id]
   }
 

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -441,10 +441,10 @@ resource "aws_security_group" "ecs_service" {
   vpc_id = var.vpc_id
 
   ingress {
-    description     = "Access to Consul dev server HTTP API and UI."
-    from_port       = 8500
-    to_port         = 8500
-    protocol        = "tcp"
+    description     = "Access to Consul dev server from security group attached to load balancer"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     security_groups = [aws_security_group.load_balancer[0].id]
   }
 


### PR DESCRIPTION
Closes #74

## Changes proposed in this PR:
- Creates another security group to explicitly attach to ecs service for consul dev server when using load balancer
- Minor name convention changes to security groups

## How I've tested this PR:
- Tested the changes in my own project
- Attempted to run the test detailed at the [test directory](https://github.com/hashicorp/terraform-aws-consul-ecs/tree/main/test/acceptance) of the project, but it was excessive and the final status was unclear.
  - **Note**: this required sessionmanager cli from aws which is undocumented in the Readme
  - The test command attempts to run HCP tests which I don't have configured and which is run last and the only thing reported at the end. Perhaps a maintainer can run this test to confirm.

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::