### PR TITLE
Fix dev-server examples

### DIFF
--- a/examples/dev-server-ec2/consul-server.tf
+++ b/examples/dev-server-ec2/consul-server.tf
@@ -20,3 +20,13 @@ module "dev_consul_server" {
   requires_compatibilities = ["EC2"]
   memory                   = 256
 }
+
+resource "aws_security_group_rule" "consul_server_ingress" {
+  description              = "Access to Consul dev server from default security group"
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = module.vpc.default_security_group_id
+  security_group_id        = module.dev_consul_server.security_group_id
+}

--- a/examples/dev-server-fargate/consul-server.tf
+++ b/examples/dev-server-fargate/consul-server.tf
@@ -18,3 +18,13 @@ module "dev_consul_server" {
   }
   launch_type = "FARGATE"
 }
+
+resource "aws_security_group_rule" "consul_server_ingress" {
+  description              = "Access to Consul dev server from default security group"
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = module.vpc.default_security_group_id
+  security_group_id        = module.dev_consul_server.security_group_id
+}

--- a/modules/dev-server/outputs.tf
+++ b/modules/dev-server/outputs.tf
@@ -3,6 +3,11 @@ output "ecs_service_name" {
   value       = aws_ecs_service.this.name
 }
 
+output "security_group_id" {
+  description = "ID of security group for the ECS service."
+  value       = aws_security_group.ecs_service.id
+}
+
 output "lb_dns_name" {
   description = "DNS name of load balancer in front of Consul server."
   value       = var.lb_enabled ? aws_lb.this[0].dns_name : null

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -104,6 +104,25 @@ module "consul_server" {
   acls                  = var.secure
 }
 
+data "aws_security_group" "vpc_default" {
+  vpc_id = var.vpc_id
+
+  filter {
+    name   = "group-name"
+    values = ["default"]
+  }
+}
+
+resource "aws_security_group_rule" "consul_server_ingress" {
+  description              = "Access to Consul dev server from default security group"
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = data.aws_security_group.vpc_default.id
+  security_group_id        = module.consul_server.security_group_id
+}
+
 module "acl_controller" {
   count  = var.secure ? 1 : 0
   source = "../../../../../../modules/acl-controller"


### PR DESCRIPTION
## Changes proposed in this PR:

In #75, the dev-server was restricted to only allow access from the load balancer. In our examples, mesh-tasks use the default security group, so this ensures they can access the dev-server.

(Acceptance tests were not affected because they do not configure a load balancer for the dev-server)

## How I've tested this PR:
* Deployed the `dev-server-fargate` and `dev-server-ec2` examples, and checked services register and the application is working

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::