### PR TITLE
File-based config for consul-ecs

### DIFF
--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -47,9 +47,10 @@ resource "aws_ecs_service" "example_client_app" {
 }
 
 module "example_client_app" {
-  source = "../../modules/mesh-task"
-  family = "${var.name}-example-client-app"
-  port   = "9090"
+  source           = "../../modules/mesh-task"
+  family           = "${var.name}-example-client-app"
+  consul_ecs_image = "hashicorpdev/consul-ecs:4a90a1e"
+  port             = "9090"
   upstreams = [
     {
       destination_name = "${var.name}-example-server-app"
@@ -62,6 +63,13 @@ module "example_client_app" {
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential        = true
     logConfiguration = local.example_client_app_log_config
+    healthCheck = {
+      command  = ["CMD-SHELL", "echo 1"]
+      interval = 30
+      retries  = 3
+      timeout  = 5
+    }
+
     environment = [
       {
         name  = "NAME"
@@ -109,14 +117,21 @@ resource "aws_ecs_service" "example_server_app" {
 }
 
 module "example_server_app" {
-  source            = "../../modules/mesh-task"
-  family            = "${var.name}-example-server-app"
-  port              = "9090"
-  log_configuration = local.example_server_app_log_config
+  source                        = "../../modules/mesh-task"
+  family                        = "${var.name}-example-server-app"
+  consul_ecs_image              = "hashicorpdev/consul-ecs:4a90a1e"
+  port                          = "9090"
+  log_configuration             = local.example_server_app_log_config
   container_definitions = [{
-    name             = "example-server-app"
-    image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
-    essential        = true
+    name      = "example-server-app"
+    image     = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
+    essential = true
+    healthCheck = {
+      command  = ["CMD-SHELL", "echo 1"]
+      interval = 30
+      retries  = 3
+      timeout  = 5
+    }
     logConfiguration = local.example_server_app_log_config
     environment = [
       {

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -128,7 +128,7 @@ module "example_server_app" {
   # A Consul-native check, included in service registration.
   checks = [
     {
-      checkid  = "server-http"
+      checkId  = "server-http"
       name     = "HTTP health check on port 9090"
       http     = "http://localhost:9090/health"
       method   = "GET"

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -47,10 +47,9 @@ resource "aws_ecs_service" "example_client_app" {
 }
 
 module "example_client_app" {
-  source           = "../../modules/mesh-task"
-  family           = "${var.name}-example-client-app"
-  consul_ecs_image = "hashicorpdev/consul-ecs:4a90a1e"
-  port             = "9090"
+  source = "../../modules/mesh-task"
+  family = "${var.name}-example-client-app"
+  port   = "9090"
   upstreams = [
     {
       destination_name = "${var.name}-example-server-app"
@@ -63,13 +62,6 @@ module "example_client_app" {
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
     essential        = true
     logConfiguration = local.example_client_app_log_config
-    healthCheck = {
-      command  = ["CMD-SHELL", "echo 1"]
-      interval = 30
-      retries  = 3
-      timeout  = 5
-    }
-
     environment = [
       {
         name  = "NAME"
@@ -117,21 +109,14 @@ resource "aws_ecs_service" "example_server_app" {
 }
 
 module "example_server_app" {
-  source                        = "../../modules/mesh-task"
-  family                        = "${var.name}-example-server-app"
-  consul_ecs_image              = "hashicorpdev/consul-ecs:4a90a1e"
-  port                          = "9090"
-  log_configuration             = local.example_server_app_log_config
+  source            = "../../modules/mesh-task"
+  family            = "${var.name}-example-server-app"
+  port              = "9090"
+  log_configuration = local.example_server_app_log_config
   container_definitions = [{
-    name      = "example-server-app"
-    image     = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
-    essential = true
-    healthCheck = {
-      command  = ["CMD-SHELL", "echo 1"]
-      interval = 30
-      retries  = 3
-      timeout  = 5
-    }
+    name             = "example-server-app"
+    image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
+    essential        = true
     logConfiguration = local.example_server_app_log_config
     environment = [
       {

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -66,9 +66,7 @@ resource "aws_ecs_service" "this" {
   network_configuration {
     subnets          = var.subnet_ids
     assign_public_ip = var.assign_public_ip
-    security_groups = length(aws_security_group.ecs_service) != 0 ? [
-      aws_security_group.ecs_service[0].id,
-    ] : null
+    security_groups  = length(aws_security_group.ecs_service) != 0 ? [aws_security_group.ecs_service[0].id] : null
   }
   launch_type = var.launch_type
   service_registries {
@@ -437,27 +435,10 @@ resource "aws_security_group" "load_balancer" {
   }
 }
 
-data "aws_security_group" "vpc_default" {
-  vpc_id = var.vpc_id
-
-  filter {
-    name   = "group-name"
-    values = ["default"]
-  }
-}
-
 resource "aws_security_group" "ecs_service" {
   count  = var.lb_enabled ? 1 : 0
   name   = "${var.name}-ecs-sg"
   vpc_id = var.vpc_id
-
-  ingress {
-    description     = "Access to Consul dev server from VPC default security group"
-    from_port       = 0
-    to_port         = 0
-    protocol        = "-1"
-    security_groups = [data.aws_security_group.vpc_default.id]
-  }
 
   ingress {
     description     = "Access to Consul dev server from security group attached to load balancer"

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -43,17 +43,8 @@ locals {
   }
 
   config = {
-    aclTokenSecret = {
-      provider = "secrets-manager"
-      configuration = {
-        prefix                     = var.acl_secret_name_prefix
-        consulClientTokenSecretArn = var.consul_client_token_secret_arn
-      }
-    }
-    mesh = {
-      for k, v in local.meshConfig :
-      k => v if v != null && try(length(v) != 0, true)
-    }
+    for k, v in local.meshConfig :
+    k => v if v != null && try(length(v) != 0, true)
   }
 
   encoded_config = jsonencode(local.config)

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -46,7 +46,7 @@ locals {
 
   config = {
     aclTokenSecret = {
-      provider = "secret-manager"
+      provider = "secrets-manager"
       configuration = {
         prefix                     = var.acl_secret_name_prefix
         consulClientTokenSecretArn = var.consul_client_token_secret_arn

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -1,0 +1,62 @@
+locals {
+  # The goal here is to prune unused fields from the config.
+  # This helps reduce the size of the CONSUL_ECS_CONFIG_JSON variable,
+  # and keeps the JSON Schema in consul-ecs simple (no nullable fields).
+  #
+  # We use loops to prune null or empty fields (null, "", {}, or []).
+  # A bit of magic here is this loop filter:
+  #
+  #   try(length(v) != 0, true)
+  #
+  # This returns the result of first expression that does not error, so we can
+  # safely test for empty values without knowing their type.
+
+  # TODO: Switch var.upstreams to camelCase so we don't need case conversion.
+  camelCaseUpstreams = [for upstream in var.upstreams :
+    {
+      destinationName = upstream.destination_name
+      localBindPort   = upstream.local_bind_port
+    }
+  ]
+
+  meshServiceConfig = {
+    name   = local.service_name
+    port   = var.port
+    tags   = var.consul_service_tags
+    meta   = var.consul_service_meta
+    checks = var.checks
+  }
+
+  meshConfig = {
+    service = {
+      for k, v in local.meshServiceConfig :
+      k => v if v != null && try(length(v) != 0, true)
+    }
+    sidecar = {
+      proxy = {
+        upstreams = [
+          for upstream in local.camelCaseUpstreams :
+          { for k, v in upstream : k => v if v != null && try(length(v) != 0, true) }
+        ]
+      }
+    }
+    healthSyncContainers = local.defaulted_check_containers
+    bootstrapDir         = local.consul_data_mount.containerPath
+  }
+
+  config = {
+    aclTokenSecret = {
+      provider = "secret-manager"
+      configuration = {
+        prefix                     = var.acl_secret_name_prefix
+        consulClientTokenSecretArn = var.consul_client_token_secret_arn
+      }
+    }
+    mesh = {
+      for k, v in local.meshConfig :
+      k => v if v != null && try(length(v) != 0, true)
+    }
+  }
+
+  encoded_config = jsonencode(local.config)
+}

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -32,13 +32,11 @@ locals {
       for k, v in local.meshServiceConfig :
       k => v if v != null && try(length(v) != 0, true)
     }
-    sidecar = {
-      proxy = {
-        upstreams = [
-          for upstream in local.camelCaseUpstreams :
-          { for k, v in upstream : k => v if v != null && try(length(v) != 0, true) }
-        ]
-      }
+    proxy = {
+      upstreams = [
+        for upstream in local.camelCaseUpstreams :
+        { for k, v in upstream : k => v if v != null && try(length(v) != 0, true) }
+      ]
     }
     healthSyncContainers = local.defaulted_check_containers
     bootstrapDir         = local.consul_data_mount.containerPath

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -20,6 +20,7 @@ locals {
     "/consul/consul-ecs", "app-entrypoint", "-shutdown-delay", "${var.application_shutdown_delay_seconds}s",
   ]
   app_mountpoints = var.application_shutdown_delay_seconds == null ? [] : [local.consul_data_mount]
+  service_name = var.consul_service_name != "" ? var.consul_service_name : var.family
 
   // container_defs_with_depends_on is the app's container definitions with their dependsOn keys
   // modified to add in dependencies on consul-ecs-mesh-init and sidecar-proxy.
@@ -61,6 +62,38 @@ locals {
   if contains(keys(def), "essential") && contains(keys(def), "healthCheck")] : []
 
   upstreams_flag = join(",", [for upstream in var.upstreams : "${upstream["destination_name"]}:${upstream["local_bind_port"]}"])
+
+  # It might make sense to extract this into a template someday.
+  config = {
+    aclTokenSecret = {
+      provider = "secret-manager"
+      configuration = {
+        prefix                     = var.acl_secret_name_prefix
+        consulClientTokenSecretArn = var.consul_client_token_secret_arn
+      }
+    }
+    mesh = {
+      service = {
+        name   = local.service_name
+        port   = var.port
+        tags   = var.consul_service_tags
+        meta   = var.consul_service_meta
+        checks = var.checks
+      }
+      sideCar = {
+        proxy = {
+          upstreams = [for upstream in var.upstreams :
+            {
+              destinationName = upstream.destination_name
+              localBindPort   = upstream.local_bind_port
+          }]
+        }
+      }
+      healthSyncContainers = local.defaulted_check_containers
+      bootstrapDir         = local.consul_data_mount.containerPath
+    }
+  }
+  encoded_config = jsonencode(local.config)
 }
 
 resource "aws_secretsmanager_secret" "service_token" {
@@ -158,7 +191,7 @@ resource "aws_ecs_task_definition" "this" {
   tags = merge(
     var.tags,
     { "consul.hashicorp.com/mesh" = "true" },
-    { "consul.hashicorp.com/service-name" = var.consul_service_name != "" ? var.consul_service_name : var.family }
+    { "consul.hashicorp.com/service-name" = local.service_name }
   )
 
   container_definitions = jsonencode(
@@ -316,14 +349,15 @@ resource "aws_ecs_task_definition" "this" {
           image            = var.consul_ecs_image
           essential        = false
           logConfiguration = var.log_configuration
-          command = [
-            "health-sync",
-            "-health-sync-containers=${join(",", local.defaulted_check_containers)}",
-            "-service-name=${var.consul_service_name}"
+          command          = ["health-sync"]
+          cpu              = 0
+          volumesFrom      = []
+          environment = [
+            {
+              name  = "CONSUL_ECS_CONFIG_JSON",
+              value = local.encoded_config
+            }
           ]
-          cpu          = 0
-          volumesFrom  = []
-          environment  = []
           portMappings = []
           dependsOn = [
             {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -240,7 +240,7 @@ module "test_server" {
   log_configuration = local.test_server_log_configuration
   checks = [
     {
-      checkid  = "server-http"
+      checkId  = "server-http"
       name     = "HTTP health check on port 9090"
       http     = "http://localhost:9090/health"
       method   = "GET"

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -49,7 +49,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:419b136"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -49,7 +49,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:419b136"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
@@ -195,7 +195,7 @@ module "test_server" {
   }
   checks = [
     {
-      checkid  = "server-http"
+      checkId  = "server-http"
       name     = "HTTP health check on port 9090"
       http     = "http://localhost:9090/health"
       method   = "GET"


### PR DESCRIPTION
## Changes proposed in this PR:
Update mesh-task to support file-based config for consul-ecs (mesh-init, health-sync).

See https://github.com/hashicorp/consul-ecs/pull/53

## How I've tested this PR:
Acceptance tests, and ran the dev-server-fargate example.

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::