### PR TITLE
mesh-task: Remove unnecessary port mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ FEATURES
   off for better graceful shutdown.
   [[GH-67](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/67)]
 
+IMPROVEMENTS
+* modules/mesh-task: Cleanup unnecessary port mappings.
+  [[GH-78](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/78)]
+
 ## 0.2.0 (Nov 16, 2021)
 
 BREAKING CHANGES

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -197,21 +197,10 @@ resource "aws_ecs_task_definition" "this" {
             ] : [],
           },
           {
-            name      = "consul-client"
-            image     = var.consul_image
-            essential = false
-            portMappings = [
-              {
-                containerPort = 8300
-                hostPort      = 8300
-                protocol      = "tcp"
-              },
-              {
-                containerPort = 8300
-                hostPort      = 8300
-                protocol      = "udp"
-              },
-            ]
+            name             = "consul-client"
+            image            = var.consul_image
+            essential        = false
+            portMappings     = []
             logConfiguration = var.log_configuration
             entryPoint       = ["/bin/sh", "-ec"]
             command = [replace(
@@ -271,13 +260,7 @@ resource "aws_ecs_task_definition" "this" {
             logConfiguration = var.log_configuration
             entryPoint       = ["/consul/consul-ecs", "envoy-entrypoint"]
             command          = ["envoy", "--config-path", "/consul/envoy-bootstrap.json"]
-            portMappings = [
-              {
-                containerPort = 20000
-                hostPort      = 20000
-                protocol      = "tcp"
-              },
-            ]
+            portMappings     = []
             mountPoints = [
               local.consul_data_mount
             ]


### PR DESCRIPTION
## Changes proposed in this PR:
* Remove port mappings that are not needed in `awsvpc` networking mode since Consul and Envoy bind to the interface of the Task ENI for gossip and the public listener port, respectively.

## How I've tested this PR:
* Acceptance tests

## How I expect reviewers to test this PR:
:eyes:

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::