### PR TITLE
mesh-task: Leverage optional values to simplify config

### DIFF
--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -1,16 +1,5 @@
 locals {
-  # The goal here is to prune unused fields from the config.
-  # This helps reduce the size of the CONSUL_ECS_CONFIG_JSON variable,
-  # and keeps the JSON Schema in consul-ecs simple (no nullable fields).
-  #
-  # We use loops to prune null or empty fields (null, "", {}, or []).
-  # A bit of magic here is this loop filter:
-  #
-  #   try(length(v) != 0, true)
-  #
-  # This returns the result of first expression that does not error, so we can
-  # safely test for empty values without knowing their type.
-
+  // Define the Consul ECS config file contents.
   # TODO: Switch var.upstreams to camelCase so we don't need case conversion.
   camelCaseUpstreams = [for upstream in var.upstreams :
     {
@@ -19,32 +8,19 @@ locals {
     }
   ]
 
-  meshServiceConfig = {
-    name   = local.service_name
-    port   = var.port
-    tags   = var.consul_service_tags
-    meta   = var.consul_service_meta
-    checks = var.checks
-  }
-
-  meshConfig = {
+  config = {
     service = {
-      for k, v in local.meshServiceConfig :
-      k => v if v != null && try(length(v) != 0, true)
+      name   = local.service_name
+      port   = var.port
+      tags   = var.consul_service_tags
+      meta   = var.consul_service_meta
+      checks = var.checks
     }
     proxy = {
-      upstreams = [
-        for upstream in local.camelCaseUpstreams :
-        { for k, v in upstream : k => v if v != null && try(length(v) != 0, true) }
-      ]
+      upstreams = local.camelCaseUpstreams
     }
     healthSyncContainers = local.defaulted_check_containers
     bootstrapDir         = local.consul_data_mount.containerPath
-  }
-
-  config = {
-    for k, v in local.meshConfig :
-    k => v if v != null && try(length(v) != 0, true)
   }
 
   encoded_config = jsonencode(local.config)


### PR DESCRIPTION
## Changes proposed in this PR:
- Simplify config to correspond with https://github.com/hashicorp/consul-ecs/pull/54 which allows null/optional values

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::