### PR TITLE
 Swap out circleci/golang with cimg/go now that circleci/golang is deprecated

### DIFF
--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile includes the dependencies for unit and acceptance tests
 # run in CircleCI.
-FROM circleci/golang:1.17
+FROM cimg/go:1.17
 
 # change the user to root so we can install stuff
 USER root


### PR DESCRIPTION
## Changes proposed in this PR:
- Swap out `circleci/golang` image with `cimg/go` in the CircleCI configuration.

## How I've tested this PR:
The tests still pass

## How I expect reviewers to test this PR:
👁️ 

## Checklist:
- [ ] Tests added - Not necessary
- [ ] CHANGELOG entry added - Not necessary