### PR TITLE
Support passing Consul Agent configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ FEATURES
   and sidecar proxy registration requests using the `consul_ecs_config`,
   `upstreams`, and `consul_namespace` variables.
   [[GH-80](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/80)]
+* module/mesh-task: Add `consul_agent_configuration` variable to pass
+  additional configuration to the Consul agent.
+  [[GH-82](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/82)]
 
 IMPROVEMENTS
 * modules/mesh-task: Cleanup unnecessary port mappings.

--- a/modules/mesh-task/templates/consul_agent_defaults.hcl.tpl
+++ b/modules/mesh-task/templates/consul_agent_defaults.hcl.tpl
@@ -1,0 +1,45 @@
+addresses = {
+  dns = "127.0.0.1"
+  grpc = "127.0.0.1"
+  http = "127.0.0.1"
+}
+advertise_addr = "$ECS_IPV4"
+advertise_reconnect_timeout = "15m"
+client_addr = "0.0.0.0"
+datacenter = "$CONSUL_DATACENTER"
+enable_central_service_config = true
+%{ if gossip_encryption_enabled ~}
+encrypt = "$CONSUL_GOSSIP_ENCRYPTION_KEY"
+%{ endif ~}
+leave_on_terminate = true
+ports {
+  grpc = 8502
+}
+retry_join = [
+%{ for j in retry_join ~}
+  "${j}",
+%{ endfor ~}
+]
+telemetry {
+  disable_compat_1.9 = true
+}
+
+%{~ if tls ~}
+auto_encrypt = {
+  tls = true
+  ip_san = ["$ECS_IPV4"]
+}
+ca_file = "/tmp/consul-ca-cert.pem"
+verify_outgoing = true
+%{ endif ~}
+
+%{~ if acls ~}
+acl {
+  enabled = true
+  default_policy = "deny"
+  down_policy = "async-cache"
+  tokens {
+    agent = "$AGENT_TOKEN"
+  }
+}
+%{ endif ~}

--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -2,36 +2,23 @@ cp /bin/consul /bin/consul-inject/consul
 
 ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
 
-%{ if tls }
+%{ if tls ~}
 echo "$CONSUL_CACERT" > /tmp/consul-ca-cert.pem
-%{ endif }
+%{ endif ~}
+
+cat << EOF > /consul/agent-defaults.hcl
+${consul_agent_defaults_hcl}
+EOF
+
+%{ if consul_agent_configuration_hcl != null ~}
+cat << EOF > /consul/agent-extra.hcl
+${consul_agent_configuration_hcl}
+EOF
+%{ endif ~}
 
 exec consul agent \
-  -advertise "$ECS_IPV4" \
-  -datacenter "$CONSUL_DATACENTER" \
-  -data-dir /consul/data \
-  -client 0.0.0.0 \
-%{ if gossip_encryption_enabled ~}
-  -encrypt "$CONSUL_GOSSIP_ENCRYPTION_KEY" \
-%{ endif ~}
-  -hcl 'addresses = { dns = "127.0.0.1" }' \
-  -hcl 'addresses = { grpc = "127.0.0.1" }' \
-  -hcl 'addresses = { http = "127.0.0.1" }' \
-%{ for j in retry_join ~}
-  -retry-join "${j}" \
-%{ endfor ~}
-  -hcl 'telemetry { disable_compat_1.9 = true }' \
-  -hcl 'leave_on_terminate = true' \
-  -hcl 'ports { grpc = 8502 }' \
-  -hcl 'advertise_reconnect_timeout = "15m"' \
-  -hcl 'enable_central_service_config = true' \
-%{ if tls ~}
-  -hcl 'ca_file = "/tmp/consul-ca-cert.pem"' \
-  -hcl 'auto_encrypt = {tls = true}' \
-  -hcl "auto_encrypt = {ip_san = [\"$ECS_IPV4\"]}" \
-  -hcl 'verify_outgoing = true' \
-%{ endif ~}
-%{ if acls ~}
-  -hcl='acl {enabled = true, default_policy = "deny", down_policy = "async-cache"}' \
-  -hcl="acl { tokens { agent = \"$AGENT_TOKEN\" } }" \
+    -data-dir /consul/data \
+    -config-file /consul/agent-defaults.hcl \
+%{ if consul_agent_configuration_hcl != null ~}
+    -config-file /consul/agent-extra.hcl
 %{ endif ~}

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -263,6 +263,12 @@ variable "consul_datacenter" {
   default     = "dc1"
 }
 
+variable "consul_agent_configuration" {
+  type        = string
+  description = "The contents of a configuration file for the Consul Agent in HCL format."
+  default     = null
+}
+
 variable "application_shutdown_delay_seconds" {
   type        = number
   description = <<-EOT

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -492,6 +492,18 @@ func TestBasic(t *testing.T) {
 		require.GreaterOrEqual(r, applicationOkLogs.Duration().Seconds(), 8.0)
 	})
 
+	// Validate that passing additional Consul agent configuration works.
+	// We enable DEBUG logs on one of the Consul agents.
+	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+		agentLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "consul-client")
+
+		require.NoError(r, err)
+		logMsg := "[DEBUG] agent:"
+		agentLogs = agentLogs.Filter(logMsg)
+		require.GreaterOrEqual(r, len(agentLogs), 1)
+		require.Contains(r, agentLogs[0].Message, logMsg)
+	})
+
 	logger.Log(t, "Test successful!")
 }
 

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -228,6 +228,10 @@ EOT
   consul_ecs_image               = var.consul_ecs_image
 
   additional_task_role_policies = [aws_iam_policy.execute-command.arn]
+
+  consul_agent_configuration = <<-EOT
+  log_level = "debug"
+  EOT
 }
 
 resource "aws_ecs_service" "test_server" {


### PR DESCRIPTION
## Changes proposed in this PR:
* Add a `consul_agent_configuration` variable to support passing an additional config file to the Consul agent.

## How I've tested this PR:
Acceptance tests, and also ran the example with additional Consul config

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::