### PR TITLE
mesh-task: Include module + module-version tags

### DIFF
--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -1,6 +1,9 @@
 data "aws_region" "current" {}
 
 locals {
+  // Must be updated for each release, and after each release to return to a "-dev" version.
+  version_string = "0.2.0-dev"
+
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"
   consul_data_mount = {
@@ -157,8 +160,12 @@ resource "aws_ecs_task_definition" "this" {
 
   tags = merge(
     var.tags,
-    { "consul.hashicorp.com/mesh" = "true" },
-    { "consul.hashicorp.com/service-name" = local.service_name }
+    {
+      "consul.hashicorp.com/mesh"           = "true"
+      "consul.hashicorp.com/service-name"   = local.service_name
+      "consul.hashicorp.com/module"         = "terraform-aws-consul-ecs"
+      "consul.hashicorp.com/module-version" = local.version_string
+    },
   )
 
   container_definitions = jsonencode(


### PR DESCRIPTION
## Changes proposed in this PR:
Add the following new tags to the task definition:
* `consul.hashicorp.com/module = "terraform-aws-consul-ecs"`
* `consul.hashicorp.com/module-version = "x.y.z-dev"`

## How I've tested this PR:
Ran the dev-server-fargate example, and checked the tags:

<img width="515" alt="Screen Shot 2022-01-19 at 11 26 50 AM" src="https://user-images.githubusercontent.com/1077740/150182863-93afe5c8-c310-49d6-86a8-34971742de83.png">

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] ~Tests added~
- [ ] ~CHANGELOG entry added~

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::