### PR TITLE
Support passing security groups to ACL controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+IMPROVEMENTS
+* module/acl-controller: Support `security_groups` input variable.
+  [[GH-89](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/89)]
+
 ## 0.3.0 (Jan 27, 2022)
 
 BREAKING CHANGES

--- a/modules/acl-controller/main.tf
+++ b/modules/acl-controller/main.tf
@@ -15,6 +15,7 @@ resource "aws_ecs_service" "this" {
   desired_count   = 1
   network_configuration {
     subnets          = var.subnets
+    security_groups  = var.security_groups
     assign_public_ip = var.assign_public_ip
   }
   launch_type            = var.launch_type

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -63,3 +63,9 @@ variable "assign_public_ip" {
   type        = bool
   default     = false
 }
+
+variable "security_groups" {
+  description = "Configure the ECS service with security groups. If not specified, the default security group for the VPC is used."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Changes proposed in this PR:
Support `security_groups` input variable for ACL controller

Fixes #88 

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::