### PR TITLE
Correct secret name when admin partitions are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1 (April 6, 2022)
 BUG FIXES
-* modules/mesh-task: Fix a bug that results in a invalid secret names
+* modules/mesh-task: Fix a bug that results in invalid secret names
   when admin partitions are enabled.
   [[GH-95](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/95)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.1 (April 6, 2022)
+BUG FIXES
+* modules/mesh-task: Fix a bug that results in a invalid secret names
+  when admin partitions are enabled.
+  [[GH-95](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/95)]
+
+
 ## 0.4.0 (April 4, 2022)
 
 FEATURES

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.4.0-dev"
+  version_string = "0.4.1"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"
@@ -27,8 +27,8 @@ locals {
   service_name    = var.consul_service_name != "" ? var.consul_service_name : var.family
 
   // Optionally, users can provide a partition and namespace for the service.
-  partition_tag = var.consul_partition != null ? { "consul.hashicorp.com/partition" = var.consul_partition } : {}
-  namespace_tag = var.consul_namespace != null ? { "consul.hashicorp.com/namespace" = var.consul_namespace } : {}
+  partition_tag = var.consul_partition != "" ? { "consul.hashicorp.com/partition" = var.consul_partition } : {}
+  namespace_tag = var.consul_namespace != "" ? { "consul.hashicorp.com/namespace" = var.consul_namespace } : {}
 
   // container_defs_with_depends_on is the app's container definitions with their dependsOn keys
   // modified to add in dependencies on consul-ecs-mesh-init and sidecar-proxy.
@@ -80,7 +80,7 @@ locals {
     }
   )
 
-  secret_name = var.consul_partition != null ? "${var.acl_secret_name_prefix}-${var.family}-${var.consul_namespace}-${var.consul_partition}" : "${var.acl_secret_name_prefix}-${var.family}"
+  secret_name = var.consul_partition != "" ? "${var.acl_secret_name_prefix}-${var.family}-${var.consul_namespace}-${var.consul_partition}" : "${var.acl_secret_name_prefix}-${var.family}"
 }
 
 resource "aws_secretsmanager_secret" "service_token" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -80,7 +80,7 @@ locals {
     }
   )
 
-  secret_name = var.consul_partition != "" ? "${var.acl_secret_name_prefix}-${var.family}-${var.consul_namespace}-${var.consul_partition}" : "${var.acl_secret_name_prefix}-${var.family}"
+  secret_name = var.consul_partition != "" ? "${var.acl_secret_name_prefix}-${local.service_name}-${var.consul_namespace}-${var.consul_partition}" : "${var.acl_secret_name_prefix}-${local.service_name}"
 }
 
 resource "aws_secretsmanager_secret" "service_token" {

--- a/modules/mesh-task/validation.tf
+++ b/modules/mesh-task/validation.tf
@@ -4,4 +4,5 @@ locals {
   require_client_token_if_acls_enabled       = (var.acls && var.consul_client_token_secret_arn == "") ? file("ERROR: consul_client_token_secret_arn must be set if acls is true") : null
   require_secret_name_prefix_if_acls_enabled = (var.acls && var.acl_secret_name_prefix == "") ? file("ERROR: acl_secret_name_prefix must be set if acls is true") : null
   require_namespace_if_partition_is_set      = (var.consul_partition != "" && var.consul_namespace == "") ? file("ERROR: consul_namespace must be set if consul_partition is set") : null
+  require_partition_if_namespace_is_set      = (var.consul_namespace != "" && var.consul_partition == "") ? file("ERROR: consul_partition must be set if consul_namespace is set") : null
 }

--- a/modules/mesh-task/validation.tf
+++ b/modules/mesh-task/validation.tf
@@ -3,4 +3,5 @@ locals {
   require_ca_cert_if_tls_enabled             = (var.tls && var.consul_server_ca_cert_arn == "") ? file("ERROR: consul_server_ca_cert_arn must be set if tls is true") : null
   require_client_token_if_acls_enabled       = (var.acls && var.consul_client_token_secret_arn == "") ? file("ERROR: consul_client_token_secret_arn must be set if acls is true") : null
   require_secret_name_prefix_if_acls_enabled = (var.acls && var.acl_secret_name_prefix == "") ? file("ERROR: acl_secret_name_prefix must be set if acls is true") : null
+  require_namespace_if_partition_is_set      = (var.consul_partition != "" && var.consul_namespace == "") ? file("ERROR: consul_namespace must be set if consul_partition is set") : null
 }

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -352,217 +352,306 @@ func TestValidation_ConsulEcsConfigVariable(t *testing.T) {
 	}
 }
 
-func TestBasic(t *testing.T) {
-	randomSuffix := strings.ToLower(random.UniqueId())
-	tfVars := suite.Config().TFVars("route_table_ids")
-	tfVars["suffix"] = randomSuffix
-	serverServiceName := "custom_test_server"
-	// This uses the explicitly passed service name rather than the task's family name.
-	tfVars["server_service_name"] = serverServiceName
-	clientServiceName := "test_client"
+// Test the validation that if a partition is provided, a namespace must also be provided.
+func TestValidation_NamespaceIsRequiredIfPartitionIsSet(t *testing.T) {
+	t.Parallel()
 
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: "./terraform/basic-install",
-		Vars:         tfVars,
-		NoColor:      true,
-	})
+	cases := map[string]struct {
+		partition string
+		namespace string
+		errMsg    string
+	}{
+		"without partition and namespace": {
+			partition: "",
+			namespace: "",
+			errMsg:    "",
+		},
+		"with partition and namespace": {
+			partition: "default",
+			namespace: "default",
+			errMsg:    "",
+		},
+		"with partition, without namespace": {
+			partition: "default",
+			namespace: "",
+			errMsg:    "ERROR: consul_namespace must be set if consul_partition is set",
+		},
+		"without partition, with namespace": {
+			partition: "",
+			namespace: "default",
+			errMsg:    "",
+		},
+	}
 
-	t.Cleanup(func() {
-		if suite.Config().NoCleanupOnFailure && t.Failed() {
-			logger.Log(t, "skipping resource cleanup because -no-cleanup-on-failure=true")
-		} else {
-			terraform.Destroy(t, terraformOptions)
-		}
-	})
-
-	terraform.InitAndApply(t, terraformOptions)
-
-	// Wait for consul server to be up.
-	var consulServerTaskARN string
-	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
-		taskListOut, err := shell.RunCommandAndGetOutputE(t, shell.Command{
-			Command: "aws",
-			Args: []string{
-				"ecs",
-				"list-tasks",
-				"--region",
-				suite.Config().Region,
-				"--cluster",
-				suite.Config().ECSClusterARN,
-				"--family",
-				fmt.Sprintf("consul_server_%s", randomSuffix),
-			},
-		})
-		r.Check(err)
-
-		var tasks listTasksResponse
-		r.Check(json.Unmarshal([]byte(taskListOut), &tasks))
-		if len(tasks.TaskARNs) != 1 {
-			r.Errorf("expected 1 task, got %d", len(tasks.TaskARNs))
-			return
-		}
-
-		consulServerTaskARN = tasks.TaskARNs[0]
-	})
-
-	// Wait for both tasks to be registered in Consul.
-	retry.RunWith(&retry.Timer{Timeout: 6 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
-		out, err := helpers.ExecuteRemoteCommand(t, suite.Config(), consulServerTaskARN, "consul-server", `/bin/sh -c "consul catalog services"`)
-		r.Check(err)
-		if !strings.Contains(out, fmt.Sprintf("%s_%s", serverServiceName, randomSuffix)) ||
-			!strings.Contains(out, fmt.Sprintf("%s_%s", clientServiceName, randomSuffix)) {
-			r.Errorf("services not yet registered, got %q", out)
-		}
-	})
-
-	// Wait for passing health check for `serverServiceName` and `clientServiceName`.
-	// `serverServiceName` has a Consul native HTTP check.
-	// `clientServiceName`  has a check synced from ECS.
-	services := []string{serverServiceName, clientServiceName}
-	for _, serviceName := range services {
-		retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
-			out, err := helpers.ExecuteRemoteCommand(
-				t,
-				suite.Config(),
-				consulServerTaskARN,
-				"consul-server",
-				fmt.Sprintf(`/bin/sh -c 'curl localhost:8500/v1/health/checks/%s_%s'`, serviceName, randomSuffix),
-			)
-			r.Check(err)
-
-			statusRegex := regexp.MustCompile(`"Status"\s*:\s*"passing"`)
-			if statusRegex.FindAllString(out, 1) == nil {
-				r.Errorf("Check status not yet passing")
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+				TerraformDir: "./terraform/admin-partition-validate",
+				NoColor:      true,
+				Vars: map[string]interface{}{
+					"partition": c.partition,
+					"namespace": c.namespace,
+				},
+			})
+			t.Cleanup(func() {
+				_, _ = terraform.DestroyE(t, terraformOptions)
+			})
+			_, err := terraform.InitAndPlanE(t, terraformOptions)
+			if c.errMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.errMsg)
 			}
 		})
 	}
+}
 
-	// Use aws exec to curl between the apps.
-	taskListOut := shell.RunCommandAndGetOutput(t, shell.Command{
-		Command: "aws",
-		Args: []string{
-			"ecs",
-			"list-tasks",
-			"--region",
-			suite.Config().Region,
-			"--cluster",
-			suite.Config().ECSClusterARN,
-			"--family",
-			fmt.Sprintf("test_client_%s", randomSuffix),
-		},
-	})
+func TestBasic(t *testing.T) {
+	cases := []bool{false, true}
 
-	var tasks listTasksResponse
-	require.NoError(t, json.Unmarshal([]byte(taskListOut), &tasks))
-	require.Len(t, tasks.TaskARNs, 1)
-	testClientTaskARN := tasks.TaskARNs[0]
-	arnParts := strings.Split(testClientTaskARN, "/")
-	testClientTaskID := arnParts[len(arnParts)-1]
+	for _, secure := range cases {
+		t.Run(fmt.Sprintf("secure: %t", secure), func(t *testing.T) {
+			randomSuffix := strings.ToLower(random.UniqueId())
+			tfVars := suite.Config().TFVars("route_table_ids")
+			tfVars["secure"] = secure
+			tfVars["suffix"] = randomSuffix
+			clientServiceName := "test_client"
 
-	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
-		curlOut, err := helpers.ExecuteRemoteCommand(t, suite.Config(), tasks.TaskARNs[0], "basic", `/bin/sh -c "curl localhost:1234"`)
-		r.Check(err)
-		if !strings.Contains(curlOut, `"code": 200`) {
-			r.Errorf("response was unexpected: %q", curlOut)
-		}
-	})
+			serverServiceName := "test_server"
+			if !secure {
+				// This uses the explicitly passed service name rather than the task's family name.
+				serverServiceName = "custom_test_server"
+			}
+			tfVars["server_service_name"] = serverServiceName
 
-	// Validate graceful shutdown behavior. We check the client app can reach its upstream after the task is stopped.
-	// This relies on a couple of helpers:
-	// * a custom entrypoint for the client app that keeps it running for 10s into Task shutdown, and
-	// * an additional "shutdown-monitor" container that makes requests to the client app
-	// Since this is timing dependent, we check logs after the fact to validate when the containers exited.
-	shell.RunCommandAndGetOutput(t, shell.Command{
-		Command: "aws",
-		Args: []string{
-			"ecs",
-			"stop-task",
-			"--region", suite.Config().Region,
-			"--cluster", suite.Config().ECSClusterARN,
-			"--task", testClientTaskARN,
-			"--reason", "Stopped to validate graceful shutdown in acceptance tests",
-		},
-	})
+			terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+				TerraformDir: "./terraform/basic-install",
+				Vars:         tfVars,
+				NoColor:      true,
+			})
 
-	// Wait for the task to stop (~30 seconds)
-	retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
-		describeTasksOut, err := shell.RunCommandAndGetOutputE(t, shell.Command{
-			Command: "aws",
-			Args: []string{
-				"ecs",
-				"describe-tasks",
-				"--region", suite.Config().Region,
-				"--cluster", suite.Config().ECSClusterARN,
-				"--task", testClientTaskARN,
-			},
+			t.Cleanup(func() {
+				if suite.Config().NoCleanupOnFailure && t.Failed() {
+					logger.Log(t, "skipping resource cleanup because -no-cleanup-on-failure=true")
+				} else {
+					terraform.Destroy(t, terraformOptions)
+				}
+			})
+
+			terraform.InitAndApply(t, terraformOptions)
+
+			// Wait for consul server to be up.
+			var consulServerTaskARN string
+			retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+				taskListOut, err := shell.RunCommandAndGetOutputE(t, shell.Command{
+					Command: "aws",
+					Args: []string{
+						"ecs",
+						"list-tasks",
+						"--region",
+						suite.Config().Region,
+						"--cluster",
+						suite.Config().ECSClusterARN,
+						"--family",
+						fmt.Sprintf("consul_server_%s", randomSuffix),
+					},
+				})
+				r.Check(err)
+
+				var tasks listTasksResponse
+				r.Check(json.Unmarshal([]byte(taskListOut), &tasks))
+				if len(tasks.TaskARNs) != 1 {
+					r.Errorf("expected 1 task, got %d", len(tasks.TaskARNs))
+					return
+				}
+
+				consulServerTaskARN = tasks.TaskARNs[0]
+			})
+
+			// Wait for both tasks to be registered in Consul.
+			retry.RunWith(&retry.Timer{Timeout: 6 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
+				out, err := helpers.ExecuteRemoteCommand(t, suite.Config(), consulServerTaskARN, "consul-server", `/bin/sh -c "consul catalog services"`)
+				r.Check(err)
+				if !strings.Contains(out, fmt.Sprintf("%s_%s", serverServiceName, randomSuffix)) ||
+					!strings.Contains(out, fmt.Sprintf("%s_%s", clientServiceName, randomSuffix)) {
+					r.Errorf("services not yet registered, got %q", out)
+				}
+			})
+
+			// Wait for passing health check for test_server and test_client
+			tokenHeader := ""
+			if secure {
+				tokenHeader = `-H "X-Consul-Token: $CONSUL_HTTP_TOKEN"`
+			}
+
+			// Wait for passing health check for `serverServiceName` and `clientServiceName`.
+			// `serverServiceName` has a Consul native HTTP check.
+			// `clientServiceName`  has a check synced from ECS.
+			services := []string{serverServiceName, clientServiceName}
+			for _, serviceName := range services {
+				retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
+					out, err := helpers.ExecuteRemoteCommand(
+						t,
+						suite.Config(),
+						consulServerTaskARN,
+						"consul-server",
+						fmt.Sprintf(`/bin/sh -c 'curl %s localhost:8500/v1/health/checks/%s_%s'`, tokenHeader, serviceName, randomSuffix),
+					)
+					r.Check(err)
+
+					statusRegex := regexp.MustCompile(`"Status"\s*:\s*"passing"`)
+					if statusRegex.FindAllString(out, 1) == nil {
+						r.Errorf("Check status not yet passing")
+					}
+				})
+			}
+
+			// Use aws exec to curl between the apps.
+			taskListOut := shell.RunCommandAndGetOutput(t, shell.Command{
+				Command: "aws",
+				Args: []string{
+					"ecs",
+					"list-tasks",
+					"--region",
+					suite.Config().Region,
+					"--cluster",
+					suite.Config().ECSClusterARN,
+					"--family",
+					fmt.Sprintf("test_client_%s", randomSuffix),
+				},
+			})
+
+			var tasks listTasksResponse
+			require.NoError(t, json.Unmarshal([]byte(taskListOut), &tasks))
+			require.Len(t, tasks.TaskARNs, 1)
+			testClientTaskARN := tasks.TaskARNs[0]
+			arnParts := strings.Split(testClientTaskARN, "/")
+			testClientTaskID := arnParts[len(arnParts)-1]
+
+			// Create an intention.
+			if secure {
+				// First check that connection between apps is unsuccessful.
+				retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+					curlOut, err := helpers.ExecuteRemoteCommand(t, suite.Config(), testClientTaskARN, "basic", `/bin/sh -c "curl localhost:1234"`)
+					r.Check(err)
+					if !strings.Contains(curlOut, `curl: (52) Empty reply from server`) {
+						r.Errorf("response was unexpected: %q", curlOut)
+					}
+				})
+				retry.RunWith(&retry.Timer{Timeout: 6 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
+					consulCmd := fmt.Sprintf(`/bin/sh -c "consul intention create test_client_%s test_server_%s"`, randomSuffix, randomSuffix)
+					_, err := helpers.ExecuteRemoteCommand(t, suite.Config(), consulServerTaskARN, "consul-server", consulCmd)
+					r.Check(err)
+				})
+			}
+
+			retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+				curlOut, err := helpers.ExecuteRemoteCommand(t, suite.Config(), testClientTaskARN, "basic", `/bin/sh -c "curl localhost:1234"`)
+				r.Check(err)
+				if !strings.Contains(curlOut, `"code": 200`) {
+					r.Errorf("response was unexpected: %q", curlOut)
+				}
+			})
+
+			// Validate graceful shutdown behavior. We check the client app can reach its upstream after the task is stopped.
+			// This relies on a couple of helpers:
+			// * a custom entrypoint for the client app that keeps it running for 10s into Task shutdown, and
+			// * an additional "shutdown-monitor" container that makes requests to the client app
+			// Since this is timing dependent, we check logs after the fact to validate when the containers exited.
+			shell.RunCommandAndGetOutput(t, shell.Command{
+				Command: "aws",
+				Args: []string{
+					"ecs",
+					"stop-task",
+					"--region", suite.Config().Region,
+					"--cluster", suite.Config().ECSClusterARN,
+					"--task", testClientTaskARN,
+					"--reason", "Stopped to validate graceful shutdown in acceptance tests",
+				},
+			})
+
+			// Wait for the task to stop (~30 seconds)
+			retry.RunWith(&retry.Timer{Timeout: 1 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+				describeTasksOut, err := shell.RunCommandAndGetOutputE(t, shell.Command{
+					Command: "aws",
+					Args: []string{
+						"ecs",
+						"describe-tasks",
+						"--region", suite.Config().Region,
+						"--cluster", suite.Config().ECSClusterARN,
+						"--task", testClientTaskARN,
+					},
+				})
+				r.Check(err)
+
+				var describeTasks ecs.DescribeTasksOutput
+				r.Check(json.Unmarshal([]byte(describeTasksOut), &describeTasks))
+				require.Len(r, describeTasks.Tasks, 1)
+				require.NotEqual(r, "RUNNING", describeTasks.Tasks[0].LastStatus)
+			})
+
+			// Check logs to see that the application ignored the TERM signal and exited about 10s later.
+			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				appLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "basic")
+				require.NoError(r, err)
+
+				logMsg := "consul-ecs: received sigterm. waiting 10s before terminating application."
+				appLogs = appLogs.Filter(logMsg)
+				require.Len(r, appLogs, 1)
+				require.Contains(r, appLogs[0].Message, logMsg)
+			})
+
+			// Check that the Envoy entrypoint received the sigterm.
+			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				envoyLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "sidecar-proxy")
+				require.NoError(r, err)
+
+				logMsg := "consul-ecs: waiting for application container(s) to stop"
+				envoyLogs = envoyLogs.Filter(logMsg)
+				require.GreaterOrEqual(r, len(envoyLogs), 1)
+				require.Contains(r, envoyLogs[0].Message, logMsg)
+			})
+
+			// Retrieve "shutdown-monitor" logs to check outgoing requests succeeded.
+			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				monitorLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "shutdown-monitor")
+				require.NoError(r, err)
+
+				// Check how long after shutdown the upstream was reachable.
+				upstreamOkLogs := monitorLogs.Filter(
+					"Signal received: signal=terminated",
+					"upstream: [OK] GET http://localhost:1234 (200)",
+				)
+				// The client app is configured to run for about 10 seconds after Task shutdown.
+				require.GreaterOrEqual(r, len(upstreamOkLogs.Filter("upstream: [OK]")), 7)
+				require.GreaterOrEqual(r, upstreamOkLogs.Duration().Seconds(), 8.0)
+
+				// Double-check the application was still functional for about 10 seconds into Task shutdown.
+				// The FakeService makes requests to the upstream, so this further validates Envoy allows outgoing requests.
+				applicationOkLogs := monitorLogs.Filter(
+					"Signal received: signal=terminated",
+					"application: [OK] GET http://localhost:9090 (200)",
+				)
+				require.GreaterOrEqual(r, len(applicationOkLogs.Filter("application: [OK]")), 7)
+				require.GreaterOrEqual(r, applicationOkLogs.Duration().Seconds(), 8.0)
+			})
+
+			// Validate that passing additional Consul agent configuration works.
+			// We enable DEBUG logs on one of the Consul agents.
+			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				agentLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "consul-client")
+
+				require.NoError(r, err)
+				logMsg := "[DEBUG] agent:"
+				agentLogs = agentLogs.Filter(logMsg)
+				require.GreaterOrEqual(r, len(agentLogs), 1)
+				require.Contains(r, agentLogs[0].Message, logMsg)
+			})
+
+			logger.Log(t, "Test successful!")
 		})
-		r.Check(err)
-
-		var describeTasks ecs.DescribeTasksOutput
-		r.Check(json.Unmarshal([]byte(describeTasksOut), &describeTasks))
-		require.Len(r, describeTasks.Tasks, 1)
-		require.NotEqual(r, "RUNNING", describeTasks.Tasks[0].LastStatus)
-	})
-
-	// Check logs to see that the application ignored the TERM signal and exited about 10s later.
-	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
-		appLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "basic")
-		require.NoError(r, err)
-
-		logMsg := "consul-ecs: received sigterm. waiting 10s before terminating application."
-		appLogs = appLogs.Filter(logMsg)
-		require.Len(r, appLogs, 1)
-		require.Contains(r, appLogs[0].Message, logMsg)
-	})
-
-	// Check that the Envoy entrypoint received the sigterm.
-	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
-		envoyLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "sidecar-proxy")
-		require.NoError(r, err)
-
-		logMsg := "consul-ecs: waiting for application container(s) to stop"
-		envoyLogs = envoyLogs.Filter(logMsg)
-		require.GreaterOrEqual(r, len(envoyLogs), 1)
-		require.Contains(r, envoyLogs[0].Message, logMsg)
-	})
-
-	// Retrieve "shutdown-monitor" logs to check outgoing requests succeeded.
-	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
-		monitorLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "shutdown-monitor")
-		require.NoError(r, err)
-
-		// Check how long after shutdown the upstream was reachable.
-		upstreamOkLogs := monitorLogs.Filter(
-			"Signal received: signal=terminated",
-			"upstream: [OK] GET http://localhost:1234 (200)",
-		)
-		// The client app is configured to run for about 10 seconds after Task shutdown.
-		require.GreaterOrEqual(r, len(upstreamOkLogs.Filter("upstream: [OK]")), 7)
-		require.GreaterOrEqual(r, upstreamOkLogs.Duration().Seconds(), 8.0)
-
-		// Double-check the application was still functional for about 10 seconds into Task shutdown.
-		// The FakeService makes requests to the upstream, so this further validates Envoy allows outgoing requests.
-		applicationOkLogs := monitorLogs.Filter(
-			"Signal received: signal=terminated",
-			"application: [OK] GET http://localhost:9090 (200)",
-		)
-		require.GreaterOrEqual(r, len(applicationOkLogs.Filter("application: [OK]")), 7)
-		require.GreaterOrEqual(r, applicationOkLogs.Duration().Seconds(), 8.0)
-	})
-
-	// Validate that passing additional Consul agent configuration works.
-	// We enable DEBUG logs on one of the Consul agents.
-	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
-		agentLogs, err := helpers.GetCloudWatchLogEvents(t, suite.Config(), testClientTaskID, "consul-client")
-
-		require.NoError(r, err)
-		logMsg := "[DEBUG] agent:"
-		agentLogs = agentLogs.Filter(logMsg)
-		require.GreaterOrEqual(r, len(agentLogs), 1)
-		require.Contains(r, agentLogs[0].Message, logMsg)
-	})
-
-	logger.Log(t, "Test successful!")
+	}
 }
 
 type listTasksResponse struct {

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -533,7 +533,7 @@ func TestBasic(t *testing.T) {
 			// Create an intention.
 			if secure {
 				// First check that connection between apps is unsuccessful.
-				retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+				retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
 					curlOut, err := helpers.ExecuteRemoteCommand(t, suite.Config(), testClientTaskARN, "basic", `/bin/sh -c "curl localhost:1234"`)
 					r.Check(err)
 					if !strings.Contains(curlOut, `curl: (52) Empty reply from server`) {
@@ -547,7 +547,7 @@ func TestBasic(t *testing.T) {
 				})
 			}
 
-			retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
 				curlOut, err := helpers.ExecuteRemoteCommand(t, suite.Config(), testClientTaskARN, "basic", `/bin/sh -c "curl localhost:1234"`)
 				r.Check(err)
 				if !strings.Contains(curlOut, `"code": 200`) {

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -541,7 +541,7 @@ func TestBasic(t *testing.T) {
 					}
 				})
 				retry.RunWith(&retry.Timer{Timeout: 6 * time.Minute, Wait: 20 * time.Second}, t, func(r *retry.R) {
-					consulCmd := fmt.Sprintf(`/bin/sh -c "consul intention create test_client_%s test_server_%s"`, randomSuffix, randomSuffix)
+					consulCmd := fmt.Sprintf(`/bin/sh -c "consul intention create %s_%s %s_%s"`, clientServiceName, randomSuffix, serverServiceName, randomSuffix)
 					_, err := helpers.ExecuteRemoteCommand(t, suite.Config(), consulServerTaskARN, "consul-server", consulCmd)
 					r.Check(err)
 				})

--- a/test/acceptance/tests/basic/terraform/admin-partition-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/admin-partition-validate/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "partition" {
+  type    = string
+  default = ""
+}
+
+variable "namespace" {
+  type    = string
+  default = ""
+}
+
+module "test_client" {
+  source = "../../../../../../modules/mesh-task"
+  family = "family"
+  container_definitions = [{
+    name = "basic"
+  }]
+  outbound_only = true
+  retry_join    = ["test"]
+
+  consul_partition = var.partition
+  consul_namespace = var.namespace
+}

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -281,10 +281,6 @@ module "test_server" {
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
 
-  // Test passing both a role resource and role data source objects to make sure both
-  // have the necessary fields ("arn" and "id").
-  task_role                     = aws_iam_role.task
-  execution_role                = aws_iam_role.execution
   additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 }
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Set secret name correctly when partition and namespace are present.
- Add validation for partition and namespace variables.
- Add acceptance tests for updates.

## How I've tested this PR:
- Ran the acceptance tests

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
