### PR TITLE
dev-server: Support Consul enterprise license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
+## Unreleased
+
+FEATURES
+* modules/dev-server: Add `consul_license` input variable to support
+  passing a Consul enterprise license.
+  [[GH-96](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/96)]
+
+
 ## 0.4.1 (April 8, 2022)
 
 BUG FIXES
 * modules/mesh-task: Fix a bug that results in invalid secret names
   when admin partitions are enabled.
   [[GH-95](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/95)]
-
 
 ## 0.4.0 (April 4, 2022)
 

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -5,6 +5,8 @@ locals {
     container_name   = "consul-server"
     container_port   = 8500
   }] : []
+
+  consul_license_enabled = var.consul_license != ""
 }
 
 resource "tls_private_key" "ca" {
@@ -58,6 +60,18 @@ resource "aws_secretsmanager_secret_version" "ca_cert" {
   secret_string = tls_self_signed_cert.ca[count.index].cert_pem
 }
 
+// Optional Enterprise license.
+resource "aws_secretsmanager_secret" "license" {
+  count = local.consul_license_enabled ? 1 : 0
+  name  = "${var.name}-consul-license"
+}
+
+resource "aws_secretsmanager_secret_version" "license" {
+  count         = local.consul_license_enabled ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.license[count.index].id
+  secret_string = chomp(var.consul_license) // trim trailing newlines
+}
+
 resource "aws_ecs_service" "this" {
   name            = var.name
   cluster         = var.ecs_cluster_arn
@@ -82,6 +96,7 @@ resource "aws_ecs_service" "this" {
     }
   }
   enable_execute_command = true
+  wait_for_steady_state  = var.wait_for_steady_state
 
   depends_on = [
     aws_iam_role.this_task
@@ -138,14 +153,20 @@ resource "aws_ecs_task_definition" "this" {
         secrets = concat(
           local.gossip_encryption_enabled ? [
             {
-              name      = "CONSUL_GOSSIP_ENCRYPTION_KEY",
+              name      = "CONSUL_GOSSIP_ENCRYPTION_KEY"
               valueFrom = var.gossip_key_secret_arn
             },
           ] : [],
           var.acls ? [
             {
-              name      = "CONSUL_HTTP_TOKEN",
+              name      = "CONSUL_HTTP_TOKEN"
               valueFrom = aws_secretsmanager_secret.bootstrap_token[0].arn
+            },
+          ] : [],
+          local.consul_license_enabled ? [
+            {
+              name      = "CONSUL_LICENSE"
+              valueFrom = aws_secretsmanager_secret.license[0].arn
             },
           ] : [],
         )
@@ -182,6 +203,17 @@ resource "aws_iam_policy" "this_execution" {
       ],
       "Resource": [
         "${aws_secretsmanager_secret.bootstrap_token[0].arn}"
+      ]
+    },
+%{endif~}
+%{if local.consul_license_enabled~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${aws_secretsmanager_secret.license[0].arn}"
       ]
     },
 %{endif~}
@@ -306,7 +338,15 @@ resource "aws_secretsmanager_secret_version" "bootstrap_token" {
 }
 
 locals {
-  consul_dns_name       = "${aws_service_discovery_service.server.name}.${aws_service_discovery_private_dns_namespace.server.name}"
+  consul_dns_name = "${aws_service_discovery_service.server.name}.${aws_service_discovery_private_dns_namespace.server.name}"
+  // TODO: Deprecated fields
+  //   The 'ca_file' field is deprecated. Use the 'tls.defaults.ca_file' field instead.
+  //   The 'cert_file' field is deprecated. Use the 'tls.defaults.cert_file' field instead.
+  //   The 'key_file' field is deprecated. Use the 'tls.defaults.key_file' field instead.
+  //   The 'verify_incoming_rpc' field is deprecated. Use the 'tls.internal_rpc.verify_incoming' field instead.
+  //   The 'verify_outgoing' field is deprecated. Use the 'tls.defaults.verify_outgoing' field instead.
+  //   The 'verify_server_hostname' field is deprecated. Use the 'tls.internal_rpc.verify_server_hostname' field instead.
+  //   The 'acl.tokens.master' field is deprecated. Use the 'acl.tokens.initial_management' field instead.
   consul_server_command = <<EOF
 ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
 

--- a/modules/dev-server/outputs.tf
+++ b/modules/dev-server/outputs.tf
@@ -34,6 +34,11 @@ output "server_dns" {
 }
 
 output "bootstrap_token_secret_arn" {
-  description = "The ARN of the ACL bootstrap token secret."
+  description = "The Secrets Manager ARN of the ACL bootstrap token secret."
   value       = var.acls ? aws_secretsmanager_secret.bootstrap_token[0].arn : null
+}
+
+output "bootstrap_token_id" {
+  description = "The Consul secret ID of the bootstrap ACL token."
+  value       = var.acls ? random_uuid.bootstrap_token[0].result : null
 }

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,6 +61,13 @@ variable "consul_image" {
   default     = "public.ecr.aws/hashicorp/consul:1.11.4"
 }
 
+variable "consul_license" {
+  description = "A Consul Enterprise license key. Requires consul_image to be set to a Consul Enterprise image."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "log_configuration" {
   description = "Task definition log configuration object (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html)."
   type        = any
@@ -111,6 +118,12 @@ variable "gossip_key_secret_arn" {
 
 variable "acls" {
   description = "Whether to enable ACLs on the server."
+  type        = bool
+  default     = false
+}
+
+variable "wait_for_steady_state" {
+  description = "Set wait_for_steady_state on the ECS service. This causes Terraform to wait for the Consul server task to be deployed."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Add `consul_license` input variable to specify an enterprise license key. This is placed in a Secrets Manager secret that is the set as the `CONSUL_LICENSE` variable for the dev-server
- Add `wait_for_steady_state` input variable, which is passed through to the ECS service
- Add `bootstrap_token_id` output variable

## How I've tested this PR:
Manually

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::