### PR TITLE
Set initProcessEnabled on injected containers

### DIFF
--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -214,6 +214,9 @@ resource "aws_ecs_task_definition" "this" {
                 value = local.encoded_config
               }
             ]
+            linuxParameters = {
+              initProcessEnabled = true
+            }
             portMappings = []
             secrets = var.acls ? [
               {
@@ -335,6 +338,9 @@ resource "aws_ecs_task_definition" "this" {
               condition     = "SUCCESS"
             },
           ]
+          linuxParameters = {
+            initProcessEnabled = true
+          }
           secrets = var.acls ? [
             {
               name      = "CONSUL_HTTP_TOKEN",


### PR DESCRIPTION
## Changes proposed in this PR:
This sets `initProcessEnabled` on each of the injected containers to see if this helps with execute-command reliability.

From [docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-enabling-and-using),

> If you set the task definition parameter initProcessEnabled to true, this starts the init process inside the container, which removes any zombie SSM agent child processes found. The following provides an example.
 
Not really sure, but both consul-client and mesh-init start at the beginning of the task, so maybe we're getting different behavior depending on which starts first?

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] ~Tests added~ n/a
- [x] ~CHANGELOG entry added~ n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::