### PR TITLE
Support the auth method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-ecs-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-ecs-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run: mkdir -p $TEST_RESULTS
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   consul-ecs-test:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.1
     environment:
       TEST_RESULTS: &TEST_RESULTS /tmp/test-results # path to where test results are saved
 
@@ -17,7 +17,7 @@ jobs:
       # Restore go module cache if there is one
       - restore_cache:
           keys:
-            - consul-ecs-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+            - consul-ecs-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
 
       - run:
           name: go mod download
@@ -26,9 +26,9 @@ jobs:
 
       # Save go module cache if the go.mod file has changed
       - save_cache:
-          key: consul-ecs-acceptance-modcache-v1-{{ checksum "test/acceptance/go.mod" }}
+          key: consul-ecs-acceptance-modcache-v2-{{ checksum "test/acceptance/go.mod" }}
           paths:
-            - "/go/pkg/mod"
+            - "/home/circleci/go/pkg/mod"
 
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
@@ -108,7 +108,7 @@ jobs:
           working_directory: test/acceptance/tests
           no_output_timeout: 1h
           command: |
-            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" -- ./... -p 1 -timeout 1h -v -failfast
+            gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
 
       - store_test_results:
           path: *TEST_RESULTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ FEATURES
 * modules/dev-server: Add `consul_license` input variable to support
   passing a Consul enterprise license.
   [[GH-96](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/96)]
+* modules/mesh-task, modules/acl-controller: Support the Consul AWS IAM auth method. This requires
+  Consul 1.12.0+. Add `consul_http_addr`, `client_token_auth_method_name`, and
+  `service_token_auth_method_name` variables to `mesh-task`. Add `iam_role_path` variable to
+  `acl-controller`. Add an `iam:GetRole` permission to the task role. Set the tags
+  `consul.hashicorp.com.service-name` and `consul.hashicorp.com.namespace` on the task role.
+  [[GH-100](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/100)]
 
 
 ## 0.4.1 (April 8, 2022)

--- a/modules/acl-controller/main.tf
+++ b/modules/acl-controller/main.tf
@@ -36,15 +36,20 @@ resource "aws_ecs_task_definition" "this" {
       image            = var.consul_ecs_image
       essential        = true
       logConfiguration = var.log_configuration,
-      command = concat([
-        "acl-controller",
-        "-consul-client-secret-arn", aws_secretsmanager_secret.client_token.arn,
-        "-secret-name-prefix", var.name_prefix
+      command = concat(
+        [
+          "acl-controller",
+          "-consul-client-secret-arn", aws_secretsmanager_secret.client_token.arn,
+          "-secret-name-prefix", var.name_prefix
         ],
         var.consul_partitions_enabled ? [
           "-partitions-enabled",
           "-partition", var.consul_partition
-      ] : [])
+        ] : [],
+        var.iam_role_path != "" ? [
+          "-iam-role-path", var.iam_role_path,
+        ] : [],
+      )
       linuxParameters = {
         initProcessEnabled = true
       }

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -37,6 +37,12 @@ variable "log_configuration" {
   default     = null
 }
 
+variable "iam_role_path" {
+  description = "IAM roles at this path will be permitted to login to the Consul AWS IAM auth method configured by this controller."
+  type        = string
+  default     = ""
+}
+
 variable "subnets" {
   description = "Subnets where the controller task should be deployed. If these are private subnets then there must be a NAT gateway for image pulls to work. If these are public subnets then you must also set assign_public_ip for image pulls to work."
   type        = list(string)

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -58,7 +58,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.11.4"
+  default     = "public.ecr.aws/hashicorp/consul:1.12.0"
 }
 
 variable "consul_license" {

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -15,7 +15,6 @@ locals {
     consulHTTPAddr   = var.consul_http_addr
     consulCACertFile = "/consul/consul-ca-cert.pem"
     consulLogin      = local.consulLogin
-    logLevel         = "DEBUG"
     service = merge(
       {
         name      = local.service_name

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -3,7 +3,19 @@ locals {
   serviceExtra = lookup(var.consul_ecs_config, "service", {})
   proxyExtra   = lookup(var.consul_ecs_config, "proxy", {})
 
+  consulLogin = var.acls ? {
+    // TODO: Switch this to `enabled = var.acls` once the auth method is fully supported.
+    enabled = var.service_token_auth_method_name != ""
+    method  = var.service_token_auth_method_name
+    // TODO: Move this to a top-level partition field in the CONSUL_ECS_CONFIG_JSON
+    extraLoginFlags = var.consul_partition != "" ? ["-partition", var.consul_partition] : []
+  } : null
+
   config = {
+    consulHTTPAddr   = var.consul_http_addr
+    consulCACertFile = "/consul/consul-ca-cert.pem"
+    consulLogin      = local.consulLogin
+    logLevel         = "DEBUG"
     service = merge(
       {
         name      = local.service_name

--- a/modules/mesh-task/iam.tf
+++ b/modules/mesh-task/iam.tf
@@ -47,7 +47,8 @@ resource "aws_iam_role" "task" {
   }
 }
 
-// If acls enabled, we need the task role configure for the auth method.
+// If acls are enabled, the task role must be configured with an `iam:GetRole` permission
+// to fetch itself, in order to be compatbile with the auth method.
 resource "aws_iam_policy" "task" {
   count       = var.acls ? 1 : 0
   name        = "${var.family}-task"

--- a/modules/mesh-task/iam.tf
+++ b/modules/mesh-task/iam.tf
@@ -25,6 +25,7 @@ locals {
 // Create the task role
 resource "aws_iam_role" "task" {
   count = local.create_task_role ? 1 : 0
+  path  = "/ecs/"
 
   name = "${var.family}-task"
   assume_role_policy = jsonencode({
@@ -39,6 +40,43 @@ resource "aws_iam_role" "task" {
       }
     ]
   })
+
+  tags = {
+    "consul.hashicorp.com.service-name" = local.service_name
+    "consul.hashicorp.com.namespace"    = var.consul_namespace
+  }
+}
+
+// If acls enabled, we need the task role configure for the auth method.
+resource "aws_iam_policy" "task" {
+  count       = var.acls ? 1 : 0
+  name        = "${var.family}-task"
+  path        = "/ecs/"
+  description = "${var.family} mesh-task task policy"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole"
+      ],
+      "Resource": [
+        "${local.task_role_arn}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_iam_role_policy_attachment" "task" {
+  count      = var.acls ? 1 : 0
+  role       = local.task_role_id
+  policy_arn = aws_iam_policy.task[count.index].arn
 }
 
 resource "aws_iam_role_policy_attachment" "additional_task_policies" {
@@ -73,6 +111,7 @@ resource "aws_iam_policy" "execution" {
   path        = "/ecs/"
   description = "${var.family} mesh-task execution policy"
 
+  // TODO: Remove client and service token secrets once switched to the auth method.
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -342,6 +342,9 @@ resource "aws_ecs_task_definition" "this" {
             }
           ]
           portMappings = []
+          mountPoints = [
+            local.consul_data_mount
+          ]
           dependsOn = [
             {
               containerName = "consul-ecs-mesh-init"

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -220,6 +220,7 @@ resource "aws_ecs_task_definition" "this" {
             portMappings = []
             secrets = var.acls ? [
               {
+                // TODO: Remove once switched to auth method
                 name      = "CONSUL_HTTP_TOKEN",
                 valueFrom = "${aws_secretsmanager_secret.service_token[0].arn}:token::"
               }
@@ -239,6 +240,11 @@ resource "aws_ecs_task_definition" "this" {
                   consul_agent_defaults_hcl      = local.consul_agent_defaults_hcl
                   consul_agent_configuration_hcl = var.consul_agent_configuration
                   tls                            = var.tls
+                  acls                           = var.acls
+                  consul_http_addr               = var.consul_http_addr
+                  client_token_auth_method_name  = var.client_token_auth_method_name
+                  consul_partition               = var.consul_partition
+                  region                         = data.aws_region.current.name
                 }
               ), "\r", "")
             ]
@@ -275,6 +281,7 @@ resource "aws_ecs_task_definition" "this" {
               ] : [],
               var.acls ? [
                 {
+                  // TODO: Remove once switched to auth method
                   name      = "AGENT_TOKEN",
                   valueFrom = "${var.consul_client_token_secret_arn}:token::"
                 }
@@ -343,6 +350,7 @@ resource "aws_ecs_task_definition" "this" {
           }
           secrets = var.acls ? [
             {
+              // TODO: Remove once switched to auth method
               name      = "CONSUL_HTTP_TOKEN",
               valueFrom = "${aws_secretsmanager_secret.service_token[0].arn}:token::"
             }

--- a/modules/mesh-task/outputs.tf
+++ b/modules/mesh-task/outputs.tf
@@ -10,6 +10,14 @@ output "execution_role_id" {
   value = local.execution_role_id
 }
 
+output "task_role_arn" {
+  value = local.task_role_arn
+}
+
+output "execution_role_arn" {
+  value = local.execution_role_arn
+}
+
 output "task_tags" {
   value = aws_ecs_task_definition.this.tags_all
 }

--- a/modules/mesh-task/templates/consul_agent_defaults.hcl.tpl
+++ b/modules/mesh-task/templates/consul_agent_defaults.hcl.tpl
@@ -29,7 +29,7 @@ auto_encrypt = {
   tls = true
   ip_san = ["$ECS_IPV4"]
 }
-ca_file = "/tmp/consul-ca-cert.pem"
+ca_file = "/consul/consul-ca-cert.pem"
 verify_outgoing = true
 %{ endif ~}
 

--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -1,6 +1,8 @@
 cp /bin/consul /bin/consul-inject/consul
 
-ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
+ECS_TASK_META=$(curl -s $ECS_CONTAINER_METADATA_URI_V4)
+ECS_IPV4=$(echo "$ECS_TASK_META" | jq -r '.Networks[0].IPv4Addresses[0]')
+TASK_REGION=$(echo "$ECS_TASK_META" | jq -r .ContainerARN | cut -d':' -f4)
 
 %{ if tls ~}
 echo "$CONSUL_CACERT" > /consul/consul-ca-cert.pem
@@ -19,6 +21,7 @@ login() {
       -partition ${ consul_partition } \
     %{ endif ~}
       -type aws -method ${ client_token_auth_method_name } \
+      -aws-region "$TASK_REGION" \
       -aws-auto-bearer-token -aws-include-entity \
       -token-sink-file /consul/client-token
 }

--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -3,7 +3,26 @@ cp /bin/consul /bin/consul-inject/consul
 ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
 
 %{ if tls ~}
-echo "$CONSUL_CACERT" > /tmp/consul-ca-cert.pem
+echo "$CONSUL_CACERT" > /consul/consul-ca-cert.pem
+%{ endif ~}
+
+%{ if acls && client_token_auth_method_name != "" ~}
+echo "Logging into auth method: name=${ client_token_auth_method_name }"
+
+consul login \
+  -http-addr ${ consul_http_addr } \
+%{ if tls ~}
+  -ca-file /consul/consul-ca-cert.pem \
+%{ endif ~}
+%{ if consul_partition != "" ~}
+  -partition ${ consul_partition } \
+%{ endif ~}
+  -type aws -method ${ client_token_auth_method_name } \
+  -aws-auto-bearer-token -aws-include-entity \
+  -token-sink-file /consul/token.txt
+
+# This is an env var which is interpolated into the agent-defaults.hcl
+export AGENT_TOKEN=$(cat /consul/token.txt)
 %{ endif ~}
 
 cat << EOF > /consul/agent-defaults.hcl

--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -20,7 +20,7 @@ login() {
     %{ endif ~}
       -type aws -method ${ client_token_auth_method_name } \
       -aws-auto-bearer-token -aws-include-entity \
-      -token-sink-file /consul/token.txt
+      -token-sink-file /consul/client-token
 }
 
 while ! login; do
@@ -28,7 +28,7 @@ while ! login; do
 done
 
 # This is an env var which is interpolated into the agent-defaults.hcl
-export AGENT_TOKEN=$(cat /consul/token.txt)
+export AGENT_TOKEN=$(cat /consul/client-token)
 %{ endif ~}
 
 cat << EOF > /consul/agent-defaults.hcl

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -108,7 +108,7 @@ variable "outbound_only" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.11.4"
+  default     = "public.ecr.aws/hashicorp/consul:1.12.0"
 }
 
 variable "consul_ecs_image" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -230,6 +230,24 @@ variable "retry_join" {
   type        = list(string)
 }
 
+variable "consul_http_addr" {
+  description = "Consul HTTP Address. Required when using the IAM Auth Method to obtain ACL tokens."
+  type        = string
+  default     = ""
+}
+
+variable "client_token_auth_method_name" {
+  description = "The name of the Consul Auth Method to login to for client tokens."
+  type        = string
+  default     = ""
+}
+
+variable "service_token_auth_method_name" {
+  description = "The name of the Consul Auth Method to login to for service tokens."
+  type        = string
+  default     = ""
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -207,6 +207,9 @@ module "test_client" {
         name  = "GOLANG_MAIN_B64"
         value = base64encode(file("${path.module}/shutdown-monitor.go"))
       }]
+      linuxParameters = {
+        initProcessEnabled = true
+      }
       # NOTE: `go run <file>` signal handling is different: https://github.com/golang/go/issues/40467
       entryPoint = ["/bin/sh", "-c", <<EOT
 echo "$GOLANG_MAIN_B64" | base64 -d > main.go

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -324,13 +324,12 @@ resource "aws_iam_role" "task" {
     ]
   })
 
-  // TODO: When using the auth method, mesh-task should add these tags if the task role
-  // is passed in.
+  // Terraform does not support managing individual tags for IAM roles yet.
+  // These tags must be set when a role is passed in to mesh-task, if acls are enabled.
   tags = {
     "consul.hashicorp.com.service-name" = "${var.server_service_name}_${var.suffix}"
-    // "consul.hashicorp.com.namespace"    = ""
+    "consul.hashicorp.com.namespace"    = ""
   }
-
 }
 
 

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -41,6 +41,13 @@ variable "secure" {
   default     = false
 }
 
+// TODO: Remove this once switched over to the auth method.
+variable "auth_method" {
+  description = "When secure=true, whether the secure configuration uses the auth method."
+  type        = bool
+  default     = false
+}
+
 variable "launch_type" {
   description = "Whether to launch tasks on Fargate or EC2"
   type        = string
@@ -143,6 +150,8 @@ module "acl_controller" {
   subnets                           = var.subnets
   name_prefix                       = var.suffix
   consul_ecs_image                  = var.consul_ecs_image
+
+  iam_role_path = var.secure && var.auth_method ? "/ecs" : ""
 }
 
 resource "aws_ecs_service" "test_client" {
@@ -229,6 +238,12 @@ EOT
 
   additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 
+  consul_http_addr = var.secure && var.auth_method ? "https://${module.consul_server.server_dns}:8501" : ""
+  // TODO: Remove these once fully switched over to the auth method.
+  // These should default to the correct value.
+  client_token_auth_method_name  = var.secure && var.auth_method ? "iam-ecs-client-token" : ""
+  service_token_auth_method_name = var.secure && var.auth_method ? "iam-ecs-service-token" : ""
+
   consul_agent_configuration = <<-EOT
   log_level = "debug"
   EOT
@@ -281,6 +296,12 @@ module "test_server" {
   acl_secret_name_prefix         = var.suffix
   consul_ecs_image               = var.consul_ecs_image
 
+  consul_http_addr = var.secure && var.auth_method ? "https://${module.consul_server.server_dns}:8501" : ""
+  // TODO: Remove these once fully switched over to the auth method.
+  // These should default to the correct value.
+  client_token_auth_method_name  = var.secure && var.auth_method ? "iam-ecs-client-token" : ""
+  service_token_auth_method_name = var.secure && var.auth_method ? "iam-ecs-service-token" : ""
+
   additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 }
 
@@ -299,6 +320,14 @@ resource "aws_iam_role" "task" {
       },
     ]
   })
+
+  // TODO: When using the auth method, mesh-task should add these tags if the task role
+  // is passed in.
+  tags = {
+    "consul.hashicorp.com.service-name" = "${var.server_service_name}_${var.suffix}"
+    // "consul.hashicorp.com.namespace"    = ""
+  }
+
 }
 
 


### PR DESCRIPTION
## Changes proposed in this PR:

This is an incremental change which flags off the login functionality until the auth method is fully supported. By default, the old mechanism for tokens is used (secrets in Secrets Manager). The `client_token_auth_method_name`, `service_token_auth_method_name`, and `consul_http_addr` variables are required to be set to use the new mechanism which logs in to auth method. Later, we'll switch over to the auth method as the default for ACL tokens.

- The server CA cert file is now placed on the shared volume, `/consul/consul-ca-cert.pem`, so that mesh-init has access to the file for its `consul login`
- New input variables: `client_token_auth_method_name`, `service_token_auth_method_name`, and `consul_http_addr`
- The IAM task role is configured with an `iam:GetRole` permission for itself
- The acl-controller has a new `iam_role_path` variable which, if set, is passed as `-iam-role-path` to the `acl-controller` command

## How I've tested this PR:
Acceptance tests.
- The existing tests should still pass
- A new test, `TestBasic/secure:_true,authMethod:_true`, tests the auth method

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::