### PR TITLE
Immediately delete the dev-server's Secrets Manager secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 FEATURES
+* modules/dev-server: Immediately delete all Secrets Manager secrets rather
+ than leaving a 30 day recovery window.
+ [[GH-100](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/100)]
 * modules/dev-server: Add `consul_license` input variable to support
   passing a Consul enterprise license.
   [[GH-96](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/96)]

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -39,8 +39,9 @@ resource "tls_self_signed_cert" "ca" {
 }
 
 resource "aws_secretsmanager_secret" "ca_key" {
-  count = var.tls ? 1 : 0
-  name  = "${var.name}-ca-key"
+  count                   = var.tls ? 1 : 0
+  name                    = "${var.name}-ca-key"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "ca_key" {
@@ -50,8 +51,9 @@ resource "aws_secretsmanager_secret_version" "ca_key" {
 }
 
 resource "aws_secretsmanager_secret" "ca_cert" {
-  count = var.tls ? 1 : 0
-  name  = "${var.name}-ca-cert"
+  count                   = var.tls ? 1 : 0
+  name                    = "${var.name}-ca-cert"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "ca_cert" {
@@ -62,8 +64,9 @@ resource "aws_secretsmanager_secret_version" "ca_cert" {
 
 // Optional Enterprise license.
 resource "aws_secretsmanager_secret" "license" {
-  count = local.consul_enterprise_enabled ? 1 : 0
-  name  = "${var.name}-consul-license"
+  count                   = local.consul_enterprise_enabled ? 1 : 0
+  name                    = "${var.name}-consul-license"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "license" {


### PR DESCRIPTION
The default value is 30, meaning trying to recreate secrets with the same name
during that time period breaks.

## Changes proposed in this PR:
- Set the recovery period for all dev server secrets to zero days.

## How I've tested this PR:
👁️ This caused a bug in mesh-task, so we made [the same change](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/modules/mesh-task/main.tf#L89).

## How I expect reviewers to test this PR:
👁️ 

## Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added 