### PR TITLE
Ensure health-sync runs, to do consul logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ FEATURES
   `service_token_auth_method_name` variables to `mesh-task`. Add `iam_role_path` variable to
   `acl-controller`. Add an `iam:GetRole` permission to the task role. Set the tags
   `consul.hashicorp.com.service-name` and `consul.hashicorp.com.namespace` on the task role.
+  `health-sync` runs when ACLs are enabled, in order to do a `consul logout` when the task stops.
   [[GH-100](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/100)]
+  [[GH-103](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/103)]
 
 
 ## 0.4.1 (April 8, 2022)

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -68,6 +68,8 @@ locals {
 
   defaulted_check_containers = length(var.checks) == 0 ? [for def in local.container_defs_with_depends_on : def.name
   if contains(keys(def), "essential") && contains(keys(def), "healthCheck")] : []
+  // health-sync is enabled if acls are enabled, in order to run 'consul logout' to cleanup tokens when the task stops
+  health_sync_enabled = length(local.defaulted_check_containers) > 0 || var.acls
 
   consul_agent_defaults_hcl = templatefile(
     "${path.module}/templates/consul_agent_defaults.hcl.tpl",
@@ -327,7 +329,7 @@ resource "aws_ecs_task_definition" "this" {
             }]
           },
         ],
-        length(local.defaulted_check_containers) > 0 ? [{
+        local.health_sync_enabled ? [{
           name             = "consul-ecs-health-sync"
           image            = var.consul_ecs_image
           essential        = false

--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -40,6 +40,10 @@ while ! consul_login; do
     sleep 2
 done
 
+# Allow the health-sync container to read this token for consul logout.
+# The user here is root, but health-sync runs as a 'consul-ecs' user.
+chmod 0644 /consul/client-token
+
 # Wait for raft replication to hopefully occur. Without this, an "ACL not found" may be cached for a while.
 # Technically, the problem could still occur but this should handle most cases.
 # This waits at most 2s (20 attempts with 0.1s sleep)


### PR DESCRIPTION
## Changes proposed in this PR:
This updates mesh-task to run `health-sync` whenever ACLs are enabled, so that it can do a `consul logout` when the task stops. The permissions of the `/consul/client-token` are changed in order to be readable by the `consul-ecs` user in the health-sync container.

## How I've tested this PR:
- Acceptance tests

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::