### PR TITLE
Remove deprecated field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ FEATURES
   `consul.hashicorp.com.service-name` and `consul.hashicorp.com.namespace` on the task role.
   [[GH-100](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/100)]
 
+BUG FIXES
+* modules/mesh-task: Remove deprecated `key_algorithm` field. [[GH-104](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/104)]
 
 ## 0.4.1 (April 8, 2022)
 

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -17,7 +17,6 @@ resource "tls_private_key" "ca" {
 
 resource "tls_self_signed_cert" "ca" {
   count           = var.tls ? 1 : 0
-  key_algorithm   = "ECDSA"
   private_key_pem = tls_private_key.ca[count.index].private_key_pem
 
   subject {


### PR DESCRIPTION
```
│ Warning: Argument is deprecated
│
│   with module.dev_consul_server.tls_self_signed_cert.ca,
│   on ../../modules/dev-server/main.tf line 20, in resource "tls_self_signed_cert" "ca":
│   20:   key_algorithm   = "ECDSA"
│
│ This is now ignored, as the key algorithm is inferred from the `private_key_pem`.
╵
```

## How I've tested this PR:
- applied

## How I expect reviewers to test this PR:
- code

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::