### PR TITLE
Placeholder for checking out tag in examples

### DIFF
--- a/examples/admin-partitions/README.md
+++ b/examples/admin-partitions/README.md
@@ -33,6 +33,7 @@ Clone this repository:
 
 ```console
 $ git clone https://github.com/hashicorp/terraform-aws-consul-ecs.git
+$ git checkout tags/<latest-version>
 $ cd terraform-aws-consul-ecs/examples/admin-partitions
 ```
 

--- a/examples/dev-server-ec2/README.md
+++ b/examples/dev-server-ec2/README.md
@@ -15,6 +15,7 @@ Clone this repository:
 
 ```console
 $ git clone https://github.com/hashicorp/terraform-aws-consul-ecs.git
+$ git checkout tags/<latest-version>
 $ cd terraform-aws-consul-ecs/examples/dev-server-ec2
 ```
 

--- a/examples/dev-server-fargate/README.md
+++ b/examples/dev-server-fargate/README.md
@@ -20,6 +20,7 @@ Clone this repository:
 
 ```console
 $ git clone https://github.com/hashicorp/terraform-aws-consul-ecs.git
+$ git checkout tags/<latest-version>
 $ cd terraform-aws-consul-ecs/examples/dev-server-fargate
 ```
 


### PR DESCRIPTION
When we do our next release we need to update these checkout commands so that
users will use a tagged version of our examples, not main.
