### PR TITLE
Use /health endpoint for fake-service

### DIFF
--- a/examples/dev-server-ec2/main.tf
+++ b/examples/dev-server-ec2/main.tf
@@ -179,7 +179,7 @@ resource "aws_lb_target_group" "example_client_app" {
   target_type          = "ip"
   deregistration_delay = 10
   health_check {
-    path                = "/"
+    path                = "/health"
     healthy_threshold   = 2
     unhealthy_threshold = 10
     timeout             = 30

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -193,7 +193,7 @@ resource "aws_lb_target_group" "example_client_app" {
   target_type          = "ip"
   deregistration_delay = 10
   health_check {
-    path                = "/"
+    path                = "/health"
     healthy_threshold   = 2
     unhealthy_threshold = 10
     timeout             = 30


### PR DESCRIPTION
This endpoint returns OK even if the upstream services are down.
This ensures the ALB won't cause the task to be stopped if its upstream
instances are having issues.

## How I've tested this PR:
- local testing

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::