### PR TITLE
Correct login type

### DIFF
--- a/modules/mesh-task/templates/consul_client_command.tpl
+++ b/modules/mesh-task/templates/consul_client_command.tpl
@@ -26,7 +26,8 @@ consul_login() {
     %{ if consul_partition != "" ~}
       -partition ${ consul_partition } \
     %{ endif ~}
-      -type aws -method ${ client_token_auth_method_name } \
+      -type aws-iam \
+      -method ${ client_token_auth_method_name } \
       -meta "consul.hashicorp.com/task-id=$TASK_ID" \
       -meta "consul.hashicorp.com/cluster=$CLUSTER_ARN" \
       -aws-region "$TASK_REGION" \


### PR DESCRIPTION
## Changes proposed in this PR:
This corrects the `-type aws` option to `-type aws-iam`. The `consul login` command actually [ignores](https://github.com/hashicorp/consul/blob/8712a088b18b798a53d3b9792291ef23cec4f750/command/login/login.go#L33) the `-type` flag, but we should correct this anyway on our side.

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::