### PR TITLE
Enforce lowercase service names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ BREAKING CHANGES
   [[GH-100](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/100)]
   [[GH-103](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/103)]
   [[GH-107](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/107)]
+* modules/mesh-task: A lower case service name is required. When the `consul_service_name` field is
+  specified, it must be a valid name for a Consul service identity. Otherwise, if `consul_service_name`
+  is not specified, the lower-cased task family is used for the Consul service name.
+  [[GH-109](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/109)]
 
 FEATURES
 * modules/dev-server: Immediately delete all Secrets Manager secrets rather

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -24,7 +24,9 @@ locals {
     "/consul/consul-ecs", "app-entrypoint", "-shutdown-delay", "${var.application_shutdown_delay_seconds}s",
   ] : null
   app_mountpoints = local.enable_app_entrypoint ? [local.consul_data_mount] : []
-  service_name    = var.consul_service_name != "" ? var.consul_service_name : var.family
+
+  // Lower case service name is required. var.consul_service_name is validated to be lower case, while the task family is forced to lower case
+  service_name = var.consul_service_name != "" ? var.consul_service_name : lower(var.family)
 
   // Optionally, users can provide a partition and namespace for the service.
   partition_tag = var.consul_partition != "" ? { "consul.hashicorp.com/partition" = var.consul_partition } : {}

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -1,5 +1,5 @@
 variable "family" {
-  description = "Task definition family (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#family). This is used by default as the Consul service name if `consul_service_name` is not provided."
+  description = "Task definition family (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#family). The lower-cased family name is used by default as the Consul service name if `consul_service_name` is not provided."
   type        = string
 }
 
@@ -7,6 +7,11 @@ variable "consul_service_name" {
   description = "The name the service will be registered as in Consul. Defaults to the Task family name."
   type        = string
   default     = ""
+
+  validation {
+    error_message = "The consul_service_name must be lower case. It must match the regex, '^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$'."
+    condition     = var.consul_service_name == "" || can(regex("^[a-z0-9]([a-z0-9_-]*[a-z0-9])?$", var.consul_service_name))
+  }
 }
 
 variable "consul_service_tags" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -162,7 +162,8 @@ resource "aws_ecs_service" "test_client" {
 
 module "test_client" {
   source = "../../../../../../modules/mesh-task"
-  family = "test_client_${var.suffix}"
+  // mesh-task will lower case this to `test_client_<suffix>` for the service name.
+  family = "Test_Client_${var.suffix}"
   container_definitions = [
     {
       name             = "basic"

--- a/test/acceptance/tests/basic/terraform/service-name-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/service-name-validate/main.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "consul_service_name" {
+  type = string
+}
+
+module "test_client" {
+  source = "../../../../../../modules/mesh-task"
+  family = "family"
+  container_definitions = [{
+    name = "basic"
+  }]
+  retry_join          = ["test"]
+  outbound_only       = true
+  consul_service_name = var.consul_service_name
+}


### PR DESCRIPTION
## Changes proposed in this PR:
Enforce lower case service names to match https://github.com/hashicorp/consul-ecs/pull/97

mesh-task does the following:

- `var.consul_service_name` is validated to be a [valid service identity](https://github.com/hashicorp/consul/blob/93b164aac37f83863707f05284b868dc8ea57719/acl/validation.go#L11)
- If the consul_server_name is not provided, fall back to the lowercase task family name

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::