### PR TITLE
Ensure lowercase service name in AP example

### DIFF
--- a/examples/admin-partitions/terraform/aws_ecs.tf
+++ b/examples/admin-partitions/terraform/aws_ecs.tf
@@ -3,8 +3,8 @@ provider "aws" {
 }
 
 locals {
-  rand_suffix = random_string.rand_suffix.result
-  ecs_name    = "consul-ecs-${random_string.rand_suffix.result}"
+  rand_suffix = lower(random_string.rand_suffix.result)
+  ecs_name    = "consul-ecs-${local.rand_suffix}"
   launch_type = "FARGATE"
 }
 

--- a/examples/admin-partitions/terraform/client.tf
+++ b/examples/admin-partitions/terraform/client.tf
@@ -1,5 +1,5 @@
 locals {
-  client_suffix = random_string.client_suffix.result
+  client_suffix = lower(random_string.client_suffix.result)
 }
 
 resource "random_string" "client_suffix" {

--- a/examples/admin-partitions/terraform/server.tf
+++ b/examples/admin-partitions/terraform/server.tf
@@ -1,5 +1,5 @@
 locals {
-  server_suffix = random_string.server_suffix.result
+  server_suffix = lower(random_string.server_suffix.result)
 }
 
 resource "random_string" "server_suffix" {


### PR DESCRIPTION
## Changes proposed in this PR:
This ensures the admin-partitions example uses lower case service names.

## How I've tested this PR:
Ran the example locally

## How I expect reviewers to test this PR:
👀 