### PR TITLE
Add load balancer to gateway-task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 FEATURES
+* modules/gateway-task: Add an optional configuration to have the `gateway-task` module
+  automatically create and configure a Network Load Balancer for public ingress. Update
+  the `gateway-task` module to create the ECS service definition.
+  [[GH-118]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/118)
 * modules/gateway-task, modules/mesh-task, modules/dev-server:
   Update `gateway-task`, `mesh-task` and `dev-server` to enable ACL token replication
   in Consul agents for WAN federation. Update `dev-server` to take a bootstrap token as

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -215,8 +215,43 @@ variable "enable_mesh_gateway_wan_federation" {
   default     = false
 }
 
-variable "retry_join_wan" {
-  description = "List of WAN addresses to join for Consul cluster federation. Must not be provided when using mesh-gateway for WAN federation."
+variable "subnets" {
+  description = "Subnets IDs where the gateway task should be deployed. If these are private subnets then there must be a NAT gateway for image pulls to work. If these are public subnets then you must also set assign_public_ip for image pulls to work."
+  type        = list(string)
+}
+
+variable "assign_public_ip" {
+  description = "Configure the ECS Service to assign a public IP to the task. This is required if running tasks on a public subnet."
+  type        = bool
+  default     = false
+}
+
+variable "lb_enabled" {
+  description = "Whether to create an Elastic Load Balancer for the task to allow public ingress to the gateway."
+  type        = bool
+  default     = false
+}
+
+variable "lb_vpc_id" {
+  description = "The VPC identifier for the load balancer. Required when lb_enabled is true."
+  type        = string
+  default     = ""
+}
+
+variable "lb_subnets" {
+  description = "Subnet IDs to attach to the load balancer. These must be public subnets if you wish to access the load balancer externally. Required when lb_enabled is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "security_groups" {
+  description = "Security group IDs that will be attached to the gateway. The default security group will be used if this is not specified. Required when lb_enabled is true so ingress rules can be added for the security groups."
+  type        = list(string)
+  default     = []
+}
+
+variable "lb_ingress_rule_cidr_blocks" {
+  description = "CIDR blocks that are allowed access to the load balancer."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Add an optional configuration to have the `gateway-task` module
  automatically create and configure a Network Load Balancer for public ingress.
- Update the `gateway-task` module to create the ECS service definition.

## How I've tested this PR:
- Units tests
- Tested against the mesh-gateway example.

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 