### PR TITLE
Add load balancer and ECS service to gateway-task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 FEATURES
+* modules/gateway-task: Add an optional configuration to have the `gateway-task` module
+  automatically create and configure a Network Load Balancer for public ingress. Update
+  the `gateway-task` module to create the ECS service definition.
+  [[GH-119]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/119)
 * modules/gateway-task, modules/mesh-task, modules/dev-server:
   Update `gateway-task`, `mesh-task` and `dev-server` to enable ACL token replication
   in Consul agents for WAN federation. Update `dev-server` to take a bootstrap token as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 FEATURES
+* modules/gateway-task: Add a `health-sync` container to `gateway-task` when ACLs are enabled
+  to perform a `consul logout` when the task stops.
+  [[GH-120]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/120)
 * modules/gateway-task: Add an optional configuration to have the `gateway-task` module
   automatically create and configure a Network Load Balancer for public ingress. Update
   the `gateway-task` module to create the ECS service definition.

--- a/examples/mesh-gateways/datacenters.tf
+++ b/examples/mesh-gateways/datacenters.tf
@@ -50,7 +50,7 @@ module "dc2" {
 
   // To enable WAN federation via mesh gateways all secondary datacenters must be
   // configured with the WAN address of the mesh gateway(s) in the primary datacenter.
-  primary_gateways = ["${module.dc1_gateway.lb_dns_name}:8443"]
+  primary_gateways = ["${module.dc1_gateway.wan_address}:${module.dc1_gateway.wan_port}"]
 
   // To enable ACL replication for secondary datacenters we need to provide a replication token.
   bootstrap_token_arn = aws_secretsmanager_secret.bootstrap_token.arn

--- a/examples/mesh-gateways/gateway/gateway.tf
+++ b/examples/mesh-gateways/gateway/gateway.tf
@@ -12,6 +12,9 @@ locals {
 module "mesh_gateway" {
   source                             = "../../../modules/gateway-task"
   family                             = var.name
+  ecs_cluster_arn                    = var.cluster
+  subnets                            = var.private_subnets
+  security_groups                    = [var.vpc.default_security_group_id]
   log_configuration                  = local.log_config
   retry_join                         = var.retry_join
   kind                               = "mesh-gateway"
@@ -21,8 +24,6 @@ module "mesh_gateway" {
   tls                                = true
   consul_server_ca_cert_arn          = var.ca_cert_arn
   gossip_key_secret_arn              = var.gossip_key_arn
-  wan_address                        = aws_lb.mesh_gateway.dns_name
-  wan_port                           = 8443
   additional_task_role_policies      = var.additional_task_role_policies
 
   acls                         = true
@@ -30,66 +31,9 @@ module "mesh_gateway" {
   consul_http_addr             = var.consul_http_addr
   consul_https_ca_cert_arn     = var.ca_cert_arn
 
+  lb_enabled = true
+  lb_subnets = var.public_subnets
+  lb_vpc_id  = var.vpc.vpc_id
+
   consul_ecs_image = var.consul_ecs_image
-}
-
-resource "aws_ecs_service" "mesh_gateway" {
-  name            = var.name
-  cluster         = var.cluster
-  task_definition = module.mesh_gateway.task_definition_arn
-  desired_count   = 1
-  network_configuration {
-    subnets = var.private_subnets
-  }
-  launch_type    = "FARGATE"
-  propagate_tags = "TASK_DEFINITION"
-  load_balancer {
-    target_group_arn = aws_lb_target_group.mesh_gateway.arn
-    container_name   = "sidecar-proxy"
-    container_port   = 8443
-  }
-  enable_execute_command = true
-}
-
-resource "aws_lb" "mesh_gateway" {
-  name               = var.name
-  internal           = false
-  load_balancer_type = "network"
-  subnets            = var.public_subnets
-}
-
-resource "aws_lb_target_group" "mesh_gateway" {
-  name                 = var.name
-  port                 = "8443"
-  protocol             = "TCP"
-  target_type          = "ip"
-  vpc_id               = var.vpc.vpc_id
-  deregistration_delay = 120
-  health_check {
-    protocol = "TCP"
-  }
-}
-
-resource "aws_lb_listener" "mesh_gateway" {
-  load_balancer_arn = aws_lb.mesh_gateway.arn
-  port              = "8443"
-  protocol          = "TCP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.mesh_gateway.arn
-  }
-}
-
-// In a production environment ingress to each mesh gateway should only be allowed
-// from the other mesh gateway. This rule allows ALL public internet traffic to reach the
-// mesh gateway through the NLB. This setup is not secure and is for example purposes only.
-resource "aws_security_group_rule" "ingress_from_internet" {
-  type              = "ingress"
-  description       = "TEST ONLY - public internet to NLB"
-  from_port         = 8443
-  to_port           = 8443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = var.vpc.default_security_group_id
 }

--- a/examples/mesh-gateways/gateway/outputs.tf
+++ b/examples/mesh-gateways/gateway/outputs.tf
@@ -1,3 +1,7 @@
-output "lb_dns_name" {
-  value = aws_lb.mesh_gateway.dns_name
+output "wan_address" {
+  value = module.mesh_gateway.wan_address
+}
+
+output "wan_port" {
+  value = module.mesh_gateway.wan_port
 }

--- a/examples/mesh-gateways/outputs.tf
+++ b/examples/mesh-gateways/outputs.tf
@@ -1,25 +1,16 @@
-output "dc1_server_url" {
-  value = "http://${module.dc1.dev_consul_server.lb_dns_name}:8500"
-}
-
-output "dc2_server_url" {
-  value = "http://${module.dc2.dev_consul_server.lb_dns_name}:8500"
+output "bootstrap_token" {
+  value     = module.dc1.dev_consul_server.bootstrap_token_id
+  sensitive = true
 }
 
 output "client_lb_address" {
   value = "http://${aws_lb.example_client_app.dns_name}:9090/ui"
 }
 
-output "private_subnets" {
-  value = module.dc1_vpc.private_subnets
+output "dc1_server_url" {
+  value = "http://${module.dc1.dev_consul_server.lb_dns_name}:8500"
 }
 
-output "dc1_server_bootstrap_token" {
-  value     = module.dc1.dev_consul_server.bootstrap_token_id
-  sensitive = true
-}
-
-output "dc2_server_bootstrap_token" {
-  value     = module.dc2.dev_consul_server.bootstrap_token_id
-  sensitive = true
+output "dc2_server_url" {
+  value = "http://${module.dc2.dev_consul_server.lb_dns_name}:8500"
 }

--- a/modules/gateway-task/config.tf
+++ b/modules/gateway-task/config.tf
@@ -28,11 +28,11 @@ locals {
       partition = var.consul_partition
       lanAddress = {
         address = var.lan_address
-        port    = var.lan_port
+        port    = local.lan_port
       }
       wanAddress = {
-        address = var.wan_address
-        port    = var.wan_port
+        address = local.wan_address
+        port    = local.wan_port
       }
     }
     healthSyncContainers = []

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -328,7 +328,7 @@ resource "aws_security_group_rule" "lb_egress_rule" {
 }
 
 resource "aws_security_group_rule" "lb_ingress_rule" {
-  count             = (var.lb_enabled && var.lb_create_security_group) || var.lb_modify_security_group ? 1 : 0
+  count             = var.lb_enabled && (var.lb_create_security_group || var.lb_modify_security_group) ? 1 : 0
   type              = "ingress"
   description       = "Ingress rule for ${local.service_name}"
   from_port         = local.wan_port

--- a/modules/gateway-task/outputs.tf
+++ b/modules/gateway-task/outputs.tf
@@ -29,3 +29,7 @@ output "wan_address" {
 output "wan_port" {
   value = local.wan_port
 }
+
+output "lb_security_group_id" {
+  value = var.lb_enabled && var.lb_create_security_group ? aws_security_group.this[0].id : null
+}

--- a/modules/gateway-task/outputs.tf
+++ b/modules/gateway-task/outputs.tf
@@ -22,3 +22,10 @@ output "task_tags" {
   value = aws_ecs_task_definition.this.tags_all
 }
 
+output "wan_address" {
+  value = local.wan_address
+}
+
+output "wan_port" {
+  value = local.wan_port
+}

--- a/modules/gateway-task/validation.tf
+++ b/modules/gateway-task/validation.tf
@@ -1,7 +1,7 @@
 locals {
   require_tls_for_wan_federation = var.enable_mesh_gateway_wan_federation && !var.tls ? file("ERROR: tls must be true when enable_mesh_gateway_wan_federation is true") : null
-  wan_address_xor_lb_enabled     = var.wan_address != "" && var.lb_enabled ? file("ERROR: Only one of wan_address or lb_enabled may be provided.") : null
-  require_security_groups_for_lb = var.lb_enabled && length(var.security_groups) < 1 ? file("ERROR: security_groups is required when lb_enabled is true.") : null
-  require_lb_subnets_for_lb      = var.lb_enabled && length(var.lb_subnets) < 1 ? file("ERROR: lb_subnets is required when lb_enabled is true.") : null
-  require_lb_vpc_for_lb          = var.lb_enabled && var.lb_vpc_id == "" ? file("ERROR: lb_vpc_id is required when lb_enabled is true.") : null
+  wan_address_xor_lb_enabled     = var.wan_address != "" && var.lb_enabled ? file("ERROR: Only one of wan_address or lb_enabled may be provided") : null
+  require_security_groups_for_lb = var.lb_enabled && length(var.security_groups) < 1 ? file("ERROR: security_groups is required when lb_enabled is true") : null
+  require_lb_subnets_for_lb      = var.lb_enabled && length(var.lb_subnets) < 1 ? file("ERROR: lb_subnets is required when lb_enabled is true") : null
+  require_lb_vpc_for_lb          = var.lb_enabled && var.lb_vpc_id == "" ? file("ERROR: lb_vpc_id is required when lb_enabled is true") : null
 }

--- a/modules/gateway-task/validation.tf
+++ b/modules/gateway-task/validation.tf
@@ -1,4 +1,7 @@
 locals {
-  retry_join_wan_xor_primary_gateways = length(var.retry_join_wan) > 0 && var.enable_mesh_gateway_wan_federation ? file("ERROR: Only one of retry_join_wan or enable_mesh_gateway_wan_federation may be provided.") : null
-  require_tls_for_wan_federation      = var.enable_mesh_gateway_wan_federation && !var.tls ? file("ERROR: tls must be true when enable_mesh_gateway_wan_federation is true") : null
+  require_tls_for_wan_federation = var.enable_mesh_gateway_wan_federation && !var.tls ? file("ERROR: tls must be true when enable_mesh_gateway_wan_federation is true") : null
+  wan_address_xor_lb_enabled     = var.wan_address != "" && var.lb_enabled ? file("ERROR: Only one of wan_address or lb_enabled may be provided.") : null
+  require_security_groups_for_lb = var.lb_enabled && length(var.security_groups) < 1 ? file("ERROR: security_groups is required when lb_enabled is true.") : null
+  require_lb_subnets_for_lb      = var.lb_enabled && length(var.lb_subnets) < 1 ? file("ERROR: lb_subnets is required when lb_enabled is true.") : null
+  require_lb_vpc_for_lb          = var.lb_enabled && var.lb_vpc_id == "" ? file("ERROR: lb_vpc_id is required when lb_enabled is true.") : null
 }

--- a/modules/gateway-task/validation.tf
+++ b/modules/gateway-task/validation.tf
@@ -1,7 +1,9 @@
 locals {
   require_tls_for_wan_federation = var.enable_mesh_gateway_wan_federation && !var.tls ? file("ERROR: tls must be true when enable_mesh_gateway_wan_federation is true") : null
   wan_address_xor_lb_enabled     = var.wan_address != "" && var.lb_enabled ? file("ERROR: Only one of wan_address or lb_enabled may be provided") : null
-  require_security_groups_for_lb = var.lb_enabled && length(var.security_groups) < 1 ? file("ERROR: security_groups is required when lb_enabled is true") : null
   require_lb_subnets_for_lb      = var.lb_enabled && length(var.lb_subnets) < 1 ? file("ERROR: lb_subnets is required when lb_enabled is true") : null
   require_lb_vpc_for_lb          = var.lb_enabled && var.lb_vpc_id == "" ? file("ERROR: lb_vpc_id is required when lb_enabled is true") : null
+
+  create_xor_modify_security_group = var.lb_create_security_group && var.lb_modify_security_group ? file("ERROR: Only one of lb_create_security_group or lb_modify_security_group may be true") : null
+  require_sg_id_for_modify         = var.lb_modify_security_group && var.lb_modify_security_group_id == "" ? file("ERROR: lb_modify_security_group_id is required when lb_modify_security_group is true") : null
 }

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -3,6 +3,11 @@ variable "family" {
   type        = string
 }
 
+variable "ecs_cluster_arn" {
+  description = "The ARN of the ECS cluster where the gateway will be running."
+  type        = string
+}
+
 variable "consul_service_name" {
   description = "The name the gateway service will be registered as in Consul. Defaults to the Task family name. Always suffixed with the gateway kind."
   type        = string
@@ -31,6 +36,12 @@ variable "requires_compatibilities" {
   description = "Set of launch types required by the task."
   type        = list(string)
   default     = ["EC2", "FARGATE"]
+}
+
+variable "launch_type" {
+  description = "Launch type on which to run service. Valid values are EC2 and FARGATE."
+  type        = string
+  default     = "FARGATE"
 }
 
 variable "cpu" {
@@ -204,7 +215,7 @@ variable "wan_address" {
 }
 
 variable "wan_port" {
-  description = "WAN port for the gateway. Defaults to 8443 if not specified."
+  description = "WAN port for the gateway. Defaults to the lan_port if not specified."
   type        = number
   default     = 0
 }
@@ -215,8 +226,43 @@ variable "enable_mesh_gateway_wan_federation" {
   default     = false
 }
 
-variable "retry_join_wan" {
-  description = "List of WAN addresses to join for Consul cluster federation. Must not be provided when using mesh-gateway for WAN federation."
+variable "security_groups" {
+  description = "Security group IDs that will be attached to the gateway. The default security group will be used if this is not specified. Required when lb_enabled is true so ingress rules can be added for the security groups."
   type        = list(string)
   default     = []
+}
+
+variable "subnets" {
+  description = "Subnets IDs where the gateway task should be deployed. If these are private subnets then there must be a NAT gateway for image pulls to work. If these are public subnets then you must also set assign_public_ip for image pulls to work."
+  type        = list(string)
+}
+
+variable "assign_public_ip" {
+  description = "Configure the ECS Service to assign a public IP to the task. This is required if running tasks on a public subnet."
+  type        = bool
+  default     = false
+}
+
+variable "lb_enabled" {
+  description = "Whether to create an Elastic Load Balancer for the task to allow public ingress to the gateway."
+  type        = bool
+  default     = false
+}
+
+variable "lb_vpc_id" {
+  description = "The VPC identifier for the load balancer. Required when lb_enabled is true."
+  type        = string
+  default     = ""
+}
+
+variable "lb_subnets" {
+  description = "Subnet IDs to attach to the load balancer. These must be public subnets if you wish to access the load balancer externally. Required when lb_enabled is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "lb_ingress_rule_cidr_blocks" {
+  description = "CIDR blocks that are allowed access to the load balancer."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -266,3 +266,21 @@ variable "lb_ingress_rule_cidr_blocks" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
+
+variable "lb_create_security_group" {
+  description = "Whether to create a security group and ingress rule for the gateway task."
+  type        = bool
+  default     = true
+}
+
+variable "lb_modify_security_group" {
+  description = "Whether to modify an existing security group with an ingress rule for the gateway task. The lb_create_security_group variable must be set to false when using this option."
+  type        = bool
+  default     = false
+}
+
+variable "lb_modify_security_group_id" {
+  description = "The ID of the security group to modify with an ingress rule for the gateway task. Required when lb_modify_security_group is true."
+  type        = string
+  default     = ""
+}

--- a/test/acceptance/tests/basic/terraform/mesh-gateway-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/mesh-gateway-validate/main.tf
@@ -42,6 +42,22 @@ variable "wan_address" {
   default = ""
 }
 
+variable "lb_create_security_group" {
+  type    = bool
+  default = true
+}
+
+variable "lb_modify_security_group" {
+  type    = bool
+  default = false
+}
+
+variable "lb_modify_security_group_id" {
+  type    = string
+  default = ""
+}
+
+
 module "test_gateway" {
   source                             = "../../../../../../modules/gateway-task"
   family                             = "family"
@@ -56,4 +72,7 @@ module "test_gateway" {
   lb_enabled                         = var.lb_enabled
   lb_vpc_id                          = var.lb_vpc_id
   lb_subnets                         = var.lb_subnets
+  lb_create_security_group           = var.lb_create_security_group
+  lb_modify_security_group           = var.lb_modify_security_group
+  lb_modify_security_group_id        = var.lb_modify_security_group_id
 }

--- a/test/acceptance/tests/basic/terraform/mesh-gateway-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/mesh-gateway-validate/main.tf
@@ -6,10 +6,6 @@ variable "kind" {
   type = string
 }
 
-variable "retry_join_wan" {
-  type = list(string)
-}
-
 variable "enable_mesh_gateway_wan_federation" {
   type = bool
 }
@@ -18,12 +14,46 @@ variable "tls" {
   type = bool
 }
 
+variable "security_groups" {
+  type    = list(string)
+  default = []
+}
+
+variable "lb_enabled" {
+  description = "Whether to create an Elastic Load Balancer for the task to allow public ingress to the gateway."
+  type        = bool
+  default     = false
+}
+
+variable "lb_vpc_id" {
+  description = "The VPC identifier for the load balancer. Required when lb_enabled is true."
+  type        = string
+  default     = ""
+}
+
+variable "lb_subnets" {
+  description = "Subnet IDs to attach to the load balancer. These must be public subnets if you wish to access the load balancer externally. Required when lb_enabled is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "wan_address" {
+  type    = string
+  default = ""
+}
+
 module "test_gateway" {
   source                             = "../../../../../../modules/gateway-task"
   family                             = "family"
+  ecs_cluster_arn                    = "cluster"
+  subnets                            = ["subnets"]
+  security_groups                    = var.security_groups
   kind                               = var.kind
   retry_join                         = ["localhost:8500"]
-  retry_join_wan                     = var.retry_join_wan
   enable_mesh_gateway_wan_federation = var.enable_mesh_gateway_wan_federation
   tls                                = var.tls
+  wan_address                        = var.wan_address
+  lb_enabled                         = var.lb_enabled
+  lb_vpc_id                          = var.lb_vpc_id
+  lb_subnets                         = var.lb_subnets
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Add an optional configuration to have the `gateway-task` module automatically create and configure a Network Load Balancer for public ingress.
- Update the `gateway-task` module to create the ECS service definition.

## How I've tested this PR:
- Unit tests
- Tested against the mesh-gateway example

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 
