### PR TITLE
Add health-sync to gateway-tasks when ACLs are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## Unreleased
 
 FEATURES
+* modules/gateway-task: Add `health-sync` to `gateway-task` when ACLs are enabled.
+  When ACLs are enabled the gateway task does a `consul login` to get a token using the
+  IAM Auth Method. The ACL controller will delete the tokens during its reconciliation
+  cycle but the gateway task should do a `consul logout` when it stops to destroy
+  its tokens. The `health-sync` container automatically attempts a `consul logout`
+  when the task stops.
+  [[GH-120]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/120)
 * modules/gateway-task: Add an optional configuration to have the `gateway-task` module
   automatically create and configure a Network Load Balancer for public ingress. Update
   the `gateway-task` module to create the ECS service definition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 ## Unreleased
 
 FEATURES
-* modules/gateway-task: Add `health-sync` to `gateway-task` when ACLs are enabled.
-  When ACLs are enabled the gateway task does a `consul login` to get a token using the
-  IAM Auth Method. The ACL controller will delete the tokens during its reconciliation
-  cycle but the gateway task should do a `consul logout` when it stops to destroy
-  its tokens. The `health-sync` container automatically attempts a `consul logout`
-  when the task stops.
+* modules/gateway-task: Add a `health-sync` container to `gateway-task` when ACLs are enabled
+  to perform a `consul logout` when the task stops.
   [[GH-120]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/120)
 * modules/gateway-task: Add an optional configuration to have the `gateway-task` module
   automatically create and configure a Network Load Balancer for public ingress. Update


### PR DESCRIPTION
## Changes proposed in this PR:
When ACLs are enabled gateway tasks do a `consul login` to get a token using the IAM Auth Method. The ACL controller will delete the tokens during its reconciliation cycle but we want task to do a `consul logout` when it stops to destroy the tokens. This PR adds a `health-sync` container to the gateway-task so that the task automatically attempts a `consul logout` when the task stops.

## How I've tested this PR:
- Ran the updated gateway-task and confirmed that health-sync performs the `consul logout`:

```log
2022-06-15T18:50:34.380Z [INFO]  signal received, ignoring: signal=terminated
2022-06-15T18:50:34.380Z [INFO]  log out token: file=/consul/service-token
2022-06-15T18:50:34.387Z [INFO]  log out token: file=/consul/client-token
```

## How I expect reviewers to test this PR:
:eyes: (Suggest ignoring whitespace to skip the indenting changes)

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added