### PR TITLE
Skip HCP tests on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,6 @@ jobs:
           name: terraform destroy
           working_directory: test/acceptance/setup-terraform
           command: |
-            set -x
-
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
             VARS+=' -var launch_type=<<parameters.launch_type>>'
             case $CIRCLE_BRANCH in

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,12 +92,10 @@ jobs:
           name: terraform init & apply
           working_directory: test/acceptance/setup-terraform
           command: |
-            set -x
-
             terraform init
 
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
-            VARS+=' -var launch_type=FARGATE'
+            VARS+=' -var launch_type=<<parameters.launch_type>>'
             case $CIRCLE_BRANCH in
                 main | release/*) VARS+=" -var enable_hcp=true";;
                 *) VARS+=" -var enable_hcp=false";;
@@ -131,7 +129,7 @@ jobs:
             set -x
 
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
-            VARS+=' -var launch_type=FARGATE'
+            VARS+=' -var launch_type=<<parameters.launch_type>>'
             case $CIRCLE_BRANCH in
                 main | release/*) VARS+=" -var enable_hcp=true";;
                 *) VARS+=" -var enable_hcp=false";;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,18 @@ jobs:
           name: terraform init & apply
           working_directory: test/acceptance/setup-terraform
           command: |
+            set -x
+
             terraform init
 
-            terraform apply -var tags="{\"build_url\": \"$CIRCLE_BUILD_URL\"}" -auto-approve -var launch_type=<<parameters.launch_type>>
+            VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
+            VARS+=' -var launch_type=FARGATE'
+            case $CIRCLE_BRANCH in
+                main | release/*) VARS+=" -var enable_hcp=true";;
+                *) VARS+=" -var enable_hcp=false";;
+            esac
+
+            terraform apply -auto-approve $VARS
 
       # Restore go module cache if there is one
       - restore_cache:
@@ -119,7 +128,16 @@ jobs:
           name: terraform destroy
           working_directory: test/acceptance/setup-terraform
           command: |
-            terraform destroy -auto-approve -var launch_type=<<parameters.launch_type>>
+            set -x
+
+            VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
+            VARS+=' -var launch_type=FARGATE'
+            case $CIRCLE_BRANCH in
+                main | release/*) VARS+=" -var enable_hcp=true";;
+                *) VARS+=" -var enable_hcp=false";;
+            esac
+
+            terraform destroy -auto-approve $VARS
           when: always
 
 workflows:

--- a/test/acceptance/setup-terraform/hcp/main.tf
+++ b/test/acceptance/setup-terraform/hcp/main.tf
@@ -1,0 +1,76 @@
+resource "hcp_hvn" "server" {
+  hvn_id         = "hvn-${var.suffix}"
+  cloud_provider = "aws"
+  region         = var.region
+  cidr_block     = "172.25.16.0/20"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "selected" {
+  id = var.vpc.vpc_id
+}
+
+resource "hcp_aws_network_peering" "this" {
+  peering_id      = "${hcp_hvn.server.hvn_id}-peering"
+  hvn_id          = hcp_hvn.server.hvn_id
+  peer_vpc_id     = var.vpc.vpc_id
+  peer_account_id = data.aws_caller_identity.current.account_id
+  peer_vpc_region = var.region
+}
+
+resource "aws_vpc_peering_connection_accepter" "peer" {
+  vpc_peering_connection_id = hcp_aws_network_peering.this.provider_peering_id
+  auto_accept               = true
+}
+
+resource "hcp_hvn_route" "peering_route" {
+  depends_on       = [aws_vpc_peering_connection_accepter.peer]
+  hvn_link         = hcp_hvn.server.self_link
+  hvn_route_id     = "${hcp_hvn.server.hvn_id}-peering-route"
+  destination_cidr = data.aws_vpc.selected.cidr_block
+  target_link      = hcp_aws_network_peering.this.self_link
+}
+
+resource "aws_route" "peering" {
+  count                     = length([var.vpc.public_route_table_ids[0], var.vpc.private_route_table_ids[0]])
+  route_table_id            = [var.vpc.public_route_table_ids[0], var.vpc.private_route_table_ids[0]][count.index]
+  destination_cidr_block    = hcp_hvn.server.cidr_block
+  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.vpc_peering_connection_id
+}
+
+resource "hcp_consul_cluster" "this" {
+  cluster_id         = "server-${var.suffix}"
+  datacenter         = "dc1"
+  hvn_id             = hcp_hvn.server.hvn_id
+  tier               = "development"
+  public_endpoint    = true
+  min_consul_version = "1.12.0"
+}
+
+resource "aws_secretsmanager_secret" "bootstrap_token" {
+  name = "${var.suffix}-bootstrap-token"
+}
+
+resource "aws_secretsmanager_secret_version" "bootstrap_token" {
+  secret_id     = aws_secretsmanager_secret.bootstrap_token.id
+  secret_string = hcp_consul_cluster.this.consul_root_token_secret_id
+}
+
+resource "aws_secretsmanager_secret" "gossip_key" {
+  name = "${var.suffix}-gossip-key"
+}
+
+resource "aws_secretsmanager_secret_version" "gossip_key" {
+  secret_id     = aws_secretsmanager_secret.gossip_key.id
+  secret_string = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["encrypt"]
+}
+
+resource "aws_secretsmanager_secret" "consul_ca_cert" {
+  name = "${var.suffix}-consul-ca-cert"
+}
+
+resource "aws_secretsmanager_secret_version" "consul_ca_cert" {
+  secret_id     = aws_secretsmanager_secret.consul_ca_cert.id
+  secret_string = base64decode(hcp_consul_cluster.this.consul_ca_file)
+}

--- a/test/acceptance/setup-terraform/hcp/outputs.tf
+++ b/test/acceptance/setup-terraform/hcp/outputs.tf
@@ -1,0 +1,28 @@
+output "consul_public_endpoint_url" {
+  value = hcp_consul_cluster.this.consul_public_endpoint_url
+}
+
+output "consul_private_endpoint_url" {
+  value = hcp_consul_cluster.this.consul_private_endpoint_url
+}
+
+output "token" {
+  value     = hcp_consul_cluster.this.consul_root_token_secret_id
+  sensitive = true
+}
+
+output "retry_join" {
+  value = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["retry_join"]
+}
+
+output "bootstrap_token_secret_arn" {
+  value = aws_secretsmanager_secret.bootstrap_token.arn
+}
+
+output "gossip_key_secret_arn" {
+  value = aws_secretsmanager_secret.gossip_key.arn
+}
+
+output "consul_ca_cert_secret_arn" {
+  value = aws_secretsmanager_secret.consul_ca_cert.arn
+}

--- a/test/acceptance/setup-terraform/hcp/variables.tf
+++ b/test/acceptance/setup-terraform/hcp/variables.tf
@@ -1,0 +1,15 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "suffix" {
+  description = "Suffix to append to resource names."
+  type        = string
+}
+
+variable "vpc" {
+  description = "VPC object from terraform-aws-modules/vpc/aws module."
+  type        = any
+}
+

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -86,79 +86,11 @@ resource "aws_cloudwatch_log_group" "log_group" {
   tags = var.tags
 }
 
-resource "hcp_hvn" "server" {
-  hvn_id         = "hvn-${local.suffix}"
-  cloud_provider = "aws"
-  region         = var.region
-  cidr_block     = "172.25.16.0/20"
-}
+module "hcp" {
+  count  = var.enable_hcp ? 1 : 0
+  source = "./hcp"
 
-data "aws_caller_identity" "current" {}
-
-data "aws_vpc" "selected" {
-  id = module.vpc.vpc_id
-}
-
-resource "hcp_aws_network_peering" "this" {
-  peering_id      = "${hcp_hvn.server.hvn_id}-peering"
-  hvn_id          = hcp_hvn.server.hvn_id
-  peer_vpc_id     = module.vpc.vpc_id
-  peer_account_id = data.aws_caller_identity.current.account_id
-  peer_vpc_region = var.region
-}
-
-resource "aws_vpc_peering_connection_accepter" "peer" {
-  vpc_peering_connection_id = hcp_aws_network_peering.this.provider_peering_id
-  auto_accept               = true
-}
-
-resource "hcp_hvn_route" "peering_route" {
-  depends_on       = [aws_vpc_peering_connection_accepter.peer]
-  hvn_link         = hcp_hvn.server.self_link
-  hvn_route_id     = "${hcp_hvn.server.hvn_id}-peering-route"
-  destination_cidr = data.aws_vpc.selected.cidr_block
-  target_link      = hcp_aws_network_peering.this.self_link
-}
-
-resource "aws_route" "peering" {
-  count                     = length([module.vpc.public_route_table_ids[0], module.vpc.private_route_table_ids[0]])
-  route_table_id            = [module.vpc.public_route_table_ids[0], module.vpc.private_route_table_ids[0]][count.index]
-  destination_cidr_block    = hcp_hvn.server.cidr_block
-  vpc_peering_connection_id = aws_vpc_peering_connection_accepter.peer.vpc_peering_connection_id
-}
-
-resource "hcp_consul_cluster" "this" {
-  cluster_id         = "server-${local.suffix}"
-  datacenter         = "dc1"
-  hvn_id             = hcp_hvn.server.hvn_id
-  tier               = "development"
-  public_endpoint    = true
-  min_consul_version = "1.12.0"
-}
-
-resource "aws_secretsmanager_secret" "bootstrap_token" {
-  name = "${local.suffix}-bootstrap-token"
-}
-
-resource "aws_secretsmanager_secret_version" "bootstrap_token" {
-  secret_id     = aws_secretsmanager_secret.bootstrap_token.id
-  secret_string = hcp_consul_cluster.this.consul_root_token_secret_id
-}
-
-resource "aws_secretsmanager_secret" "gossip_key" {
-  name = "${local.suffix}-gossip-key"
-}
-
-resource "aws_secretsmanager_secret_version" "gossip_key" {
-  secret_id     = aws_secretsmanager_secret.gossip_key.id
-  secret_string = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["encrypt"]
-}
-
-resource "aws_secretsmanager_secret" "consul_ca_cert" {
-  name = "${local.suffix}-consul-ca-cert"
-}
-
-resource "aws_secretsmanager_secret_version" "consul_ca_cert" {
-  secret_id     = aws_secretsmanager_secret.consul_ca_cert.id
-  secret_string = base64decode(hcp_consul_cluster.this.consul_ca_file)
+  region = var.region
+  suffix = local.suffix
+  vpc    = module.vpc
 }

--- a/test/acceptance/setup-terraform/outputs.tf
+++ b/test/acceptance/setup-terraform/outputs.tf
@@ -42,31 +42,35 @@ output "route_table_ids" {
   value = [module.vpc.public_route_table_ids[0], module.vpc.private_route_table_ids[0]]
 }
 
+output "enable_hcp" {
+  value = var.enable_hcp
+}
+
 output "consul_public_endpoint_url" {
-  value = hcp_consul_cluster.this.consul_public_endpoint_url
+  value = var.enable_hcp ? module.hcp[0].consul_public_endpoint_url : ""
 }
 
 output "consul_private_endpoint_url" {
-  value = hcp_consul_cluster.this.consul_private_endpoint_url
+  value = var.enable_hcp ? module.hcp[0].consul_private_endpoint_url : ""
 }
 
 output "token" {
-  value     = hcp_consul_cluster.this.consul_root_token_secret_id
+  value     = var.enable_hcp ? module.hcp[0].token : ""
   sensitive = true
 }
 
 output "retry_join" {
-  value = jsondecode(base64decode(hcp_consul_cluster.this.consul_config_file))["retry_join"]
+  value = var.enable_hcp ? module.hcp[0].retry_join : []
 }
 
 output "bootstrap_token_secret_arn" {
-  value = aws_secretsmanager_secret.bootstrap_token.arn
+  value = var.enable_hcp ? module.hcp[0].bootstrap_token_secret_arn : ""
 }
 
 output "gossip_key_secret_arn" {
-  value = aws_secretsmanager_secret.gossip_key.arn
+  value = var.enable_hcp ? module.hcp[0].gossip_key_secret_arn : ""
 }
 
 output "consul_ca_cert_secret_arn" {
-  value = aws_secretsmanager_secret.consul_ca_cert.arn
+  value = var.enable_hcp ? module.hcp[0].consul_ca_cert_secret_arn : ""
 }

--- a/test/acceptance/setup-terraform/variables.tf
+++ b/test/acceptance/setup-terraform/variables.tf
@@ -19,6 +19,11 @@ variable "launch_type" {
   description = "The ECS launch type for the cluster. Either EC2 or FARGATE."
 }
 
+variable "enable_hcp" {
+  description = "Whether to spin up an HCP Consul cluster."
+  type        = bool
+}
+
 variable "instance_count" {
   description = "Number of EC2 instances to create for the EC2 launch type (if enabled)."
   type        = number


### PR DESCRIPTION
## Changes proposed in this PR:
This updates CI and acceptance tests to skip the HCP tests on PRs.

The way this works is:
* Pass either `-var enable_hcp=true|false` to setup-terraform to control whether an HCP Consul cluster is created.
* HCP tests look for the `enable_hcp` output variable in setup-terraform, and skip themselves if there is no HCP cluster.
* In CI, we set `enable_hcp=true` for `main` and `release/*` branches. Otherwise, it is set to false.

For the moment, no enterprise tests will run on PRs, which I'll address in a follow up using the dev-server.

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [ ] ~CHANGELOG entry added~

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::