### PR TITLE
Parallelize TestBasic

### DIFF
--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -3,7 +3,8 @@ package config
 // TestConfig holds configuration for the test suite.
 type TestConfig struct {
 	NoCleanupOnFailure bool
-	ECSClusterARN      string      `json:"ecs_cluster_arn"`
+	ECSClusterARN      string      `json:"ecs_cluster_1_arn"`
+	ECSCluster2ARN     string      `json:"ecs_cluster_2_arn"`
 	LaunchType         string      `json:"launch_type"`
 	Subnets            interface{} `json:"subnets"`
 	Suffix             string

--- a/test/acceptance/framework/helpers/cloudwatch.go
+++ b/test/acceptance/framework/helpers/cloudwatch.go
@@ -11,11 +11,11 @@ import (
 )
 
 // GetCloudWatchLogEvents fetches all log events for the given container.
-func GetCloudWatchLogEvents(t terratestTesting.TestingT, testConfig *config.TestConfig, taskId, containerName string) (LogMessages, error) {
+func GetCloudWatchLogEvents(t terratestTesting.TestingT, testConfig *config.TestConfig, clusterARN, taskId, containerName string) (LogMessages, error) {
 	args := []string{
 		"ecs-cli", "logs",
 		"--region", testConfig.Region,
-		"--cluster", testConfig.ECSClusterARN,
+		"--cluster", clusterARN,
 		"--task-id", taskId,
 		"--container-name", containerName,
 		"--timestamps",

--- a/test/acceptance/framework/helpers/helpers.go
+++ b/test/acceptance/framework/helpers/helpers.go
@@ -12,7 +12,7 @@ import (
 
 // ExecuteRemoteCommand executes a command inside a container in the task specified
 // by taskARN.
-func ExecuteRemoteCommand(t *testing.T, testConfig *config.TestConfig, taskARN, container, command string) (string, error) {
+func ExecuteRemoteCommand(t *testing.T, testConfig *config.TestConfig, clusterARN, taskARN, container, command string) (string, error) {
 	return shell.RunCommandAndGetOutputE(t, shell.Command{
 		Command: "aws",
 		Args: []string{
@@ -21,7 +21,7 @@ func ExecuteRemoteCommand(t *testing.T, testConfig *config.TestConfig, taskARN, 
 			"--region",
 			testConfig.Region,
 			"--cluster",
-			testConfig.ECSClusterARN,
+			clusterARN,
 			"--task",
 			taskARN,
 			fmt.Sprintf("--container=%s", container),

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -207,6 +207,8 @@ func TestValidation_AdditionalPolicies(t *testing.T) {
 	for name, c := range cases {
 		c := c
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := terraform.PlanE(t, &terraform.Options{
 				TerraformDir: terraformOptions.TerraformDir,
 				NoColor:      true,
@@ -412,7 +414,11 @@ func TestValidation_ConsulServiceName(t *testing.T) {
 	terraform.Init(t, terraformOptions)
 
 	for name, c := range cases {
+		c := c
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			out, err := terraform.PlanE(t, &terraform.Options{
 				TerraformDir: terraformOptions.TerraformDir,
 				NoColor:      true,
@@ -468,7 +474,11 @@ func TestValidation_ConsulEcsConfigVariable(t *testing.T) {
 	terraform.Init(t, terraformOptions)
 
 	for name, c := range cases {
+		c := c
+
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
 			out, err := terraform.PlanE(t, &terraform.Options{
 				TerraformDir: terraformOptions.TerraformDir,
 				NoColor:      true,
@@ -492,6 +502,8 @@ func TestValidation_ConsulEcsConfigVariable(t *testing.T) {
 
 // Test the validation that both partition and namespace must be provided or neither.
 func TestValidation_NamespaceAndPartitionRequired(t *testing.T) {
+	t.Parallel()
+
 	cases := map[string]struct {
 		partition string
 		namespace string
@@ -737,6 +749,8 @@ func TestValidation_MeshGateway(t *testing.T) {
 }
 
 func TestBasic(t *testing.T) {
+	t.Parallel()
+
 	cfg := suite.Config()
 
 	cases := []struct {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -57,6 +57,11 @@ variable "server_service_name" {
   type        = string
 }
 
+variable "consul_datacenter" {
+  description = "The consul datacenter name. Should be unique among parallel test cases to ensure a unique Cloud Map namespace."
+  type        = string
+}
+
 provider "aws" {
   region = var.region
 }
@@ -103,6 +108,9 @@ module "consul_server" {
   generate_gossip_encryption_key = false
   gossip_key_secret_arn          = var.secure ? aws_secretsmanager_secret.gossip_key[0].arn : ""
   acls                           = var.secure
+
+  service_discovery_namespace = var.consul_datacenter
+  datacenter                  = var.consul_datacenter
 }
 
 data "aws_security_group" "vpc_default" {
@@ -240,6 +248,8 @@ EOT
   consul_agent_configuration = <<-EOT
   log_level = "debug"
   EOT
+
+  consul_datacenter = var.consul_datacenter
 }
 
 resource "aws_ecs_service" "test_server" {
@@ -296,6 +306,7 @@ module "test_server" {
   task_role             = aws_iam_role.task
   execution_role        = aws_iam_role.execution
 
+  consul_datacenter = var.consul_datacenter
 }
 
 // Configure a task role for passing in to mesh-task.


### PR DESCRIPTION
## Changes proposed in this PR:
This updates TestBasic to run the `secure:true` and `secure:false` cases in parallel.

Right now, this only saves about 5 mins (~15 mins vs 20mins). More importantly, it enables us to add additional tests for enterprise dev-server without extending the test runtime (hopefully).

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::