### PR TITLE
Add initial enterprise dev-server test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
             VARS+=' -var launch_type=<<parameters.launch_type>>'
             case $CIRCLE_BRANCH in
-                main | release/*) VARS+=" -var enable_hcp=true";;
+                main | release/* | pglass/*) VARS+=" -var enable_hcp=true";;
                 *) VARS+=" -var enable_hcp=false";;
             esac
 
@@ -129,7 +129,7 @@ jobs:
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
             VARS+=' -var launch_type=<<parameters.launch_type>>'
             case $CIRCLE_BRANCH in
-                main | release/*) VARS+=" -var enable_hcp=true";;
+                main | release/* | pglass/*) VARS+=" -var enable_hcp=true";;
                 *) VARS+=" -var enable_hcp=false";;
             esac
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
             VARS+=' -var launch_type=<<parameters.launch_type>>'
             case $CIRCLE_BRANCH in
-                main | release/* | pglass/*) VARS+=" -var enable_hcp=true";;
+                main | release/*) VARS+=" -var enable_hcp=true";;
                 *) VARS+=" -var enable_hcp=false";;
             esac
 
@@ -129,7 +129,7 @@ jobs:
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
             VARS+=' -var launch_type=<<parameters.launch_type>>'
             case $CIRCLE_BRANCH in
-                main | release/* | pglass/*) VARS+=" -var enable_hcp=true";;
+                main | release/*) VARS+=" -var enable_hcp=true";;
                 *) VARS+=" -var enable_hcp=false";;
             esac
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,15 @@ executors:
       - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.2
     environment:
       TEST_RESULTS: &TEST_RESULTS /tmp/test-results # path to where test results are saved
+    # medium (2cpu / 4gb) with parallel invocations of Terraform sometimes ran out of memory.
+    # Bumped to medium+ (3cpu / 6gb) to help with this.
+    # https://circleci.com/docs/configuration-reference#resourceclass
+    resource_class: medium+
 
 jobs:
   go-fmt-and-lint-acceptance:
     executor: consul-ecs-test
+    resource_class: medium
     steps:
       - checkout
 
@@ -63,6 +68,7 @@ jobs:
 
   terraform-fmt:
     executor: consul-ecs-test
+    resource_class: medium
     steps:
       - checkout
       - run: terraform fmt -check -recursive .

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -61,7 +61,7 @@ in the test directory containing the terraform state file (`*.tfstate`), althoug
 this takes some extra effort.
 
 TestBasic uses multiple state files to isolate resources for parallel test
-runs. You must pass the the `-state` argument with the correct state file. To
+runs. You must pass the `-state` argument with the correct state file. To
 cleanup resources for all cases of TestBasic, you must run `terraform destroy
 -state terraform-<index>.tfstate` for each state file.
 
@@ -84,8 +84,8 @@ Additionally, you must pass in the correct variables when running `terraform des
 
 * Edit `setup-outputs.hcl` as-needed for this particular module, until `terraform destory` works.
   All the resources are in the state file, so in most cases the values of the variables won't matter
-  since Terraform still knows what to destroy. For example, the follow changes might work for TestBasic,
-  but this will be different to the HCP tests.
+  since Terraform still knows what to destroy. For example, the following changes might work for TestBasic,
+  but this will be different for the HCP tests.
 
     ```
     terraform destroy -var-file setup-outputs.hcl -state terraform-2.tfstate

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -3,8 +3,7 @@ package config
 // TestConfig holds configuration for the test suite.
 type TestConfig struct {
 	NoCleanupOnFailure bool
-	ECSClusterARN      string      `json:"ecs_cluster_1_arn"`
-	ECSCluster2ARN     string      `json:"ecs_cluster_2_arn"`
+	ECSClusterARNs     []string    `json:"ecs_cluster_arns"`
 	LaunchType         string      `json:"launch_type"`
 	Subnets            interface{} `json:"subnets"`
 	Suffix             string
@@ -19,13 +18,13 @@ type TestConfig struct {
 
 func (t TestConfig) TFVars(ignoreVars ...string) map[string]interface{} {
 	vars := map[string]interface{}{
-		"ecs_cluster_arn": t.ECSClusterARN,
-		"launch_type":     t.LaunchType,
-		"subnets":         t.Subnets,
-		"region":          t.Region,
-		"log_group_name":  t.LogGroupName,
-		"vpc_id":          t.VpcID,
-		"route_table_ids": t.RouteTableIDs,
+		"ecs_cluster_arns": t.ECSClusterARNs,
+		"launch_type":      t.LaunchType,
+		"subnets":          t.Subnets,
+		"region":           t.Region,
+		"log_group_name":   t.LogGroupName,
+		"vpc_id":           t.VpcID,
+		"route_table_ids":  t.RouteTableIDs,
 	}
 
 	// If the flag is an empty string or object then terratest

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	flagNoCleanupOnFailure = "no-cleanup-on-failure"
-	flagECSClusterARN      = "ecs-cluster-arn"
+	flagECSClusterARNs     = "ecs-cluster-arns"
 	flagLaunchType         = "launch-type"
 	flagSubnets            = "subnets"
 	flagRegion             = "region"
@@ -27,7 +27,7 @@ const (
 
 type TestFlags struct {
 	flagNoCleanupOnFailure bool
-	flagECSClusterARN      string
+	flagECSClusterARNs     string
 	flagLaunchType         string
 	flagSubnets            string
 	flagRegion             string
@@ -49,7 +49,7 @@ func (t *TestFlags) init() {
 	flag.BoolVar(&t.flagNoCleanupOnFailure, flagNoCleanupOnFailure, false,
 		"If true, the tests will not clean up resources they create when they finish running."+
 			"Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.")
-	flag.StringVar(&t.flagECSClusterARN, flagECSClusterARN, "", "ECS Cluster ARN.")
+	flag.StringVar(&t.flagECSClusterARNs, flagECSClusterARNs, "", "ECS Cluster ARNs. In TF Var form, e.g. '[<arn>, <arn>]'")
 	flag.StringVar(&t.flagLaunchType, flagLaunchType, "", "The ECS launch type to test: 'FARGATE' or 'EC2'.")
 	flag.StringVar(&t.flagSubnets, flagSubnets, "", "Subnets to deploy into. In TF var form, e.g. '[\"sub1\",\"sub2\"]'.")
 	flag.StringVar(&t.flagRegion, flagRegion, "", "Region.")
@@ -108,9 +108,15 @@ func (t *TestFlags) TestConfigFromFlags() (*config.TestConfig, error) {
 			return nil, err
 		}
 	} else {
+		var arns []string
+		err := json.Unmarshal([]byte(t.flagECSClusterARNs), &arns)
+		if err != nil {
+			return nil, err
+		}
+
 		cfg = config.TestConfig{
 			NoCleanupOnFailure: t.flagNoCleanupOnFailure,
-			ECSClusterARN:      t.flagECSClusterARN,
+			ECSClusterARNs:     arns,
 			LaunchType:         t.flagLaunchType,
 			Subnets:            t.flagSubnets,
 			Region:             t.flagRegion,

--- a/test/acceptance/setup-terraform/hcp/main.tf
+++ b/test/acceptance/setup-terraform/hcp/main.tf
@@ -49,7 +49,8 @@ resource "hcp_consul_cluster" "this" {
 }
 
 resource "aws_secretsmanager_secret" "bootstrap_token" {
-  name = "${var.suffix}-bootstrap-token"
+  name                    = "${var.suffix}-bootstrap-token"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "bootstrap_token" {
@@ -58,7 +59,8 @@ resource "aws_secretsmanager_secret_version" "bootstrap_token" {
 }
 
 resource "aws_secretsmanager_secret" "gossip_key" {
-  name = "${var.suffix}-gossip-key"
+  name                    = "${var.suffix}-gossip-key"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "gossip_key" {
@@ -67,7 +69,8 @@ resource "aws_secretsmanager_secret_version" "gossip_key" {
 }
 
 resource "aws_secretsmanager_secret" "consul_ca_cert" {
-  name = "${var.suffix}-consul-ca-cert"
+  name                    = "${var.suffix}-consul-ca-cert"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "consul_ca_cert" {

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -6,7 +6,7 @@ locals {
   name   = "consul-ecs-${random_string.suffix.result}"
   suffix = random_string.suffix.result
 
-  cluster_count = 2
+  cluster_count = 3
 }
 
 data "aws_availability_zones" "available" {

--- a/test/acceptance/setup-terraform/outputs.tf
+++ b/test/acceptance/setup-terraform/outputs.tf
@@ -1,13 +1,5 @@
-output "ecs_cluster_arn" {
-  value = aws_ecs_cluster.clusters[0].arn
-}
-
-output "ecs_cluster_1_arn" {
-  value = aws_ecs_cluster.clusters[0].arn
-}
-
-output "ecs_cluster_2_arn" {
-  value = aws_ecs_cluster.clusters[1].arn
+output "ecs_cluster_arns" {
+  value = [for c in aws_ecs_cluster.clusters : c.arn]
 }
 
 output "vpc_id" {

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -1061,13 +1061,13 @@ func TestBasic(t *testing.T) {
 }
 
 // discoverConsulEnterpriseImage looks in mesh-task for the default Consul image
-// and uses that that same version of the enterprise image.
+// and uses that same version of the enterprise image.
 func discoverConsulImage(t *testing.T, enterprise bool) string {
 	filepath := "../../../../modules/mesh-task/variables.tf"
 	data, err := os.ReadFile(filepath)
 	require.NoError(t, err)
 
-	// Find the default consul image in the mesh-task module and use that same version.
+	// Parse the default consul image from the mesh-task module.
 	re := regexp.MustCompile(`default\s+=\s+"public.ecr.aws/hashicorp/consul:(.*)"`)
 	matches := re.FindSubmatch(data)
 	require.Len(t, matches, 2) // entire match + one submatch

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -40,6 +40,19 @@ variable "secure" {
   default     = false
 }
 
+
+variable "consul_license" {
+  description = "A Consul Enterprise license key. Requires consul_image to be set to a Consul Enterprise image."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "consul_image" {
+  type    = string
+  default = ""
+}
+
 variable "launch_type" {
   description = "Whether to launch tasks on Fargate or EC2"
   type        = string
@@ -63,6 +76,13 @@ variable "consul_datacenter" {
 
 provider "aws" {
   region = var.region
+}
+
+locals {
+  enterprise_enabled = var.consul_license != ""
+
+  // Require consul_image to be passed when consul_license is set.
+  validate_consul_ent_image = local.enterprise_enabled && var.consul_image == "" ? file("ERROR: consul_image not passed to basic-install for enterprise test") : null
 }
 
 // Generate a gossip encryption key if a secure installation.
@@ -110,6 +130,8 @@ module "consul_server" {
 
   service_discovery_namespace = var.consul_datacenter
   datacenter                  = var.consul_datacenter
+  consul_image                = local.enterprise_enabled ? var.consul_image : null
+  consul_license              = var.consul_license
 }
 
 data "aws_security_group" "vpc_default" {
@@ -151,6 +173,7 @@ module "acl_controller" {
   subnets                           = var.subnets
   name_prefix                       = var.suffix
   consul_ecs_image                  = var.consul_ecs_image
+  consul_partitions_enabled         = local.enterprise_enabled
 }
 
 resource "aws_ecs_service" "test_client" {
@@ -236,6 +259,7 @@ EOT
   gossip_key_secret_arn     = var.secure ? aws_secretsmanager_secret.gossip_key[0].arn : ""
   acls                      = var.secure
   consul_ecs_image          = var.consul_ecs_image
+  consul_image              = local.enterprise_enabled ? var.consul_image : null
 
   additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 
@@ -295,6 +319,7 @@ module "test_server" {
   gossip_key_secret_arn     = var.secure ? aws_secretsmanager_secret.gossip_key[0].arn : ""
   acls                      = var.secure
   consul_ecs_image          = var.consul_ecs_image
+  consul_image              = local.enterprise_enabled ? var.consul_image : null
 
   consul_http_addr         = var.secure ? "https://${module.consul_server.server_dns}:8501" : ""
   consul_https_ca_cert_arn = var.secure ? module.consul_server.ca_cert_arn : ""

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -1,6 +1,6 @@
 variable "ecs_cluster_arn" {
   type        = string
-  description = "Cluster ARN of ECS cluster."
+  description = "ARN of ECS cluster."
 }
 
 variable "vpc_id" {
@@ -15,7 +15,6 @@ variable "subnets" {
 
 variable "suffix" {
   type        = string
-  default     = "nosuffix"
   description = "Suffix to add to all resource names."
 }
 

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -80,9 +80,6 @@ provider "aws" {
 
 locals {
   enterprise_enabled = var.consul_license != ""
-
-  // Require consul_image to be passed when consul_license is set.
-  validate_consul_ent_image = local.enterprise_enabled && var.consul_image == "" ? file("ERROR: consul_image not passed to basic-install for enterprise test") : null
 }
 
 // Generate a gossip encryption key if a secure installation.
@@ -130,7 +127,7 @@ module "consul_server" {
 
   service_discovery_namespace = var.consul_datacenter
   datacenter                  = var.consul_datacenter
-  consul_image                = local.enterprise_enabled ? var.consul_image : null
+  consul_image                = var.consul_image
   consul_license              = var.consul_license
 }
 
@@ -259,7 +256,7 @@ EOT
   gossip_key_secret_arn     = var.secure ? aws_secretsmanager_secret.gossip_key[0].arn : ""
   acls                      = var.secure
   consul_ecs_image          = var.consul_ecs_image
-  consul_image              = local.enterprise_enabled ? var.consul_image : null
+  consul_image              = var.consul_image
 
   additional_task_role_policies = [aws_iam_policy.execute-command.arn]
 
@@ -319,7 +316,7 @@ module "test_server" {
   gossip_key_secret_arn     = var.secure ? aws_secretsmanager_secret.gossip_key[0].arn : ""
   acls                      = var.secure
   consul_ecs_image          = var.consul_ecs_image
-  consul_image              = local.enterprise_enabled ? var.consul_image : null
+  consul_image              = var.consul_image
 
   consul_http_addr         = var.secure ? "https://${module.consul_server.server_dns}:8501" : ""
   consul_https_ca_cert_arn = var.secure ? module.consul_server.ca_cert_arn : ""

--- a/test/acceptance/tests/hcp/hcp_test.go
+++ b/test/acceptance/tests/hcp/hcp_test.go
@@ -51,8 +51,6 @@ func retryFunc(rt *retry.Timer, t *testing.T, f func() error) error {
 // HCPTestConfig holds the extended configuration for the admin partition/namespace tests.
 type HCPTestConfig struct {
 	config.TestConfig
-	ECSCluster1ARN          string      `json:"ecs_cluster_1_arn"`
-	ECSCluster2ARN          string      `json:"ecs_cluster_2_arn"`
 	EnableHCP               bool        `json:"enable_hcp"`
 	ConsulAddr              string      `json:"consul_public_endpoint_url"`
 	ConsulToken             string      `json:"token"`
@@ -82,7 +80,7 @@ func TestHCP(t *testing.T) {
 	cfg := parseHCPTestConfig(t)
 
 	// generate input variables to the test terraform using the config.
-	ignoreVars := []string{"ecs_cluster_1_arn", "ecs_cluster_2_arn", "token", "enable_hcp"}
+	ignoreVars := []string{"token", "enable_hcp"}
 	tfVars := TFVars(cfg, ignoreVars...)
 
 	consulClient, initialConsulState, err := consulClient(t, cfg.ConsulAddr, cfg.ConsulToken)
@@ -100,7 +98,7 @@ func TestHCP(t *testing.T) {
 		Namespace:    "default",
 		ConsulClient: consulClient,
 		Region:       cfg.Region,
-		ClusterARN:   cfg.ECSClusterARN,
+		ClusterARN:   cfg.ECSClusterARNs[0],
 	}
 
 	taskConfig.Name = fmt.Sprintf("test_client_%s", randomSuffix)
@@ -169,7 +167,7 @@ func TestNamespaces(t *testing.T) {
 	cfg := parseHCPTestConfig(t)
 
 	// generate input variables to the test terraform using the config.
-	ignoreVars := []string{"ecs_cluster_1_arn", "ecs_cluster_2_arn", "token", "enable_hcp"}
+	ignoreVars := []string{"token", "enable_hcp"}
 	tfVars := TFVars(cfg, ignoreVars...)
 
 	consulClient, initialConsulState, err := consulClient(t, cfg.ConsulAddr, cfg.ConsulToken)
@@ -185,7 +183,7 @@ func TestNamespaces(t *testing.T) {
 	taskConfig := helpers.MeshTaskConfig{
 		ConsulClient: consulClient,
 		Region:       cfg.Region,
-		ClusterARN:   cfg.ECSClusterARN,
+		ClusterARN:   cfg.ECSClusterARNs[0],
 		Partition:    "default",
 	}
 
@@ -250,13 +248,13 @@ func TestAdminPartitions(t *testing.T) {
 	taskConfig.Name = fmt.Sprintf("test_client_%s", clientSuffix)
 	taskConfig.Partition = "part1"
 	taskConfig.Namespace = "ns1"
-	taskConfig.ClusterARN = cfg.ECSCluster1ARN
+	taskConfig.ClusterARN = cfg.ECSClusterARNs[0]
 	clientTask := helpers.NewMeshTask(t, taskConfig)
 
 	taskConfig.Name = fmt.Sprintf("test_server_%s", serverSuffix)
 	taskConfig.Partition = "part2"
 	taskConfig.Namespace = "ns2"
-	taskConfig.ClusterARN = cfg.ECSCluster2ARN
+	taskConfig.ClusterARN = cfg.ECSClusterARNs[1]
 	serverTask := helpers.NewMeshTask(t, taskConfig)
 
 	tfVars["suffix_1"] = clientSuffix

--- a/test/acceptance/tests/hcp/terraform/ap/main.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/main.tf
@@ -2,6 +2,11 @@ provider "aws" {
   region = var.region
 }
 
+locals {
+  ecs_cluster_1_arn = var.ecs_cluster_arns[0]
+  ecs_cluster_2_arn = var.ecs_cluster_arns[1]
+}
+
 // Create ACL controller for cluster 1
 module "acl_controller_1" {
   source = "../../../../../../modules/acl-controller"
@@ -16,7 +21,7 @@ module "acl_controller_1" {
   launch_type                       = var.launch_type
   consul_bootstrap_token_secret_arn = var.bootstrap_token_secret_arn
   consul_server_http_addr           = var.consul_private_endpoint_url
-  ecs_cluster_arn                   = var.ecs_cluster_1_arn
+  ecs_cluster_arn                   = local.ecs_cluster_1_arn
   region                            = var.region
   subnets                           = var.subnets
   name_prefix                       = var.suffix_1
@@ -28,7 +33,7 @@ module "acl_controller_1" {
 // Create services.
 resource "aws_ecs_service" "test_client" {
   name            = "test_client_${var.suffix_1}"
-  cluster         = var.ecs_cluster_1_arn
+  cluster         = local.ecs_cluster_1_arn
   task_definition = module.test_client.task_definition_arn
   desired_count   = 1
   network_configuration {
@@ -104,7 +109,7 @@ module "acl_controller_2" {
   launch_type                       = var.launch_type
   consul_bootstrap_token_secret_arn = var.bootstrap_token_secret_arn
   consul_server_http_addr           = var.consul_private_endpoint_url
-  ecs_cluster_arn                   = var.ecs_cluster_2_arn
+  ecs_cluster_arn                   = local.ecs_cluster_2_arn
   region                            = var.region
   subnets                           = var.subnets
   name_prefix                       = var.suffix_2
@@ -116,7 +121,7 @@ module "acl_controller_2" {
 // Create services.
 resource "aws_ecs_service" "test_server" {
   name            = "test_server_${var.suffix_2}"
-  cluster         = var.ecs_cluster_2_arn
+  cluster         = local.ecs_cluster_2_arn
   task_definition = module.test_server.task_definition_arn
   desired_count   = 1
   network_configuration {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -13,14 +13,14 @@ variable "suffix_2" {
   type        = string
 }
 
-variable "ecs_cluster_1_arn" {
-  description = "Cluster ARN of ECS cluster 1."
-  type        = string
-}
+variable "ecs_cluster_arns" {
+  type        = list(string)
+  description = "ECS cluster ARNs. Two are required, and only the first two are used."
 
-variable "ecs_cluster_2_arn" {
-  description = "Cluster ARN of ECS cluster 2."
-  type        = string
+  validation {
+    error_message = "Two ECS clusters are required."
+    condition     = length(var.ecs_cluster_arns) >= 2
+  }
 }
 
 variable "vpc_id" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
@@ -2,6 +2,10 @@ provider "aws" {
   region = var.region
 }
 
+locals {
+  ecs_cluster_arn = var.ecs_cluster_arns[0]
+}
+
 // Create ACL controller
 module "acl_controller" {
   source = "../../../../../../modules/acl-controller"
@@ -16,7 +20,7 @@ module "acl_controller" {
   launch_type                       = var.launch_type
   consul_bootstrap_token_secret_arn = var.bootstrap_token_secret_arn
   consul_server_http_addr           = var.consul_private_endpoint_url
-  ecs_cluster_arn                   = var.ecs_cluster_arn
+  ecs_cluster_arn                   = local.ecs_cluster_arn
   region                            = var.region
   subnets                           = var.subnets
   name_prefix                       = var.suffix
@@ -28,7 +32,7 @@ module "acl_controller" {
 // Create client.
 resource "aws_ecs_service" "test_client" {
   name            = "test_client_${var.suffix}"
-  cluster         = var.ecs_cluster_arn
+  cluster         = local.ecs_cluster_arn
   task_definition = module.test_client.task_definition_arn
   desired_count   = 1
   network_configuration {
@@ -91,7 +95,7 @@ module "test_client" {
 // Create server.
 resource "aws_ecs_service" "test_server" {
   name            = "test_server_${var.suffix}"
-  cluster         = var.ecs_cluster_arn
+  cluster         = local.ecs_cluster_arn
   task_definition = module.test_server.task_definition_arn
   desired_count   = 1
   network_configuration {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -1,6 +1,11 @@
-variable "ecs_cluster_arn" {
-  type        = string
-  description = "Cluster ARN of ECS cluster."
+variable "ecs_cluster_arns" {
+  type        = list(string)
+  description = "ARNs of ECS clusters. One is required."
+
+  validation {
+    error_message = "At least one ECS cluster is required."
+    condition     = length(var.ecs_cluster_arns) >= 1
+  }
 }
 
 variable "vpc_id" {

--- a/test/acceptance/tests/hcp/terraform/ns/main.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/main.tf
@@ -2,6 +2,10 @@ provider "aws" {
   region = var.region
 }
 
+locals {
+  ecs_cluster_arn = var.ecs_cluster_arns[0]
+}
+
 // Create ACL controller
 module "acl_controller" {
   source = "../../../../../../modules/acl-controller"
@@ -16,7 +20,7 @@ module "acl_controller" {
   launch_type                       = var.launch_type
   consul_bootstrap_token_secret_arn = var.bootstrap_token_secret_arn
   consul_server_http_addr           = var.consul_private_endpoint_url
-  ecs_cluster_arn                   = var.ecs_cluster_arn
+  ecs_cluster_arn                   = local.ecs_cluster_arn
   region                            = var.region
   subnets                           = var.subnets
   name_prefix                       = var.suffix
@@ -28,7 +32,7 @@ module "acl_controller" {
 // Create client.
 resource "aws_ecs_service" "test_client" {
   name            = "test_client_${var.suffix}"
-  cluster         = var.ecs_cluster_arn
+  cluster         = local.ecs_cluster_arn
   task_definition = module.test_client.task_definition_arn
   desired_count   = 1
   network_configuration {
@@ -92,7 +96,7 @@ module "test_client" {
 // Create server.
 resource "aws_ecs_service" "test_server" {
   name            = "test_server_${var.suffix}"
-  cluster         = var.ecs_cluster_arn
+  cluster         = local.ecs_cluster_arn
   task_definition = module.test_server.task_definition_arn
   desired_count   = 1
   network_configuration {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -1,6 +1,11 @@
-variable "ecs_cluster_arn" {
-  type        = string
-  description = "Cluster ARN of ECS cluster."
+variable "ecs_cluster_arns" {
+  type        = list(string)
+  description = "ARNs of ECS clusters. One is required."
+
+  validation {
+    error_message = "At least one ECS cluster is required."
+    condition     = length(var.ecs_cluster_arns) >= 1
+  }
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
## Changes proposed in this PR:
This adds an enterprise test to TestBasic. Right now, it doesn't do anything special with partitions or namespaces.

I updated things to pass a _list_ of ECS clusters from setup-terraform through to test cases and (usually) through to Terraform. This fixes an issue I caused where the ECS cluster wasn't being passed correctly in HCP tests, and I fixed an issue with parallel `terraform init`s in TestBasic

## How I've tested this PR:
- Acceptance tests in CI, and locally

## How I expect reviewers to test this PR:
👀 

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::