### PR TITLE
Fix gossip key ARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ FEATURES
   variable for configuring login to the AWS IAM auth method.
   [[GH-132](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/132)]
 
+BUG FIXES
+* modules/dev-server: Fix a bug where the `dev-server` selects the wrong gossip encryption key
+  secret ARN when creating the execution policy. The gossip encryption key selection would work
+  if the secret ARN was passed in, but it would fail when trying to use the generated gossip key.
+  The cause of the failure was an incorrect resource ARN in the generated policy.
+  [[GH-133](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/133)]
+
 ## 0.5.0 (June 21, 2022)
 
 BREAKING CHANGES

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -260,7 +260,7 @@ resource "aws_iam_policy" "this_execution" {
         "secretsmanager:GetSecretValue"
       ],
       "Resource": [
-        "${var.gossip_key_secret_arn}"
+        "${local.gossip_key_arn}"
       ]
     },
 %{endif~}


### PR DESCRIPTION
## Changes proposed in this PR:
Fix a bug in the `dev-server` where it doesn't pick up the correct secret ARN for the gossip encryption key when the module is configured to generate the gossip key. When `var.gossip_encryption_enabled = true` the module is supposed to create and use a gossip key. However, when `gossip_encryption_enabled = true` it was always using the value of `var.gossip_key_secret_arn`, even if that was unset (which it should be in the case where the key is generated). This caused the creation of the execution role policy to fail because the `Resource` ARN for gossip key secret was the empty string.

## How I've tested this PR:
- :eyes:
- Using the Lambda registrator acceptance tests (how I found the issue)

## How I expect reviewers to test this PR:
:eyes:

## Checklist:
- [x] ~Tests added~ N/A
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::