### PR TITLE
add fargate ha consul cluster backed by efs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ vendor
 # Ignore Terraform lock files, as we want to test the Terraform code in these repos with the latest provider
 # versions.
 .terraform.lock.hcl
+
+# all pem files
+*.pem

--- a/examples/ha-cluster-fargate/GNUmakefile
+++ b/examples/ha-cluster-fargate/GNUmakefile
@@ -1,0 +1,31 @@
+SHELL = bash
+
+CONSUL_DC?=dc1
+CONSUL_COUNT?=3
+NODE_NAME?=consul
+ADDITIONAL_DNSNAMES?=()
+
+# Build CA & Certs for Consul
+.PHONY: certs
+certs: clean-certs
+	ADD_NAMES=""
+	# Creating CA and CA-Key
+	consul tls ca create
+	# Creating Client and CLI key pairs
+	for I in "-client" "-cli"; do \
+	    consul tls cert create $$I -dc $(CONSUL_DC); \
+	done;
+	# Creating Consul ALB Cert
+	for J in "$(ADDITIONAL_DNSNAMES)"; do \
+		ADD_NAMES="$$ADD_NAMES -additional-dnsname=$${J}"; \
+	done;
+	consul tls cert create -server \
+		-node="consul" \
+		-dc="$(CONSUL_DC)" \
+		-additional-dnsname="consul.$(CONSUL_DC)" \
+		$$ADD_NAMES;
+
+# Clean out local CA & Cert
+.PHONY: clean-certs
+clean-certs:
+	rm -f *.pem

--- a/examples/ha-cluster-fargate/README.md
+++ b/examples/ha-cluster-fargate/README.md
@@ -1,0 +1,105 @@
+# Consul HA Cluster backed by EFS storage on Fargate Example
+
+This example deploys a new VPC, EFS Cluster and ECS Cluster to host 3 Consul Servers in HA with 3 Consul Agents. A K6
+container is built by local provisioner and stored in ECR for use in Lambda to load test the KV system on EFS with Raft.
+
+## Usage
+
+### Setup
+
+Clone this repository:
+
+```console
+$ git clone https://github.com/hashicorp/terraform-aws-consul-ecs.git
+$ git checkout tags/<latest-version>
+$ cd terraform-aws-consul-ecs/examples/ha-cluster-fargate
+```
+
+> This module utilizes the Consul Image with a Go-Discover module version
+> v0.0.0-20220714221025-1c234a67149a
+
+
+The following `variables.auto.tfvars` file can be used to target a specific image.
+```terraform
+consul_image = "registry.gitlab.com/fdir/consul:latest"
+```
+
+Create the Consul CA Key and Cert, Client and CLI keypairs and an ALB keypair.
+```bash
+make certs
+```
+
+Initialize Terraform:
+
+```bash
+terraform init
+```
+
+### Terraform Apply
+
+Then apply the Terraform:
+
+```bash
+terraform apply
+```
+
+In this deployment the ALB is internal to reduce the cost of load test traffic.
+
+Tail the logs in cloudwatch until the Cluster has quorum and all agents have joined.
+
+### Interact with a server
+
+Get a cluster By Name
+
+```bash
+aws ecs list-clusters | jq -r '.clusterArns[0]'
+```
+
+Get the consul0 service task
+```bash
+aws ecs list-tasks --cluster consul-dc1 --service-name Consul0
+```
+
+List the consul members
+```bash
+aws ecs execute-command --interactive --cluster consul-dc1 --task $TASK_ID --container consul-server --command "consul members"
+```
+```console
+The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.
+Starting session with SessionId: ecs-execute-command-00cd14d5b53dd200c
+Node           Address          Status  Type    Build      Protocol  DC   Partition  Segment
+consul0        10.0.2.30:8301   alive   server  1.15.0dev  2         dc1  default    <all>
+consul1        10.0.4.75:8301   alive   server  1.15.0dev  2         dc1  default    <all>
+consul2        10.0.6.118:8301  alive   server  1.15.0dev  2         dc1  default    <all>
+consul-agent0  10.0.2.145:8301  alive   client  1.15.0dev  2         dc1  default    <default>
+consul-agent1  10.0.4.37:8301   alive   client  1.15.0dev  2         dc1  default    <default>
+consul-agent2  10.0.6.160:8301  alive   client  1.15.0dev  2         dc1  default    <default>
+```
+
+Start a session on the service, using cluster name and task id
+```bash
+aws ecs execute-command --interactive --cluster consul-dc1 --task 0b5744fd84444932ba832f2da298f6a2 --container consul-server --command sh
+```
+
+### Start a Load Test
+
+When ready to run load test, invoke the lambda.
+```bash
+terraform apply -auto-approve -var 'invoke_loadtest=true'
+```
+
+You can follow the load test while in progress in the cloudwatch log group `/aws/lambda/K6Lambda`.
+
+If you want to rerun the load test, taint the invocation and apply again.
+```bash
+terraform taint aws_lambda_invocation.k6[0]
+terraform apply -auto-approve -var 'invoke_loadtest=true'
+```
+
+## Cleanup
+
+Once you've done testing, be sure to clean up the resources you've created:
+
+```bash
+terraform destroy -auto-approve
+```

--- a/examples/ha-cluster-fargate/consul-client.tf
+++ b/examples/ha-cluster-fargate/consul-client.tf
@@ -1,0 +1,298 @@
+locals {
+  clients = tomap({ for c in range(3) : "agent${c}" => {
+    index : c,
+    subnet_id : module.vpc.private_subnets[c],
+    command : format(local.consul_client_command_template, c)
+  } })
+
+  consul_client_command_template = <<EOF
+set +ex
+ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
+mkdir -p /tmp/consul-data
+echo "$CONSUL_CACERT_PEM" > /tmp/consul-data/consul-agent-ca.pem
+
+exec consul agent \
+  -advertise "$ECS_IPV4" \
+  -client 0.0.0.0 \
+  -data-dir "/tmp/consul-data" \
+  -encrypt "$CONSUL_GOSSIP_ENCRYPTION_KEY" \
+  -hcl='node_name = "consul-agent%s"' \
+  -hcl='datacenter = "${local.datacenter}"' \
+  -hcl='connect { enabled = true }' \
+  -hcl='leave_on_terminate = true' \
+  -hcl='auto_encrypt { tls = true }' \
+  -hcl='tls { defaults { ca_file = "/tmp/consul-data/consul-agent-ca.pem" }}' \
+  -hcl='tls { defaults { verify_incoming = true, verify_outgoing = true }}' \
+  -hcl='tls { internal_rpc { verify_server_hostname = true }}' \
+  -hcl='ports { server = 8300, serf_lan = 8301, serf_wan = 8302, https = 8501, grpc = 8502, grpc_tls = 8503 }' \
+  -retry-join "provider=aws tag_key=Consul-Auto-Join tag_value=consul service=ecs"
+EOF
+
+  client_portmap = [{
+    containerPort : 8300,
+    hostPort : 8300,
+    protocol : "tcp"
+    }, {
+    containerPort : 8301,
+    hostPort : 8301,
+    protocol : "tcp"
+    }, {
+    containerPort : 8302,
+    hostPort : 8302,
+    protocol : "tcp"
+    }, {
+    containerPort : 8500,
+    hostPort : 8500,
+    protocol : "tcp"
+    }, {
+    containerPort : 8501,
+    hostPort : 8501,
+    protocol : "tcp"
+    }, {
+    containerPort : 8502,
+    hostPort : 8502,
+    protocol : "tcp"
+    }, {
+    containerPort : 8600,
+    hostPort : 8600,
+    protocol : "udp"
+  }]
+}
+
+resource "aws_lb_target_group" "agent" {
+  for_each    = local.clients
+  name        = title(each.key)
+  port        = 8500
+  protocol    = "HTTP"
+  vpc_id      = module.vpc.vpc_id
+  target_type = "ip"
+  slow_start  = 30
+
+  health_check {
+    enabled             = true
+    path                = "/v1/status/leader"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 2
+    interval            = 5
+  }
+}
+
+resource "aws_lb_listener" "agent" {
+  load_balancer_arn = module.consul-cluster.mgmt_alb_arn
+  port              = "8500"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-2019-08"
+  certificate_arn   = module.consul-cluster.alb_iam_cert_arn
+
+  default_action {
+    type = "forward"
+    forward {
+      dynamic "target_group" {
+        for_each = aws_lb_target_group.agent
+        content {
+          arn = aws_lb_target_group.agent[target_group.key].arn
+        }
+      }
+    }
+  }
+}
+
+module "consul-clients" {
+  source   = "../../modules/ecs-service"
+  for_each = local.clients
+
+  name       = title(each.key)
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = [each.value["subnet_id"]]
+
+  ecs_cluster_name = aws_ecs_cluster.ecs.name
+
+  target_groups = {
+    consul8500 : {
+      protocol : "TCP"
+      port : 8500
+      arn : aws_lb_target_group.agent[each.key].arn
+    }
+  }
+
+  container_name   = "consul-agent"
+  cpu              = 2048
+  memory           = 4096
+  cpu_architecture = "ARM64"
+
+  task_definition = [
+    {
+      name : "consul-agent"
+      image : var.consul_image
+      cpu : 2048
+      memory : 4096
+      essential : true
+      entryPoint : ["/bin/sh", "-ec"]
+      command : [replace(each.value["command"], "\r", "")]
+      linuxParameters : {
+        initProcessEnabled : true
+      }
+      portMappings : local.client_portmap
+      secrets : [
+        {
+          name      = "CONSUL_GOSSIP_ENCRYPTION_KEY"
+          valueFrom = module.consul-cluster.gossip_key_arn
+        },
+        {
+          name      = "CONSUL_CACERT_PEM",
+          valueFrom = module.consul-cluster.ca_cert_arn
+        },
+      ]
+      healthCheck : {
+        retries : 3,
+        command : ["CMD-SHELL", "curl http://127.0.0.1:8500/v1/status/leader"],
+        timeout : 5,
+        interval : 30,
+        startPeriod : 15,
+      }
+      logConfiguration : {
+        logDriver : "awslogs",
+        options : {
+          awslogs-group : module.consul-cluster.cloudwatch_log_group_name,
+          awslogs-region : data.aws_region.current.name,
+          awslogs-stream-prefix : "consul-agent"
+        }
+      }
+    }
+  ]
+
+  security_group_ids = [
+    module.consul-cluster.consul_server_security_group_id,
+  ]
+  ecs_execution_role_arn = aws_iam_role.client_execution_role.arn
+  ecs_task_role_arn      = aws_iam_role.client_task_role.arn
+  ecs_task_role_id       = aws_iam_role.client_task_role.id
+
+  depends_on = [
+    aws_lb_target_group.agent,
+    module.consul-cluster,
+  ]
+}
+
+data "aws_iam_policy_document" "client_execution" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+    resources = [
+      data.aws_kms_alias.secretsmanager.arn,
+      data.aws_kms_alias.secretsmanager.target_key_arn,
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+      module.consul-cluster.gossip_key_arn,
+      module.consul-cluster.ca_key_arn,
+      module.consul-cluster.ca_cert_arn,
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:consul/${local.datacenter}/tls/CONSUL_CLIENT_*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "client_execution" {
+  name   = "${title(var.name)}Execution"
+  role   = aws_iam_role.client_execution_role.id
+  policy = data.aws_iam_policy_document.client_execution.json
+}
+
+data "aws_iam_policy_document" "client_execution_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "client_execution_role" {
+  name        = "${title(var.name)}Execution"
+  path        = "/ecs/"
+  description = "Consul client execution role"
+
+  assume_role_policy = data.aws_iam_policy_document.client_execution_assume.json
+
+}
+
+data "aws_iam_policy_document" "client_task_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "client_task" {
+  statement {
+    sid    = "${title(replace(var.name, "-", ""))}AutoDiscover"
+    effect = "Allow"
+    actions = [
+      "ecs:ListClusters",
+      "ecs:ListServices",
+      "ecs:DescribeServices",
+      "ecs:ListTasks",
+      "ecs:DescribeTasks",
+      "ecs:DescribeContainerInstances",
+      "ec2:DescribeNetworkInterfaces",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "client_task" {
+  name   = "${title(var.name)}Task"
+  policy = data.aws_iam_policy_document.client_task.json
+  role   = aws_iam_role.client_task_role.id
+}
+
+#data "aws_iam_policy_document" "ecs_datadog" {
+#  statement {
+#    sid    = "${title(replace(var.name, "-", ""))}Datadog"
+#    effect = "Allow"
+#    actions = [
+#      "ecs:ListClusters",
+#      "ecs:ListContainerInstances",
+#      "ecs:DescribeContainerInstances",
+#    ]
+#    resources = ["*"]
+#  }
+#}
+#
+#resource "aws_iam_role_policy" "ecs_datadog" {
+#  name   = "${title(replace(var.name, "-", ""))}Datadog"
+#  policy = data.aws_iam_policy_document.ecs_datadog.json
+#  role   = aws_iam_role.client_task_role.id
+#}
+
+resource "aws_iam_role" "client_task_role" {
+  name               = "${title(var.name)}Task"
+  assume_role_policy = data.aws_iam_policy_document.client_task_assume.json
+}

--- a/examples/ha-cluster-fargate/loadtest.tf
+++ b/examples/ha-cluster-fargate/loadtest.tf
@@ -1,0 +1,12 @@
+module "k6lambda" {
+  source  = "../../modules/lambda-k6"
+  vpc_id  = module.vpc.vpc_id
+  subnets = module.vpc.private_subnets
+  target  = module.consul-cluster.mgmt_alb_dns_name
+}
+
+resource "aws_lambda_invocation" "k6" {
+  count         = var.invoke_loadtest ? 1 : 0
+  function_name = module.k6lambda.function_name
+  input         = jsonencode({})
+}

--- a/examples/ha-cluster-fargate/main.tf
+++ b/examples/ha-cluster-fargate/main.tf
@@ -1,0 +1,73 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_kms_alias" "secretsmanager" {
+  name = "alias/aws/secretsmanager"
+}
+
+locals {
+  datacenter = "dc1"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Create VPC with public and also private subnets
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.21.0"
+
+  name               = var.name
+  cidr               = var.vpc_cidr
+  azs                = var.vpc_az
+  public_subnets     = var.public_subnet_cidrs
+  private_subnets    = var.private_subnet_cidrs
+  enable_nat_gateway = true
+  single_nat_gateway = var.single_nat_gateway
+
+  # Specifically for EFS mount via dns feature
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_ecs_cluster" "ecs" {
+  name = var.name
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+module "consul-cluster" {
+  source = "../../modules/ha-cluster"
+  # version = ""
+
+  name               = "consul"
+  datacenter         = local.datacenter
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnets
+  public_subnet_ids  = module.vpc.public_subnets
+
+  lb_enabled                      = true
+  internal_alb_listener           = true
+  lb_ingress_rule_cidr_blocks     = var.lb_ingress_rule_cidr_blocks
+  lb_ingress_rule_security_groups = compact(concat(
+    var.lb_ingress_rule_security_groups,
+    [module.k6lambda.security_group_id]
+  ))
+
+  ecs_cluster_name = aws_ecs_cluster.ecs.name
+
+  consul_image              = var.consul_image
+  operating_system_family   = var.operating_system_family
+  cpu_architecture          = var.cpu_architecture
+  docker_username           = var.docker_username
+  docker_password           = var.docker_password
+  consul_count              = var.consul_count
+  gossip_encryption_enabled = true
+  acls                      = false # acl disabled for the load test
+  # otherwise need to distribute agent tokens and policy
+
+  # The certificates must exist in your codebase. See GNUmakefile for more about certs.
+  tls = true
+}

--- a/examples/ha-cluster-fargate/variables.tf
+++ b/examples/ha-cluster-fargate/variables.tf
@@ -1,0 +1,101 @@
+variable "name" {
+  description = "Name to be used on all the resources as identifier."
+  type        = string
+  default     = "consul-dc1"
+}
+
+variable "vpc_az" {
+  type        = list(string)
+  description = "VPC Availability Zone"
+  validation {
+    condition     = length(var.vpc_az) >= 2
+    error_message = "VPC needs at least two Availability Zones for ALB to work."
+  }
+  default = ["us-east-2a", "us-east-2b", "us-east-2c"]
+}
+
+variable "vpc_name" {
+  description = "Name of the VPC"
+  default     = "consul-vpc"
+}
+
+variable "vpc_cidr" {
+  description = "List of CIDR blocks for the VPC module"
+  default     = "10.0.0.0/16"
+}
+
+variable "vpc_allowed_ssh_cidr" {
+  description = "List of CIDR blocks allowed to ssh to the test server; set to 0.0.0.0/0 to allow access from anywhere"
+  default     = "10.0.0.0/16"
+}
+
+variable "lb_ingress_rule_cidr_blocks" {
+  description = "CIDR blocks that are allowed access to the load balancer."
+  type        = list(string)
+  default     = []
+}
+
+variable "lb_ingress_rule_security_groups" {
+  description = "Security groups that are allowed access to the load balancer."
+  type        = list(string)
+  default     = []
+}
+
+variable "single_nat_gateway" {
+  description = "Deploy a single nat gateway. Default is false."
+  default     = true
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR Block for the Public Subnet, must be within VPC CIDR range"
+  default     = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "CIDR Block for the Private Subnet, must be within VPC CIDR range"
+  default     = ["10.0.2.0/24", "10.0.4.0/24", "10.0.6.0/24"]
+}
+
+variable "consul_image" {
+  type        = string
+  description = "Name of the Consul Agent Docker Image"
+  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+}
+
+variable "operating_system_family" {
+  default = "LINUX"
+}
+
+variable "cpu_architecture" {
+  default = "ARM64"
+}
+
+variable "docker_username" {
+  type        = string
+  description = "Username for Docker Hub authentication."
+  default     = null
+}
+
+variable "docker_password" {
+  type        = string
+  description = "Password (or token) for Docker Hub authentication."
+  default     = null
+}
+
+variable "consul_count" {
+  description = "Number of consul servers to deploy. Default 3"
+  default     = 3
+}
+
+variable "consul_license" {
+  description = "A Consul Enterprise license key. Requires consul_image to be set to a Consul Enterprise image."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "invoke_loadtest" {
+  default = false
+}

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -1,0 +1,83 @@
+resource "aws_ecs_task_definition" "task_def" {
+  family = var.name
+
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  execution_role_arn       = var.ecs_execution_role_arn
+  task_role_arn            = var.ecs_task_role_arn
+  tags                     = var.tags
+  cpu                      = var.cpu
+  memory                   = var.memory
+
+  runtime_platform {
+    operating_system_family = var.operating_system_family
+    cpu_architecture        = var.cpu_architecture
+  }
+
+  container_definitions = jsonencode(var.task_definition)
+
+  dynamic "volume" {
+    for_each = var.efs_volumes
+    content {
+      name = volume.key
+      efs_volume_configuration {
+        file_system_id          = volume.value["file_system_id"]
+        root_directory          = volume.value["root_directory"]
+        transit_encryption      = volume.value["transit_encryption"]
+        transit_encryption_port = volume.value["encryption_port"]
+        authorization_config {
+          access_point_id = volume.value["access_point_id"]
+          iam             = volume.value["iam"]
+        }
+      }
+    }
+  }
+}
+
+resource "aws_ecs_service" "task_service" {
+  name            = var.name
+  cluster         = var.ecs_cluster_name
+  task_definition = aws_ecs_task_definition.task_def.arn
+  tags            = var.tags
+  propagate_tags  = "SERVICE"
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
+
+  enable_execute_command = true
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = var.deployment_circuit_breaker_enable
+    rollback = false
+  }
+
+  network_configuration {
+    assign_public_ip = var.assign_public_ip
+    subnets          = var.subnet_ids
+    security_groups  = var.security_group_ids
+  }
+
+  dynamic "load_balancer" {
+    for_each = var.target_groups
+    content {
+      target_group_arn = load_balancer.value["arn"]
+      container_name   = var.container_name
+      container_port   = load_balancer.value["port"]
+    }
+  }
+
+  dynamic "service_registries" {
+    for_each = var.service_registries
+    content {
+      registry_arn   = service_registries.value["registry_arn"]
+      container_name = service_registries.value["container_name"]
+    }
+  }
+}

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -1,0 +1,125 @@
+variable "name" { default = "container" }
+variable "tags" {
+  description = "Tags for the resources"
+  type        = map(string)
+  default = {
+    env : "dev"
+  }
+}
+
+variable "ecs_cluster_name" {
+  description = "ECS Cluster Name to Deploy this container and launch template"
+  type        = string
+}
+
+variable "ecs_execution_role_arn" {
+  type = string
+}
+
+variable "ecs_task_role_arn" {
+  type = string
+}
+
+variable "ecs_task_role_id" {
+  type = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID the subnets are attached to"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet ids to deploy the containers in"
+  type        = list(string)
+}
+
+variable "desired_count" {
+  description = "ECS Service Fixed Count"
+  type        = number
+  default     = 1
+}
+
+variable "cpu" {
+  default = 256
+}
+
+variable "memory" {
+  default = 512
+}
+
+variable "deployment_maximum_percent" {
+  default = 200
+}
+variable "deployment_minimum_healthy_percent" {
+  default = 100
+}
+variable "deployment_circuit_breaker_enable" {
+  default = false
+}
+
+variable "security_group_ids" {
+  description = "Additional Security Group IDs to add to the Service"
+  type        = list(string)
+  default     = []
+}
+
+variable "secrets" {
+  type    = list(object({ name : string, valueFrom : string }))
+  default = []
+}
+
+variable "task_definition" {
+  default = {}
+}
+
+variable "operating_system_family" {
+  default = "LINUX"
+}
+
+variable "cpu_architecture" {
+  default = "X86_64"
+}
+
+variable "efs_volumes" {
+  type = map(object({
+    file_system_id : string
+    access_point_id : string
+    root_directory : string
+    transit_encryption : string
+    encryption_port : number
+    iam : string
+  }))
+  default = {}
+}
+
+variable "container_name" {
+  type    = string
+  default = ""
+}
+
+variable "sidecar_name" {
+  type    = string
+  default = ""
+}
+
+variable "target_groups" {
+  default = {}
+}
+
+variable "health_check_grace_period_seconds" {
+  default = 0
+}
+
+variable "assign_public_ip" {
+  default = false
+}
+
+variable "ignore_changes" {
+  default = []
+}
+
+variable "service_registries" {
+  default = {}
+}
+

--- a/modules/efs-cluster/README.md
+++ b/modules/efs-cluster/README.md
@@ -1,0 +1,5 @@
+# EFS Cluster
+
+This module deploys an AWS EFS cluster for use by the HA Consul cluster for development/testing purposes.
+
+See https://www.consul.io/docs/ecs for additional documentation.

--- a/modules/efs-cluster/main.tf
+++ b/modules/efs-cluster/main.tf
@@ -1,0 +1,49 @@
+data "aws_region" "current" {}
+
+resource "aws_efs_file_system" "efs_storage" {
+  encrypted = true
+}
+
+resource "aws_efs_access_point" "efs_storage" {
+  for_each       = var.access_point_config
+  file_system_id = aws_efs_file_system.efs_storage.id
+  tags           = var.tags
+  root_directory {
+    path = "/${each.key}"
+    creation_info {
+      owner_gid   = each.value["owner_gid"]
+      owner_uid   = each.value["owner_uid"]
+      permissions = each.value["permissions"]
+    }
+  }
+}
+
+resource "aws_efs_mount_target" "efs_storage" {
+  for_each        = var.access_point_config
+  file_system_id  = aws_efs_file_system.efs_storage.id
+  subnet_id       = each.value["subnet_id"]
+  security_groups = [aws_security_group.storage_service.id]
+}
+
+resource "aws_security_group" "storage_service" {
+  name   = "${title(var.name)}EFSService"
+  tags   = var.tags
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group" "storage_client" {
+  name   = "${title(var.name)}EFSClient"
+  tags   = var.tags
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group_rule" "consul_storage_rule" {
+  description              = "Allow Access to EFS Access Point"
+  security_group_id        = aws_security_group.storage_service.id
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  type                     = "ingress"
+  source_security_group_id = aws_security_group.storage_client.id
+}
+

--- a/modules/efs-cluster/outputs.tf
+++ b/modules/efs-cluster/outputs.tf
@@ -1,0 +1,31 @@
+output "efs_id" {
+  value = aws_efs_file_system.efs_storage.id
+}
+
+output "efs_arn" {
+  value = aws_efs_file_system.efs_storage.arn
+}
+
+output "efs_name" {
+  value = aws_efs_file_system.efs_storage.arn
+}
+
+output "access_point_arns" {
+  value = [for p in aws_efs_access_point.efs_storage : p.arn]
+}
+
+output "access_point_ids" {
+  value = [for p in aws_efs_access_point.efs_storage : p.id]
+}
+
+output "mount_target_ids" {
+  value = [for t in aws_efs_mount_target.efs_storage : t.id]
+}
+
+output "efs_service_security_group_id" {
+  value = aws_security_group.storage_service.id
+}
+
+output "efs_client_security_group_id" {
+  value = aws_security_group.storage_client.id
+}

--- a/modules/efs-cluster/variables.tf
+++ b/modules/efs-cluster/variables.tf
@@ -1,0 +1,16 @@
+variable "name" {
+  default = "efs"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "access_point_config" {
+  default = {}
+}

--- a/modules/ha-cluster/README.md
+++ b/modules/ha-cluster/README.md
@@ -1,0 +1,5 @@
+# Highly Available Cluster
+
+This module deploys a Consul server cluster as an ECS Task for development/testing purposes.
+
+See https://www.consul.io/docs/ecs for additional documentation.

--- a/modules/ha-cluster/main.tf
+++ b/modules/ha-cluster/main.tf
@@ -1,0 +1,894 @@
+terraform {
+  required_version = ">= 0.13"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_kms_alias" "secretsmanager" {
+  name = "alias/aws/secretsmanager"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Create variables and ssh keys
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  // Determine which secrets are provided and which ones need to be created.
+  generate_gossip_key      = var.gossip_encryption_enabled && var.generate_gossip_encryption_key
+  generate_ca              = var.tls ? var.generate_ca : false
+  generate_bootstrap_token = var.acls ? var.generate_bootstrap_token : false
+
+  gossip_key_arn      = local.generate_gossip_key ? aws_secretsmanager_secret.gossip_key[0].arn : var.gossip_key_secret_arn
+  ca_cert_arn         = local.generate_ca ? aws_secretsmanager_secret.certs["CONSUL_CA"].arn : var.ca_cert_arn
+  ca_key_arn          = local.generate_ca ? aws_secretsmanager_secret.certs["CONSUL_CA_KEY"].arn : var.ca_key_arn
+  bootstrap_token_arn = local.generate_bootstrap_token ? aws_secretsmanager_secret.bootstrap_token[0].arn : var.bootstrap_token_arn
+  bootstrap_token     = var.acls ? var.generate_bootstrap_token ? random_uuid.bootstrap_token[0].result : var.bootstrap_token : null
+
+  // Setup Consul server options
+  consul_enterprise_enabled          = var.consul_license != ""
+  enable_mesh_gateway_wan_federation = var.enable_mesh_gateway_wan_federation || length(var.primary_gateways) > 0 ? true : false
+  node_name                          = var.node_name != "" ? var.node_name : var.name
+
+  // If the user has passed an explicit Cloud Map service discovery namespace then use it.
+  // Otherwise set the namespace to match the datacenter for the Consul server.
+  service_discovery_namespace = var.service_discovery_namespace != "" ? var.service_discovery_namespace : var.datacenter
+
+  certs = {
+    CONSUL_CA : "consul-agent-ca.pem"
+    CONSUL_CA_KEY : "consul-agent-ca-key.pem"
+    CONSUL_ALB_KEY : "${var.datacenter}-server-consul-0-key.pem"
+    CONSUL_ALB_CERT : "${var.datacenter}-server-consul-0.pem"
+    CONSUL_CLIENT_KEY : "${var.datacenter}-client-consul-0-key.pem"
+    CONSUL_CLIENT_CERT : "${var.datacenter}-client-consul-0.pem"
+  }
+  cert_arns = [for cert in aws_secretsmanager_secret.certs : cert.arn]
+
+  server_map = tomap({ for c in range(var.consul_count) : "consul${c}" => {
+    index : c
+    subnet_id : var.private_subnet_ids[c]
+    owner_gid : 1000
+    owner_uid : 100
+    permissions : "0700"
+    command : format(local.consul_server_command_template, c)
+    init : var.tls ? [{
+      name      = "tls-init"
+      image     = var.consul_image
+      essential = false
+      logConfiguration = {
+        logDriver : "awslogs",
+        options : {
+          awslogs-group : aws_cloudwatch_log_group.container-logs.name,
+          awslogs-region : data.aws_region.current.name,
+          awslogs-stream-prefix : "tls-init"
+        }
+      }
+      mountPoints = var.deploy_efs_cluster ? [
+        {
+          containerPath : "/consul"
+          sourceVolume : "consul${c}"
+          readOnly : false
+        }
+      ] : []
+      entryPoint = ["/bin/sh", "-ec"]
+      command    = [format(local.consul_server_tls_init_command_template, c, c)]
+      secrets = [
+        {
+          name      = "CONSUL_CACERT_PEM",
+          valueFrom = local.ca_cert_arn
+        },
+        {
+          name      = "CONSUL_CAKEY",
+          valueFrom = local.ca_key_arn
+        }
+      ]
+    }] : []
+  } })
+
+  consul_server_command_template = <<EOF
+ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
+
+exec consul agent -server \
+  -bootstrap-expect ${var.consul_count} \
+  -ui \
+  -advertise "$ECS_IPV4" \
+  -client 0.0.0.0 \
+  -data-dir ${var.deploy_efs_cluster ? "/consul/data" : "/tmp/consul-data"} \
+%{if var.gossip_encryption_enabled~}
+  -encrypt "$CONSUL_GOSSIP_ENCRYPTION_KEY" \
+%{endif~}
+  -hcl='node_name = "${local.node_name}%s"' \
+  -hcl='datacenter = "${var.datacenter}"' \
+  -hcl='connect { enabled = true }' \
+  -hcl='enable_central_service_config = true' \
+  -hcl='performance { raft_multiplier = ${var.raft_multiplier} }' \
+  -hcl='leave_on_terminate = true' \
+%{if var.tls~}
+  -hcl='tls { defaults { ca_file = "/consul/consul-agent-ca.pem" }}' \
+  -hcl='tls { defaults { cert_file = "/consul/${var.datacenter}-server-consul-0.pem" }}' \
+  -hcl='tls { defaults { key_file = "/consul/${var.datacenter}-server-consul-0-key.pem" }}' \
+  -hcl='tls { defaults { verify_incoming = true, verify_outgoing = true }}' \
+  -hcl='tls { internal_rpc { verify_server_hostname = true }}' \
+  -hcl='auto_encrypt = {allow_tls = true}' \
+  -hcl='ports { server = 8300, serf_lan = 8301, serf_wan = 8302, https = 8501, grpc = 8502, grpc_tls = 8503 }' \
+%{endif~}
+%{if var.acls~}
+  -hcl='acl {enabled = true, default_policy = "deny", down_policy = "extend-cache", enable_token_persistence = true}' \
+  -hcl='acl = { tokens = { initial_management = "${local.bootstrap_token}", default = "${local.bootstrap_token}" }}' \
+%{endif~}
+%{if var.acls && local.enable_mesh_gateway_wan_federation~}
+  -hcl='acl = { enable_token_replication = true }' \
+%{endif~}
+%{if var.acls && var.replication_token != ""~}
+  -hcl='acl = { tokens = { replication = "${var.replication_token}"}}' \
+%{endif~}
+%{if var.primary_datacenter != ""~}
+  -hcl='primary_datacenter = "${var.primary_datacenter}"' \
+%{endif~}
+%{if var.aws_auto_join~}
+  -retry-join "provider=aws tag_key=Consul-Auto-Join tag_value=${var.name} service=ecs" \
+%{endif~}
+%{if length(var.retry_join_wan) > 0~}
+  -hcl='retry_join_wan = [
+  %{for addr in var.retry_join_wan~}
+    "${addr}",
+  %{endfor~}
+  ]' \
+%{endif~}
+%{if local.enable_mesh_gateway_wan_federation~}
+  -hcl='connect { enable_mesh_gateway_wan_federation = true }' \
+%{endif~}
+%{if length(var.primary_gateways) > 0~}
+  -hcl='primary_gateways = [
+  %{for addr in var.primary_gateways~}
+    "${addr}",
+  %{endfor~}
+  ]' \
+%{endif~}
+EOF
+  // Generate consul_count server configurations.
+  // The index of the range iteration is specified multiple times to be used the same number of times in the template.
+  //consul_server_commands = [for i in range(var.consul_count) : format(local.consul_server_command_template, i)]
+
+  // We use this command to generate the server certs dynamically before the servers start
+  // because we need to add the IP of the task as a SAN to the certificate, and we don't know that
+  // IP ahead of time.
+  consul_server_tls_init_command_template = <<EOF
+ECS_IPV4=$(curl -s $ECS_CONTAINER_METADATA_URI_V4 | jq -r '.Networks[0].IPv4Addresses[0]')
+cd /consul
+echo "$CONSUL_CACERT_PEM" > ./consul-agent-ca.pem
+echo "$CONSUL_CAKEY" > ./consul-agent-ca-key.pem
+consul tls cert create -server \
+  -node="${local.node_name}%s" \
+  -dc="${var.datacenter}" \
+  -additional-ipaddress=$ECS_IPV4 \
+  -additional-dnsname="${var.name}%s.${local.service_discovery_namespace}" \
+%{if length(var.additional_dns_names) > 0~}
+  %{for dnsname in var.additional_dns_names~}
+    -additional-dnsname="${dnsname}" \
+  %{endfor~}
+%{endif~}
+EOF
+
+  consul_portmap = [{
+    containerPort : 8300,
+    hostPort : 8300,
+    protocol : "tcp"
+    }, {
+    containerPort : 8301,
+    hostPort : 8301,
+    protocol : "tcp"
+    }, {
+    containerPort : 8302,
+    hostPort : 8302,
+    protocol : "tcp"
+    }, {
+    containerPort : 8500,
+    hostPort : 8500,
+    protocol : "tcp"
+    }, {
+    containerPort : 8501,
+    hostPort : 8501,
+    protocol : "tcp"
+    }, {
+    containerPort : 8502,
+    hostPort : 8502,
+    protocol : "tcp"
+    }, {
+    containerPort : 8600,
+    hostPort : 8600,
+    protocol : "udp"
+  }]
+  datadog_portmap = [{
+    containerPort : 8125,
+    hostPort : 8125,
+    protocol : "udp"
+  }]
+
+  use_docker_credentials = length(compact([var.docker_username, var.docker_password])) == 2 ? true : false
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Create TLS, Enterprise License, Bootstrap Token and Gossip-Key Secrets
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "certs" {
+  for_each                = local.certs
+  name                    = "${lower(var.name)}/${lower(var.datacenter)}/tls/${each.key}"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "certs" {
+  for_each      = local.certs
+  secret_id     = aws_secretsmanager_secret.certs[each.key].id
+  secret_string = templatefile("${path.root}/${each.value}", {})
+}
+
+// Optional Enterprise license.
+resource "aws_secretsmanager_secret" "license" {
+  count                   = local.consul_enterprise_enabled ? 1 : 0
+  name                    = "${lower(var.name)}/${lower(var.datacenter)}/consul-license"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "license" {
+  count         = local.consul_enterprise_enabled ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.license[count.index].id
+  secret_string = chomp(var.consul_license) // trim trailing newlines
+}
+
+resource "random_uuid" "bootstrap_token" {
+  count = local.generate_bootstrap_token ? 1 : 0
+}
+
+resource "aws_secretsmanager_secret" "bootstrap_token" {
+  count                   = local.generate_bootstrap_token ? 1 : 0
+  name                    = "${lower(var.name)}/${lower(var.datacenter)}/bootstrap-token"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "bootstrap_token" {
+  count         = local.generate_bootstrap_token ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.bootstrap_token[0].id
+  secret_string = local.bootstrap_token
+}
+
+resource "random_id" "gossip_key" {
+  count       = local.generate_gossip_key ? 1 : 0
+  byte_length = 32
+}
+
+resource "aws_secretsmanager_secret" "gossip_key" {
+  count                   = local.generate_gossip_key ? 1 : 0
+  name                    = "${lower(var.name)}/${lower(var.datacenter)}/gossip-key"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "gossip_key" {
+  count         = local.generate_gossip_key ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.gossip_key[count.index].id
+  secret_string = random_id.gossip_key[count.index].b64_std
+}
+
+resource "aws_secretsmanager_secret" "datadog_apikey" {
+  count                   = var.datadog_apikey == "" ? 0 : 1
+  name                    = "${lower(var.name)}/${lower(var.datacenter)}/datadog_apikey"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "datadog_apikey" {
+  count         = var.datadog_apikey == "" ? 0 : 1
+  secret_id     = aws_secretsmanager_secret.datadog_apikey[0].id
+  secret_string = var.datadog_apikey
+}
+
+resource "aws_secretsmanager_secret" "docker_key" {
+  count                   = local.use_docker_credentials ? 1 : 1
+  name                    = "${lower(var.name)}/${lower(var.datacenter)}/docker_key"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "docker_key" {
+  count     = local.use_docker_credentials ? 1 : 0
+  secret_id = aws_secretsmanager_secret.docker_key[0].id
+  secret_string = jsonencode({
+    username : var.docker_username
+    password : var.docker_password
+  })
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Create the EFS Cluster
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "consul-server-efs-cluster" {
+  source = "../efs-cluster"
+
+  name   = "${title(var.name)}FS"
+  count  = var.deploy_efs_cluster ? 1 : 0
+  vpc_id = var.vpc_id
+
+  access_point_config = { for k, v in local.server_map : k => {
+    owner_gid : v["owner_gid"]
+    owner_uid : v["owner_uid"]
+    permissions : v["permissions"]
+    subnet_id : var.private_subnet_ids[v["index"]]
+  } }
+}
+
+resource "aws_cloudwatch_dashboard" "consul-ecs-efs" {
+  count          = var.deploy_efs_cluster ? 1 : 0
+  dashboard_name = "${var.name}Dashboard"
+  dashboard_body = templatefile("${path.module}/templates/consul-ecs-efs-dashboard.json.j2", {
+    aws_region : data.aws_region.current.name
+    cluster_name : var.ecs_cluster_name
+    efs_filesystem_id : module.consul-server-efs-cluster[0].efs_id
+  })
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Create the Consul Server ECS Service, Tasks & IAM
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "container-logs" {
+  name              = "/ecs/${var.name}"
+  retention_in_days = var.ecs_log_retention_period
+}
+
+module "consul-server" {
+  source   = "../ecs-service"
+  for_each = local.server_map
+
+  name             = title(each.key)
+  ecs_cluster_name = var.ecs_cluster_name
+  subnet_ids       = [each.value["subnet_id"]]
+  vpc_id           = var.vpc_id
+
+  # health_check_grace_period_seconds  = 90
+  # Force ecs to retire the old container before the new one is started
+  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 0
+  # deployment_circuit_breaker_enable  = true
+  target_groups = {
+    consul8501 : {
+      protocol : "TCP"
+      port : 8500
+      arn : aws_lb_target_group.this[each.key].arn
+    }
+  }
+  service_registries = [{
+    registry_arn   = aws_service_discovery_service.server.arn
+    container_name = "consul-server"
+  }]
+  container_name = "consul-server"
+  sidecar_name   = var.datadog_apikey == "" ? null : "datadog"
+  cpu            = var.consul_container_cpu
+  memory         = var.consul_container_memory
+
+  cpu_architecture        = var.cpu_architecture
+  operating_system_family = var.operating_system_family
+
+  tags = {
+    "Consul-Auto-Join" : var.name
+  }
+
+  task_definition = concat(each.value["init"], [
+    {
+      name : "consul-server"
+      image : var.consul_image
+      repositoryCredentials : local.use_docker_credentials ? {
+        credentialsParameter : aws_secretsmanager_secret.docker_key[0].arn
+      } : null
+      cpu : var.consul_task_cpu
+      memory : var.consul_task_memory
+      essential : true
+      entryPoint : ["/bin/sh", "-ec"]
+      command : [replace(each.value["command"], "\r", "")]
+      linuxParameters : {
+        initProcessEnabled : true
+      }
+      dependsOn = var.tls ? [
+        {
+          containerName = "tls-init"
+          condition     = "SUCCESS"
+        },
+      ] : []
+      portMappings : local.consul_portmap
+      volumesFrom : []
+      mountPoints : var.deploy_efs_cluster ? [
+        {
+          containerPath : "/consul"
+          sourceVolume : each.key
+          readOnly : false
+        }
+      ] : []
+      secrets : concat(
+        var.gossip_encryption_enabled ? [
+          {
+            name      = "CONSUL_GOSSIP_ENCRYPTION_KEY"
+            valueFrom = local.gossip_key_arn
+          },
+        ] : [],
+        var.acls ? [
+          {
+            name      = "CONSUL_HTTP_TOKEN"
+            valueFrom = local.bootstrap_token_arn
+          },
+        ] : [],
+        local.consul_enterprise_enabled ? [
+          {
+            name      = "CONSUL_LICENSE"
+            valueFrom = aws_secretsmanager_secret.license[0].arn
+          },
+        ] : [],
+      )
+      healthCheck : {
+        retries : 3,
+        command : ["CMD-SHELL", "curl http://127.0.0.1:8500/v1/status/leader"],
+        timeout : 5,
+        interval : 30,
+        startPeriod : 15,
+      }
+      logConfiguration : {
+        logDriver : "awslogs",
+        options : {
+          awslogs-group : aws_cloudwatch_log_group.container-logs.name,
+          awslogs-region : data.aws_region.current.name,
+          awslogs-stream-prefix : "consul"
+        }
+      }
+    }
+    ], var.datadog_apikey == "" ? [] : [{
+      name : "datadog"
+      image : "public.ecr.aws/datadog/agent:7"
+      cpu : var.datadog_task_cpu
+      memory : var.datadog_task_memory
+      essential : false
+      portMappings : local.datadog_portmap
+      environment : [
+        {
+          name : "ECS_FARGATE"
+          value : "true"
+        },
+        {
+          name : "DD_DOGSTATSD_NON_LOCAL_TRAFFIC"
+          value : "true"
+        },
+      ]
+      volumesFrom : []
+      mountPoints : []
+      secrets : [
+        {
+          name : "DD_API_KEY",
+          valueFrom : aws_secretsmanager_secret.datadog_apikey[0].arn
+        }
+      ]
+      healthCheck : {
+        retries : 3,
+        command : ["CMD-SHELL", "agent health"],
+        timeout : 5,
+        interval : 30,
+        startPeriod : 15,
+      }
+      logConfiguration : {
+        logDriver : "awslogs",
+        options : {
+          awslogs-group : aws_cloudwatch_log_group.container-logs.name,
+          awslogs-region : data.aws_region.current.name,
+          awslogs-stream-prefix : "datadog"
+        }
+      }
+    }
+  ])
+  efs_volumes = var.deploy_efs_cluster ? {
+    (each.key) : {
+      file_system_id : module.consul-server-efs-cluster[0].efs_id
+      access_point_id : module.consul-server-efs-cluster[0].access_point_ids[each.value["index"]]
+      root_directory : "/"
+      transit_encryption : "ENABLED"
+      encryption_port : 2049
+      iam : "DISABLED"
+    }
+  } : {}
+  security_group_ids = compact([
+    aws_security_group.ecs_service.id,
+    var.deploy_efs_cluster ? module.consul-server-efs-cluster[0].efs_client_security_group_id : null,
+  ])
+  ecs_execution_role_arn = aws_iam_role.this_execution.arn
+  ecs_task_role_arn      = aws_iam_role.this_task.arn
+  ecs_task_role_id       = aws_iam_role.this_task.id
+
+  depends_on = [
+    aws_lb_target_group.this
+  ]
+}
+
+resource "aws_iam_policy" "this_execution" {
+  name        = "${var.name}_execution"
+  path        = "/ecs/"
+  description = "Consul server execution"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:DescribeKey"
+      ],
+      "Resource": [
+        "${data.aws_kms_alias.secretsmanager.arn}",
+        "${data.aws_kms_alias.secretsmanager.target_key_arn}"
+      ]
+    },
+%{if var.tls~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${lower(var.name)}/${lower(var.datacenter)}/tls/*"
+      ]
+    },
+%{endif~}
+%{if var.acls~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${local.bootstrap_token_arn}"
+      ]
+    },
+%{endif~}
+%{if local.consul_enterprise_enabled~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${aws_secretsmanager_secret.license[0].arn}"
+      ]
+    },
+%{endif~}
+%{if var.gossip_encryption_enabled~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${local.gossip_key_arn}"
+      ]
+    },
+%{endif~}
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "this_execution" {
+  name = "${var.name}_execution"
+  path = "/ecs/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "this_execution" {
+  role       = aws_iam_role.this_execution.id
+  policy_arn = aws_iam_policy.this_execution.arn
+}
+
+resource "aws_iam_role" "this_task" {
+  name = "${var.name}_task"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  inline_policy {
+    name = "exec"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel"
+          ]
+          Resource = "*"
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "elasticfilesystem:ClientMount",
+            "elasticfilesystem:ClientWrite",
+            "elasticfilesystem:ClientRootAccess",
+          ]
+          Resource = [
+            module.consul-server-efs-cluster[0].efs_arn
+          ]
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "ecs:ListClusters",
+            "ecs:ListServices",
+            "ecs:DescribeServices",
+            "ecs:ListTasks",
+            "ecs:DescribeTasks",
+            "ecs:ListContainerInstances",
+            "ecs:DescribeContainerInstances",
+            "ec2:DescribeNetworkInterfaces",
+          ]
+          Resource = "*"
+        },
+      ]
+    })
+  }
+}
+
+#data "aws_iam_policy_document" "ecs_efs_access" {
+#  count = var.deploy_efs_cluster ? 1 : 0
+#  statement {
+#    sid    = "${title(replace(var.name, "-", ""))}EfsAccess"
+#    effect = "Allow"
+#    actions = [
+#      "elasticfilesystem:ClientMount",
+#      "elasticfilesystem:ClientWrite",
+#      "elasticfilesystem:ClientRootAccess",
+#    ]
+#    resources = [
+#      module.consul-server-efs-cluster[0].efs_arn
+#    ]
+#  }
+#}
+#
+#resource "aws_iam_role_policy" "ecs_efs_access" {
+#  count  = var.deploy_efs_cluster ? 1 : 0
+#  name   = "${title(replace(var.name, "-", ""))}EfsAccess"
+#  policy = data.aws_iam_policy_document.ecs_efs_access[0].json
+#  role   = aws_iam_role.this_task.id
+#}
+#
+#data "aws_iam_policy_document" "ecs_auto_discover" {
+#  statement {
+#    sid    = "${title(replace(var.name, "-", ""))}AutoDiscover"
+#    effect = "Allow"
+#    actions = [
+#      "ecs:ListClusters",
+#      "ecs:ListServices",
+#      "ecs:DescribeServices",
+#      "ecs:ListTasks",
+#      "ecs:DescribeTasks",
+#      "ecs:DescribeContainerInstances",
+#      "ec2:DescribeNetworkInterfaces",
+#    ]
+#    resources = ["*"]
+#  }
+#}
+#
+#resource "aws_iam_role_policy" "ecs_auto_discover" {
+#  name   = "${title(replace(var.name, "-", ""))}AutoDiscover"
+#  policy = data.aws_iam_policy_document.ecs_auto_discover.json
+#  role   = aws_iam_role.this_task.id
+#}
+#
+#data "aws_iam_policy_document" "ecs_datadog" {
+#  statement {
+#    sid    = "${title(replace(var.name, "-", ""))}Datadog"
+#    effect = "Allow"
+#    actions = [
+#      "ecs:ListClusters",
+#      "ecs:ListContainerInstances",
+#      "ecs:DescribeContainerInstances",
+#    ]
+#    resources = ["*"]
+#  }
+#}
+#
+#resource "aws_iam_role_policy" "ecs_datadog" {
+#  name   = "${title(replace(var.name, "-", ""))}Datadog"
+#  policy = data.aws_iam_policy_document.ecs_auto_discover.json
+#  role   = aws_iam_role.this_task.id
+#}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Add Consul to AWS Service Discovery
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_service_discovery_private_dns_namespace" "server" {
+  name        = local.service_discovery_namespace
+  description = "The domain name for the Consul dev server in ${var.datacenter}."
+  vpc         = var.vpc_id
+}
+
+resource "aws_service_discovery_service" "server" {
+  name = var.name
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.server.id
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ALB & Security Groups
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_lb" "this" {
+  count              = var.lb_enabled ? 1 : 0
+  name               = var.name
+  internal           = var.internal_alb_listener
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.load_balancer[0].id]
+  #subnets            = var.internal_alb_listener ? var.private_subnet_ids : var.public_subnet_ids
+
+  access_logs {
+    enabled = false
+    bucket  = ""
+  }
+
+  dynamic "subnet_mapping" {
+    for_each = var.internal_alb_listener ? var.private_subnet_ids : var.public_subnet_ids
+    content {
+      subnet_id  = subnet_mapping.value
+      outpost_id = null
+    }
+  }
+
+  tags = {}
+}
+
+resource "aws_iam_server_certificate" "alb-cert" {
+  count            = var.lb_enabled ? 1 : 0
+  name             = "${var.name}_alb_certificate"
+  certificate_body = aws_secretsmanager_secret_version.certs["CONSUL_ALB_CERT"].secret_string
+  private_key      = aws_secretsmanager_secret_version.certs["CONSUL_ALB_KEY"].secret_string
+}
+
+resource "aws_lb_target_group" "this" {
+  for_each    = var.lb_enabled ? local.server_map : {}
+  name        = title(each.key)
+  port        = 8500
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    path                = "/v1/status/leader"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 2
+    interval            = 5
+  }
+}
+
+resource "aws_lb_listener" "this" {
+  count             = var.lb_enabled ? 1 : 0
+  load_balancer_arn = aws_lb.this[0].arn
+  port              = "8501"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-2019-08"
+  certificate_arn   = aws_iam_server_certificate.alb-cert[0].arn
+
+  default_action {
+    type = "forward"
+    forward {
+      dynamic "target_group" {
+        for_each = aws_lb_target_group.this
+        content {
+          arn = aws_lb_target_group.this[target_group.key].arn
+        }
+      }
+    }
+  }
+  depends_on = [
+    aws_iam_server_certificate.alb-cert
+  ]
+}
+
+resource "aws_security_group" "load_balancer" {
+  count  = var.lb_enabled ? 1 : 0
+  name   = "${var.name}-lb-sg"
+  vpc_id = var.vpc_id
+
+  ingress {
+    description     = "Access to Consul dev server HTTP API and UI."
+    from_port       = 8500
+    to_port         = 8501
+    protocol        = "tcp"
+    cidr_blocks     = var.lb_ingress_rule_cidr_blocks
+    security_groups = var.lb_ingress_rule_security_groups
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ecs_service" {
+  name   = "${var.name}-ecs-sg"
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group_rule" "ecs_service_self" {
+  description       = "Allow Consul Servers to speak with each other on all ports and protocols."
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  self              = true
+  security_group_id = aws_security_group.ecs_service.id
+}
+
+resource "aws_security_group_rule" "lb_ingress_to_service" {
+  count = var.lb_enabled ? 1 : 0
+
+  description              = "Access to Consul dev server from security group attached to load balancer"
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  source_security_group_id = aws_security_group.load_balancer[0].id
+  security_group_id        = aws_security_group.ecs_service.id
+}
+
+
+resource "aws_security_group_rule" "egress_from_service" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.ecs_service.id
+}
+

--- a/modules/ha-cluster/outputs.tf
+++ b/modules/ha-cluster/outputs.tf
@@ -1,0 +1,60 @@
+output "gossip_key_arn" {
+  value = local.generate_gossip_key ? aws_secretsmanager_secret.gossip_key[0].arn : null
+}
+
+output "gossip_key" {
+  value     = local.generate_gossip_key ? random_id.gossip_key[0].b64_std : null
+  sensitive = true
+}
+
+output "bootstrap_token_arn" {
+  value = local.generate_bootstrap_token ? aws_secretsmanager_secret.bootstrap_token[0].arn : null
+}
+
+output "bootstrap_token" {
+  value = local.generate_bootstrap_token ? random_uuid.bootstrap_token[0].result : null
+}
+
+output "ca_cert_arn" {
+  value = var.tls ? local.generate_ca ? aws_secretsmanager_secret.certs["CONSUL_CA"].arn : null : null
+}
+
+output "ca_key_arn" {
+  value = var.tls ? local.generate_ca ? aws_secretsmanager_secret.certs["CONSUL_CA_KEY"].arn : null : null
+}
+
+output "alb_iam_cert_arn" {
+  value = var.tls ? local.generate_ca ? aws_iam_server_certificate.alb-cert[0].arn : null : null
+}
+
+output "client_cert_arn" {
+  value = var.tls ? local.generate_ca ? aws_secretsmanager_secret.certs["CONSUL_CLIENT_CERT"].arn : null : null
+}
+
+output "client_key_arn" {
+  value = var.tls ? local.generate_ca ? aws_secretsmanager_secret.certs["CONSUL_CLIENT_KEY"].arn : null : null
+}
+
+output "datadog_apikey_arn" {
+  value = var.datadog_apikey == "" ? null : aws_secretsmanager_secret.datadog_apikey[0].arn
+}
+
+output "consul_server_security_group_id" {
+  value = aws_security_group.ecs_service.id
+}
+
+output "cloudwatch_log_group_name" {
+  value = aws_cloudwatch_log_group.container-logs.name
+}
+
+output "mgmt_alb_arn" {
+  value = var.lb_enabled ? aws_lb.this[0].arn : null
+}
+
+output "mgmt_alb_dns_name" {
+  value = var.lb_enabled ? aws_lb.this[0].dns_name : null
+}
+
+output "mgmt_alb_security_group_id" {
+  value = var.lb_enabled ? aws_security_group.load_balancer[0].id : null
+}

--- a/modules/ha-cluster/templates/consul-ecs-efs-dashboard.json.j2
+++ b/modules/ha-cluster/templates/consul-ecs-efs-dashboard.json.j2
@@ -1,0 +1,293 @@
+{
+    "widgets": [
+        {
+            "height": 6,
+            "width": 8,
+            "y": 0,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "region": "${aws_region}",
+                "title": "CPU Utilization",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "metrics": [
+                    [ { "id": "expr1m0", "label": "${cluster_name}", "expression": "mm1m0 * 100 / mm0m0", "stat": "Average" } ],
+                    [ "ECS/ContainerInsights", "CpuReserved", "ClusterName", "${cluster_name}", { "id": "mm0m0", "visible": false, "stat": "Sum" } ],
+                    [ ".", "CpuUtilized", ".", ".", { "id": "mm1m0", "visible": false, "stat": "Sum" } ]
+                ],
+                "liveData": false,
+                "period": 60,
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "showUnits": false,
+                        "label": "Percent"
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 0,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "region": "${aws_region}",
+                "title": "Memory Utilization",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "metrics": [
+                    [ { "id": "expr1m0", "label": "${cluster_name}", "expression": "mm1m0 * 100 / mm0m0", "stat": "Average" } ],
+                    [ "ECS/ContainerInsights", "MemoryReserved", "ClusterName", "${cluster_name}", { "id": "mm0m0", "visible": false, "stat": "Sum" } ],
+                    [ ".", "MemoryUtilized", ".", ".", { "id": "mm1m0", "visible": false, "stat": "Sum" } ]
+                ],
+                "liveData": false,
+                "period": 60,
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "showUnits": false,
+                        "label": "Percent"
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 0,
+            "x": 16,
+            "type": "metric",
+            "properties": {
+                "region": "${aws_region}",
+                "title": "Network",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "metrics": [
+                    [ { "id": "expr1m0", "label": "${cluster_name}", "expression": "mm0m0 + mm1m0", "stat": "Average" } ],
+                    [ "ECS/ContainerInsights", "NetworkRxBytes", "ClusterName", "${cluster_name}", { "id": "mm0m0", "visible": false, "stat": "Average" } ],
+                    [ ".", "NetworkTxBytes", ".", ".", { "id": "mm1m0", "visible": false, "stat": "Average" } ]
+                ],
+                "liveData": false,
+                "period": 60,
+                "yAxis": {
+                    "left": {
+                        "showUnits": false,
+                        "label": "Bytes/Second"
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 6,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "region": "${aws_region}",
+                "title": "Container Instance Count",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "metrics": [
+                    [ "ECS/ContainerInsights", "ContainerInstanceCount", "ClusterName", "${cluster_name}", { "stat": "Average" } ]
+                ],
+                "liveData": false,
+                "period": 60
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 6,
+            "x": 16,
+            "type": "metric",
+            "properties": {
+                "region": "${aws_region}",
+                "title": "Task Count",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "metrics": [
+                    [ "ECS/ContainerInsights", "TaskCount", "ClusterName", "${cluster_name}", { "stat": "Average" } ]
+                ],
+                "liveData": false,
+                "period": 60
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 6,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "region": "${aws_region}",
+                "title": "Service Count",
+                "legend": {
+                    "position": "bottom"
+                },
+                "timezone": "Local",
+                "metrics": [
+                    [ "ECS/ContainerInsights", "ServiceCount", "ClusterName", "${cluster_name}", { "stat": "Average" } ]
+                ],
+                "liveData": false,
+                "period": 60
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 12,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "(m1/1048576)/PERIOD(m1)", "label": "Expression1", "id": "e1", "visible": false } ],
+                    [ { "expression": "m2/1048576", "label": "Expression2", "id": "e2", "visible": false } ],
+                    [ { "expression": "e2-e1", "label": "Expression3", "id": "e3", "visible": false } ],
+                    [ { "expression": "((e1)*100)/(e2)", "label": "Throughput utilization (%)", "id": "e4" } ],
+                    [ "AWS/EFS", "MeteredIOBytes", "FileSystemId", "${efs_filesystem_id}", { "id": "m1", "period": 60, "visible": false } ],
+                    [ ".", "PermittedThroughput", ".", ".", { "id": "m2", "period": 60, "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${aws_region}",
+                "stat": "Sum",
+                "period": 60,
+                "title": "Throughput utilization (%)",
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "visible": true,
+                            "color": "#d13212",
+                            "label": "Utilization warning",
+                            "value": 75,
+                            "fill": "above",
+                            "yAxis": "left"
+                        }
+                    ]
+                },
+                "yAxis": {
+                    "left": {
+                        "max": 100
+                    }
+                }
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 12,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "(m2*100)/m1", "label": "Data write", "id": "e2" } ],
+                    [ { "expression": "(m3*100)/m1", "label": "Data read", "id": "e3" } ],
+                    [ { "expression": "(m4*100)/m1", "label": "Metadata", "id": "e4" } ],
+                    [ "AWS/EFS", "TotalIOBytes", "FileSystemId", "${efs_filesystem_id}", { "id": "m1", "visible": false } ],
+                    [ ".", "DataWriteIOBytes", ".", ".", { "id": "m2", "visible": false } ],
+                    [ ".", "DataReadIOBytes", ".", ".", { "id": "m3", "visible": false } ],
+                    [ ".", "MetadataIOBytes", ".", ".", { "id": "m4", "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${aws_region}",
+                "stat": "SampleCount",
+                "period": 60,
+                "title": "IOPS by type"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 18,
+            "x": 16,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ { "expression": "(m2*100)/m1", "label": "Data write", "id": "e2" } ],
+                    [ { "expression": "(m3*100)/m1", "label": "Data read", "id": "e3" } ],
+                    [ { "expression": "(m4*100)/m1", "label": "Metadata", "id": "e4" } ],
+                    [ "AWS/EFS", "TotalIOBytes", "FileSystemId", "${efs_filesystem_id}", { "id": "m1", "visible": false } ],
+                    [ ".", "DataWriteIOBytes", ".", ".", { "id": "m2", "visible": false } ],
+                    [ ".", "DataReadIOBytes", ".", ".", { "id": "m3", "visible": false } ],
+                    [ ".", "MetadataIOBytes", ".", ".", { "id": "m4", "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${aws_region}",
+                "stat": "Sum",
+                "period": 60,
+                "title": "Throughput by type"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 18,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "view": "timeSeries",
+                "stacked": false,
+                "metrics": [
+                    [ "AWS/EFS", "PercentIOLimit", "FileSystemId", "${efs_filesystem_id}", { "label": "${efs_filesystem_id}" } ]
+                ],
+                "region": "${aws_region}",
+                "title": "Percent IO limit"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 12,
+            "x": 16,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/EFS", "ClientConnections", "FileSystemId", "${efs_filesystem_id}", { "label": "${efs_filesystem_id}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${aws_region}",
+                "stat": "Sum",
+                "period": 60,
+                "title": "Client connections"
+            }
+        },
+        {
+            "height": 6,
+            "width": 8,
+            "y": 18,
+            "x": 8,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/EFS", "StorageBytes", "StorageClass", "Total", "FileSystemId", "${efs_filesystem_id}", { "id": "mTotal", "visible": false } ],
+                    [ { "expression": "IF(mTotal > 1000, IF(mTotal > 1000000, IF(mTotal > 1000000000, IF(mTotal > 1000000000000, IF(mTotal > 1000000000000000, 1, mTotal*0.9094947), mTotal*0.9313226), mTotal*0.9536743), mTotal*0.9765625), mTotal)", "label": "Total" } ],
+                    [ "AWS/EFS", "StorageBytes", "StorageClass", "Standard", "FileSystemId", "${efs_filesystem_id}", { "id": "mStandard", "visible": false } ],
+                    [ { "expression": "IF(mStandard > 1000, IF(mStandard > 1000000, IF(mStandard > 1000000000, IF(mStandard > 1000000000000, IF(mStandard > 1000000000000000, 1, mStandard*0.9094947), mStandard*0.9313226), mStandard*0.9536743), mStandard*0.9765625), mStandard)", "label": "Standard" } ],
+                    [ "AWS/EFS", "StorageBytes", "StorageClass", "IA", "FileSystemId", "${efs_filesystem_id}", { "id": "mIA", "visible": false } ],
+                    [ { "expression": "IF(mIA > 1000, IF(mIA > 1000000, IF(mIA > 1000000000, IF(mIA > 1000000000000, IF(mIA > 1000000000000000, 1, mIA*0.9094947), mIA*0.9313226), mIA*0.9536743), mIA*0.9765625), mIA)", "label": "Standard-IA" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${aws_region}",
+                "title": "Storage bytes"
+            }
+        }
+    ]
+}

--- a/modules/ha-cluster/variables.tf
+++ b/modules/ha-cluster/variables.tf
@@ -1,0 +1,328 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name to be used on all the resources as identifier."
+  type        = string
+  default     = "consul-example"
+}
+
+variable "aws_region" {
+  description = "What region the cluster and resources will be deployed into."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_id" {
+  description = "The ID of the existing VPC."
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "The existing VPC Private Subnets. Should be at least 3 and should match server count."
+  type        = list(string)
+}
+
+variable "public_subnet_ids" {
+  description = "The existing VPC Public Subnets. Should be at least 3 and should match server count."
+  type        = list(string)
+}
+
+variable "consul_image" {
+  type        = string
+  description = "Name of the Consul Agent Docker Image"
+  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+}
+
+variable "operating_system_family" {
+  default = "LINUX"
+}
+
+variable "cpu_architecture" {
+  default = "X86_64"
+}
+
+variable "docker_username" {
+  type        = string
+  description = "Username for Docker Hub authentication."
+  default     = null
+}
+
+variable "docker_password" {
+  type        = string
+  description = "Password (or token) for Docker Hub authentication."
+  default     = null
+}
+
+variable "lb_enabled" {
+  description = "Whether to create an ALB for the server task. Useful for accessing the UI."
+  type        = bool
+  default     = true
+}
+
+variable "internal_alb_listener" {
+  type        = bool
+  description = "ALB is internal-only to reduce load-test costs. When false the ALB will be accessible over the public network."
+  default     = true
+}
+
+variable "deploy_efs_cluster" {
+  type        = bool
+  description = "Deploy EFS Cluster for Consul data storage? Default is true."
+  default     = true
+}
+
+variable "ecs_cluster_name" {
+  description = "Specify an ECS cluster name to deploy the consul services."
+  default     = null
+}
+
+variable "create_ecs_log_group" {
+  description = "Create an ECS Log Group for the containers. Default is True"
+  default     = true
+}
+
+variable "ecs_log_retention_period" {
+  description = "Specify a log retnetion period in days. Default is 7."
+  default     = 7
+}
+
+variable "consul_container_cpu" {
+  description = "Set the Consul Container total CPU limit. Default is 2048."
+  default     = 2048
+}
+
+variable "consul_container_memory" {
+  description = "Set the Consul Cotainer total Memory limit. Default is 4096."
+  default     = 4096
+}
+
+variable "consul_task_cpu" {
+  description = "Set the Consul Server task CPU limit. Default is 1792."
+  default     = 1792
+}
+
+variable "consul_task_memory" {
+  description = "Set the Consul Server container Memory limit. Default is 3584."
+  default     = 3584
+}
+
+variable "datadog_task_cpu" {
+  description = "Set the Consul Server task CPU limit. Default is 1792."
+  default     = 256
+}
+
+variable "datadog_task_memory" {
+  description = "Set the Consul Server container Memory limit. Default is 3584."
+  default     = 512
+}
+
+variable "aws_auto_join" {
+  description = "Enable AWS Auto-Join based on ECS Tag value."
+  default     = true
+}
+
+variable "raft_multiplier" {
+  description = "The Consul Performance Raft-Multiplier. Default is 1."
+  default     = 1
+}
+
+variable "run_k6" {
+  type    = bool
+  default = false
+}
+
+variable "k6_apikey" {
+  description = "K6 API key"
+  type        = string
+  default     = ""
+}
+
+variable "datadog_apikey" {
+  description = "Datadog API key"
+  type        = string
+  default     = ""
+}
+
+variable "lb_ingress_rule_cidr_blocks" {
+  description = "CIDR blocks that are allowed access to the load balancer."
+  type        = list(string)
+  default     = null
+}
+
+variable "lb_ingress_rule_security_groups" {
+  description = "Security groups that are allowed access to the load balancer."
+  type        = list(string)
+  default     = null
+}
+
+variable "consul_count" {
+  description = "Number of consul servers to deploy. Default 3"
+  default     = 3
+}
+
+variable "consul_license" {
+  description = "A Consul Enterprise license key. Requires consul_image to be set to a Consul Enterprise image."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "service_discovery_namespace" {
+  description = "The namespace where the Consul server service will be registered with AWS Cloud Map. Defaults to the Consul server domain name: server.<datacenter>.<domain>."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "launch_type" {
+  description = "Launch type on which to run service. Valid values are EC2 and FARGATE."
+  type        = string
+  default     = "EC2"
+}
+
+variable "assign_public_ip" {
+  description = "Assign a public IP address to the ENI. If running in public subnets this is required so that ECS can pull the Docker images."
+  type        = bool
+  default     = false
+}
+
+variable "tls" {
+  description = "Whether to enable TLS on the server for the control plane traffic."
+  type        = bool
+  default     = false
+}
+
+variable "generate_ca" {
+  description = "Controls whether or not a CA key and certificate will automatically be created and stored in Secrets Manager. Default is true. Set this to false and set ca_cert_arn and ca_key_arn to provide pre-existing secrets."
+  type        = bool
+  default     = true
+}
+
+variable "ca_cert_arn" {
+  description = "The Secrets Manager ARN of the Consul CA certificate."
+  type        = string
+  default     = ""
+}
+
+variable "ca_key_arn" {
+  description = "The Secrets Manager ARN of the Consul CA certificate key."
+  type        = string
+  default     = ""
+}
+
+variable "gossip_encryption_enabled" {
+  description = "Whether or not to enable gossip encryption."
+  type        = bool
+  default     = false
+}
+
+variable "generate_gossip_encryption_key" {
+  description = "Controls whether or not a gossip encryption key will automatically be created and stored in Secrets Manager. Default is true. Set this to false and set gossip_key_secret_arn to provide a pre-existing secret."
+  type        = bool
+  default     = true
+}
+
+variable "gossip_key_secret_arn" {
+  description = "The ARN of the Secrets Manager secret containing the Consul gossip encryption key. A gossip encryption key will automatically be created and stored in Secrets Manager if gossip encryption is enabled and this variable is not provided."
+  type        = string
+  default     = ""
+}
+
+variable "acls" {
+  description = "Whether to enable ACLs on the server."
+  type        = bool
+  default     = false
+}
+
+variable "generate_bootstrap_token" {
+  description = "Whether to automatically generate a bootstrap token."
+  type        = bool
+  default     = true
+}
+
+variable "bootstrap_token" {
+  description = "The Consul bootstrap token. By default a bootstrap token will be generated automatically. This field can be used to explicity set the value of the bootstrap token."
+  type        = string
+  default     = ""
+}
+
+variable "bootstrap_token_arn" {
+  description = "The ARN of the Secrets Manager secret containing the Consul bootstrap token. By default a secret will be created automatically."
+  type        = string
+  default     = ""
+}
+
+variable "wait_for_steady_state" {
+  description = "Set wait_for_steady_state on the ECS service. This causes Terraform to wait for the Consul server task to be deployed."
+  type        = bool
+  default     = false
+}
+
+variable "datacenter" {
+  description = "Consul datacenter. Defaults to 'dc1'."
+  type        = string
+  default     = "dc1"
+}
+
+variable "node_name" {
+  description = "Node name of the Consul server. Defaults to the value of 'var.name'."
+  type        = string
+  default     = ""
+}
+
+variable "primary_datacenter" {
+  description = "Consul primary datacenter. Required when joining Consul datacenters via mesh gateways. All datacenters are required to use the same primary datacenter."
+  type        = string
+  default     = ""
+}
+
+variable "retry_join_wan" {
+  description = "List of WAN addresses to join for Consul cluster peering. Must not be provided when using mesh-gateway WAN federation."
+  type        = list(string)
+  default     = []
+}
+
+variable "primary_gateways" {
+  description = "List of WAN addresses of the primary mesh gateways for Consul servers in secondary datacenters to use to reach the Consul servers in the primary datcenter."
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_mesh_gateway_wan_federation" {
+  description = "Controls whether or not WAN cluster peering via mesh gateways is enabled. Default is false."
+  type        = bool
+  default     = false
+}
+
+variable "additional_dns_names" {
+  description = "List of additional DNS names to add to the Subject Alternative Name (SAN) field of the server's certificate."
+  type        = list(string)
+  default     = []
+}
+
+variable "replication_token" {
+  description = "Replication token required for ACL replication in secondary datacenters. See https://www.consul.io/docs/security/acl/acl-federated-datacenters."
+  type        = string
+  default     = ""
+}
+
+locals {
+  retry_join_wan_xor_primary_gateways = length(var.retry_join_wan) > 0 && length(var.primary_gateways) > 0 ? file("ERROR: Only one of retry_join_wan or primary_gateways may be provided.") : null
+}

--- a/modules/lambda-k6/container/Dockerfile
+++ b/modules/lambda-k6/container/Dockerfile
@@ -1,0 +1,18 @@
+FROM amazonlinux:2 as k6bin
+ARG K6_VERSION=v0.41.0
+
+RUN yum update -y \
+ && yum install -y curl tar gzip zip
+
+RUN curl -O -L "https://github.com/grafana/k6/releases/download/${K6_VERSION}/k6-${K6_VERSION}-linux-amd64.tar.gz"  \
+ && tar -xvf k6-${K6_VERSION}-linux-amd64.tar.gz \
+ && mv /k6-${K6_VERSION}-linux-amd64/k6 /usr/local/bin/
+
+
+FROM public.ecr.aws/lambda/nodejs:14
+
+COPY --from=k6bin /usr/local/bin/k6 /usr/local/bin/
+COPY index.js loadtest.js service.json ${LAMBDA_TASK_ROOT}
+
+WORKDIR /var/task
+CMD ["index.handler"]

--- a/modules/lambda-k6/container/index.js
+++ b/modules/lambda-k6/container/index.js
@@ -1,0 +1,5 @@
+const { execSync } = require('child_process')
+
+exports.handler = async (event) => {
+  execSync('k6 run loadtest.js', { encoding: 'utf8', stdio: 'inherit' })
+}

--- a/modules/lambda-k6/container/loadtest.js
+++ b/modules/lambda-k6/container/loadtest.js
@@ -1,0 +1,48 @@
+import http from 'k6/http';
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.0.0/index.js";
+import { check, fail } from 'k6';
+
+let data = JSON.parse(open('service.json'));
+
+
+export default function() {
+
+  const key = uuidv4();
+  const ipaddress = `https://${__ENV.LB_ENDPOINT}:8500`;
+  const kv_uri = '/v1/kv/';
+  const value = { data: uuidv4() };
+  const kv_address = `${ipaddress + kv_uri + key}`
+  
+  //Put valid K/V
+  let kvres = http.put(kv_address, JSON.stringify(value));
+  if (
+    !check(kvres, {
+      'kv status code MUST be 200': (kvres) => kvres.status === 200,
+    })
+  ) {
+    fail(`registry check status code was *not* 200. error: ${kvres.error}. body: ${kvres.body}`)
+  }
+
+  //Register Service
+  data["Name"] = key;
+  const service_uri = '/v1/agent/service/register';
+
+  const service_address = `${ipaddress + service_uri }`
+  let servres = http.put(service_address, JSON.stringify(data));
+  if (
+    !check(servres, {
+      'register service status code MUST be 200': (servres) => servres.status === 200,
+    })
+  ) {
+    fail(`registry check status code was *not* 200. error: ${servres.error}. body: ${servres.body}`)
+  }
+}
+
+export let options = {
+  // 25 virtual users
+  vus: 25,
+  // 10 minute
+  duration: "10m",
+  // 95% of requests must complete below 2.5s
+  thresholds: { http_req_duration: ["p(95)<2500"] },
+};

--- a/modules/lambda-k6/container/service.json
+++ b/modules/lambda-k6/container/service.json
@@ -1,0 +1,16 @@
+{
+  "Address": "127.0.0.1",
+  "Port": 8000,
+  "Meta": {
+    "redis_version": "4.0"
+  },
+  "Check": {
+    "HTTP": "https://example.com:850040220",
+    "Method": "POST",
+    "Header": {"Content-Type": ["application/json"]},
+    "Body": "{\"method\":\"health\"}",
+    "Timeout": "5s",
+    "DeregisterCriticalServiceAfter": "2m",
+    "Interval": "10s"
+  }
+}

--- a/modules/lambda-k6/main.tf
+++ b/modules/lambda-k6/main.tf
@@ -1,0 +1,155 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${var.name}"
+  retention_in_days = 0
+}
+
+resource "aws_ecr_repository" "this" {
+  name                 = lower(var.name)
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+}
+
+resource "null_resource" "this" {
+  provisioner "local-exec" {
+    environment = {
+      K6_VERSION = var.k6_version
+    }
+    command = <<EOF
+docker build --platform linux/amd64 -t k6:local ${path.module}/container && \
+docker tag k6:local "${aws_ecr_repository.this.repository_url}:latest" && \
+aws ecr get-login-password \
+  --region ${data.aws_region.current.name} | \
+docker login --username AWS --password-stdin \
+  ${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com && \
+docker push ${aws_ecr_repository.this.repository_url}:latest
+EOF
+  }
+
+  depends_on = [
+    aws_ecr_repository.this
+  ]
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = title(var.name)
+  role          = aws_iam_role.assume.arn
+  image_uri     = "${aws_ecr_repository.this.repository_url}:latest"
+  memory_size   = 256
+  timeout       = 900
+
+  #source_code_hash = filebase64sha256("${path.root}/k6-amazon2.zip")
+  package_type = "Image"
+  publish      = true
+
+  #  layers = [
+  #    aws_lambda_layer_version.this.id,
+  #  ]
+
+  vpc_config {
+    subnet_ids = var.subnets
+    security_group_ids = [
+      aws_security_group.this.id
+    ]
+  }
+
+  environment {
+    variables = {
+      LB_ENDPOINT                 = var.target
+      K6_CLOUD_TOKEN              = var.apikey
+      K6_INSECURE_SKIP_TLS_VERIFY = true
+      XDG_CONFIG_HOME             = "/var/task"
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.this,
+    aws_ecr_repository.this,
+    null_resource.this,
+  ]
+}
+
+resource "aws_security_group" "this" {
+  name   = "${title(var.name)}Access"
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group_rule" "egress_all" {
+  security_group_id = aws_security_group.this.id
+  type              = "egress"
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 65535
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      identifiers = ["lambda.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "assume" {
+  name               = "${title(var.name)}Assume"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+data "aws_iam_policy_document" "execution" {
+  statement {
+    sid = "AWSLambdaBasicExecutionRole"
+
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "execution" {
+  name   = "${title(var.name)}Execution"
+  policy = data.aws_iam_policy_document.execution.json
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.assume.name
+  policy_arn = aws_iam_policy.execution.arn
+}
+
+resource "aws_iam_policy" "logging" {
+  name        = "lambda_logging"
+  path        = "/"
+  description = "IAM policy for logging from a lambda"
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Action : [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Resource : "arn:aws:logs:*:*:*",
+        Effect : "Allow"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "logs" {
+  role       = aws_iam_role.assume.name
+  policy_arn = aws_iam_policy.logging.arn
+}

--- a/modules/lambda-k6/outputs.tf
+++ b/modules/lambda-k6/outputs.tf
@@ -1,0 +1,7 @@
+output "function_name" {
+  value = aws_lambda_function.this.function_name
+}
+
+output "security_group_id" {
+  value = aws_security_group.this.id
+}

--- a/modules/lambda-k6/variables.tf
+++ b/modules/lambda-k6/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  default = "k6Lambda"
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "apikey" {
+  default = ""
+}
+
+variable "target" {
+  type = string
+}
+
+variable "k6_version" {
+  description = "Release Tag. https://github.com/grafana/k6/releases"
+  type        = string
+  default     = "v0.41.0"
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- add an additional module implementing consul on ecs backed by efs storage
- add a load test for consul kv

## How I've tested this PR:
After building consul with [PR: 13782](https://github.com/hashicorp/consul/pull/13782) to support ECS for Go Discover, create a variables file as described within the [README.md](https://github.com/fdr2/terraform-aws-consul-ecs/blob/5ed316420879f9731ef5a4c68812643e19cd92b5/examples/ha-cluster-fargate/README.md) to point your consul image variable at the image url for the image you have built (until consul is updated with the necessary go-discover version).

## How I expect reviewers to test this PR:
Using the example `ha-cluster-fargate`, create ca and certs, deploy resources to AWS and load test.

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 
- [X] Tag @pglass for visibility

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::