### PR TITLE
Update test dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: lint-consul-retry
           working_directory: test/acceptance
           command: |
-            go get -u github.com/hashicorp/lint-consul-retry
+            go install github.com/hashicorp/lint-consul-retry@latest
             lint-consul-retry
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   consul-ecs-test:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.2
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.3
     environment:
       TEST_RESULTS: &TEST_RESULTS /tmp/test-results # path to where test results are saved
     # medium (2cpu / 4gb) with parallel invocations of Terraform sometimes ran out of memory.
@@ -48,11 +48,6 @@ jobs:
             fi
 
       - run:
-          name: go vet
-          working_directory: test/acceptance
-          command: go vet ./...
-
-      - run:
           name: lint-consul-retry
           working_directory: test/acceptance
           command: |
@@ -62,9 +57,7 @@ jobs:
       - run:
           name: golangci-lint
           working_directory: test/acceptance
-          command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
-            golangci-lint run
+          command: golangci-lint run
 
   terraform-fmt:
     executor: consul-ecs-test

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -401,7 +401,7 @@ exec consul agent -server \
   -hcl='cert_file = "/consul/${var.datacenter}-server-consul-0.pem"' \
   -hcl='key_file = "/consul/${var.datacenter}-server-consul-0-key.pem"' \
   -hcl='auto_encrypt = {allow_tls = true}' \
-  -hcl='ports { https = 8501, grpc_tls = 8502 }' \
+  -hcl='ports { https = 8501, grpc = 8502 }' \
   -hcl='verify_incoming_rpc = true' \
   -hcl='verify_outgoing = true' \
   -hcl='verify_server_hostname = true' \

--- a/test/acceptance/framework/helpers/helpers.go
+++ b/test/acceptance/framework/helpers/helpers.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/config"
-	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
 )
 
 // ExecuteRemoteCommand executes a command inside a container in the task specified
@@ -29,6 +27,5 @@ func ExecuteRemoteCommand(t *testing.T, testConfig *config.TestConfig, clusterAR
 			command,
 			"--interactive",
 		},
-		Logger: terratestLogger.New(logger.TestLogger{}),
 	})
 }

--- a/test/acceptance/go.mod
+++ b/test/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance
 
-go 1.15
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.9
@@ -10,4 +10,47 @@ require (
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/consul/sdk v0.9.0
 	github.com/stretchr/testify v1.4.0
+)
+
+require (
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
+	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
+	github.com/aws/aws-sdk-go-v2 v1.16.4 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.12.4 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.11 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.12 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.11.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.16.6 // indirect
+	github.com/aws/smithy-go v1.11.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-hclog v0.12.0 // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
+	github.com/hashicorp/serf v0.9.6 // indirect
+	github.com/hashicorp/terraform-json v0.9.0 // indirect
+	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/zclconf/go-cty v1.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 // indirect
+	golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/test/acceptance/go.sum
+++ b/test/acceptance/go.sum
@@ -276,7 +276,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2OptiY=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
@@ -541,7 +540,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/test/docker/Makefile
+++ b/test/docker/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME=hashicorpdev/consul-ecs-test
-VERSION=0.3.2
+VERSION=0.3.3
 
 IMAGE_TAG=$(IMAGE_NAME):$(VERSION)
 

--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -29,7 +29,7 @@ After you've pushed the image, logout of the `hashicorpconsul` user.
 
 Then, update the `.circleci/config.yml` to reference the new version of the image:
 
-```
+```diff
 diff --git a/.circleci/config.yml b/.circleci/config.yml
 index 9b8a5cb..649d193 100644
 --- a/.circleci/config.yml

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -1,11 +1,11 @@
 # This Dockerfile includes the dependencies for unit and acceptance tests
 # run in CircleCI.
-FROM cimg/go:1.17
+FROM cimg/go:1.19
 
 # change the user to root so we can install stuff
 USER root
 
-ENV TERRAFORM_VERSION "1.2.2"
+ENV TERRAFORM_VERSION "1.3.4"
 
 # base packages
 RUN apt-get install -y \


### PR DESCRIPTION
## Changes proposed in this PR:

- Bump acceptance tests to Go 1.19
- Bump Terraform to 1.3.4
- Update other versions (gotestsum, golangci-lint, aws cli, session-manager-plugin)
- Don't use `grpc_tls` setting yet, which is not valid in 1.13.3

## How I've tested this PR:

* Acceptance test locally with both Consul 1.12.2 and 1.13.3

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::