### PR TITLE
Backport: Add envoy_public_listener_port input var to mesh-task [0.5.x]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     # medium (2cpu / 4gb) with parallel invocations of Terraform sometimes ran out of memory.
     # Bumped to medium+ (3cpu / 6gb) to help with this.
     # https://circleci.com/docs/configuration-reference#resourceclass
-    resource_class: medium+
+    resource_class: xlarge
 
 jobs:
   go-fmt-and-lint-acceptance:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+FEATURES
+* modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
+
 ## 0.5.1 (July 29, 2022)
 
 FEATURES

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -28,7 +28,8 @@ locals {
     )
     proxy = merge(
       {
-        upstreams = var.upstreams
+        publicListenerPort = var.envoy_public_listener_port
+        upstreams          = var.upstreams
       },
       local.proxyExtra
     )

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -291,7 +291,7 @@ resource "aws_ecs_task_definition" "this" {
               },
             ]
             healthCheck = {
-              command  = ["nc", "-z", "127.0.0.1", "20000"]
+              command  = ["nc", "-z", "127.0.0.1", tostring(var.envoy_public_listener_port)]
               interval = 30
               retries  = 3
               timeout  = 5

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -151,6 +151,31 @@ variable "envoy_image" {
   default     = "envoyproxy/envoy-alpine:v1.21.4"
 }
 
+variable "envoy_public_listener_port" {
+  description = "The public listener port for Envoy that is used for service-to-service communication."
+  type        = number
+  default     = 20000
+
+  validation {
+    error_message = "The envoy_public_listener_port must be greater than 0 and less than or equal to 65535."
+    condition     = var.envoy_public_listener_port > 0 && var.envoy_public_listener_port <= 65535
+  }
+
+  validation {
+    error_message = "The envoy_public_listener_port must not conflict with the following ports that are reserved for Consul and Envoy: 8300, 8301, 8302, 8500, 8501, 8502, 8600, 19000."
+    condition = !contains([
+      8300,  // consul rpc port
+      8301,  // consul lan serf
+      8302,  // consul wan serf
+      8500,  // consul http
+      8501,  // consul https
+      8502,  // consul grpc
+      8600,  // consul dns
+      19000, // envoy admin port
+    ], var.envoy_public_listener_port)
+  }
+}
+
 variable "log_configuration" {
   description = "Task definition log configuration object (https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LogConfiguration.html)."
   type        = any

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -342,7 +342,57 @@ func TestValidation_UpstreamsVariable(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestValidation_EnvoyPublicListenerPort(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		port  int
+		error string
+	}{
+		"allowed-port": {
+			port: 21000,
+		},
+		"too-high-port": {
+			port:  65536,
+			error: "The envoy_public_listener_port must be greater than 0 and less than or equal to 65535.",
+		},
+		"disallowed-port": {
+			port:  19000,
+			error: "The envoy_public_listener_port must not conflict with the following ports that are reserved for Consul and Envoy",
+		},
+	}
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "./terraform/public-listener-port-validate",
+		NoColor:      true,
+	}
+	terraform.Init(t, terraformOptions)
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := terraform.PlanE(t, &terraform.Options{
+				TerraformDir: terraformOptions.TerraformDir,
+				NoColor:      true,
+				Vars: map[string]interface{}{
+					"envoy_public_listener_port": c.port,
+				},
+			})
+
+			if c.error == "" {
+				require.NoError(t, err)
+			} else {
+				// handle multiline error messages.
+				regex := strings.ReplaceAll(regexp.QuoteMeta(c.error), " ", "\\s+")
+				require.Error(t, err)
+				require.Regexp(t, regex, out)
+			}
+		})
+	}
 }
 
 func TestValidation_ChecksVariable(t *testing.T) {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -61,7 +61,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -61,7 +61,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -250,6 +250,8 @@ EOT
   outbound_only     = true
   // This keeps the application running for 10 seconds.
   application_shutdown_delay_seconds = 10
+  // Test with a port other than the default of 20000.
+  envoy_public_listener_port = 21000
 
   tls                       = var.secure
   consul_server_ca_cert_arn = var.secure ? module.consul_server.ca_cert_arn : ""

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -61,7 +61,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/public-listener-port-validate/main.tf
+++ b/test/acceptance/tests/basic/terraform/public-listener-port-validate/main.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "envoy_public_listener_port" {
+  type = number
+}
+
+module "test_client" {
+  source = "../../../../../../modules/mesh-task"
+  family = "family"
+  container_definitions = [{
+    name = "basic"
+  }]
+  retry_join                 = ["test"]
+  outbound_only              = true
+  envoy_public_listener_port = var.envoy_public_listener_port
+}

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -57,13 +57,13 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.2-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.6-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -63,7 +63,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -63,7 +63,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -59,7 +59,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -59,7 +59,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -53,13 +53,13 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.2-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.6-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -59,7 +59,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -59,7 +59,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:b3c0d40"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -53,13 +53,13 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.2-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.6-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
 }
 
 variable "consul_public_endpoint_url" {


### PR DESCRIPTION
## Changes proposed in this PR:

This backports https://github.com/hashicorp/terraform-aws-consul-ecs/pull/142 to release/0.5.x

- [x] Depends on https://github.com/hashicorp/consul-ecs/pull/127

## How I've tested this PR:

Acceptance tests

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::