### PR TITLE
Backport: Test with 1.13 and 1.14 to release/0.5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,12 @@ jobs:
     executor: consul-ecs-test
     parameters:
       launch_type:
-        default: ""
         type: string
+      consul_version:
+        type: string
+      # HCP is never enabled for PRs.
+      enable_hcp:
+        type: boolean
     steps:
       - checkout
 
@@ -95,8 +99,9 @@ jobs:
 
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
             VARS+=' -var launch_type=<<parameters.launch_type>>'
+            VARS+=' -var consul_version=<<parameters.consul_version>>'
             case $CIRCLE_BRANCH in
-                main | release/*) VARS+=" -var enable_hcp=true";;
+                main | release/*) VARS+=" -var enable_hcp=<<parameters.enable_hcp>>";;
                 *) VARS+=" -var enable_hcp=false";;
             esac
 
@@ -127,13 +132,23 @@ jobs:
           command: |
             VARS="-var tags={\"build_url\":\"$CIRCLE_BUILD_URL\"}"
             VARS+=' -var launch_type=<<parameters.launch_type>>'
+            VARS+=' -var consul_version=<<parameters.consul_version>>'
             case $CIRCLE_BRANCH in
-                main | release/*) VARS+=" -var enable_hcp=true";;
+                main | release/*) VARS+=" -var enable_hcp=<<parameters.enable_hcp>>";;
                 *) VARS+=" -var enable_hcp=false";;
             esac
 
             terraform destroy -auto-approve $VARS
           when: always
+
+
+acceptance-common: &acceptance-common
+  filters:
+    branches:
+      # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      ignore: /pull\/[0-9]+|docs\/.*/
+  requires:
+    - go-fmt-and-lint-acceptance
 
 workflows:
   version: 2.1
@@ -141,15 +156,13 @@ workflows:
     jobs:
       - go-fmt-and-lint-acceptance
       - terraform-fmt
-      - acceptance:
-          matrix:
-            parameters:
-              launch_type:
-                - FARGATE
-                - EC2
-          filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+|docs\/.*/
-          requires:
-            - go-fmt-and-lint-acceptance
+      # We have a limit of 6 HCP Consul clusters.
+      # The following controls whether to enable HCP when testing release branches.
+      # HCP is always disabled for tests on PRs.
+      - acceptance: {name: "acceptance-1.12-FARGATE-HCP", consul_version: '1.12.6', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.3', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.1', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.12-EC2", consul_version: '1.12.6', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.3', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.1', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   consul-ecs-test:
     docker:
-      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.2
+      - image: docker.mirror.hashicorp.services/hashicorpdev/consul-ecs-test:0.3.3
     environment:
       TEST_RESULTS: &TEST_RESULTS /tmp/test-results # path to where test results are saved
     # medium (2cpu / 4gb) with parallel invocations of Terraform sometimes ran out of memory.
@@ -48,23 +48,16 @@ jobs:
             fi
 
       - run:
-          name: go vet
-          working_directory: test/acceptance
-          command: go vet ./...
-
-      - run:
           name: lint-consul-retry
           working_directory: test/acceptance
           command: |
-            go get -u github.com/hashicorp/lint-consul-retry
+            go install github.com/hashicorp/lint-consul-retry@latest
             lint-consul-retry
 
       - run:
           name: golangci-lint
           working_directory: test/acceptance
-          command: |
-            curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
-            golangci-lint run
+          command: golangci-lint run
 
   terraform-fmt:
     executor: consul-ecs-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
 
+IMPROVEMENTS
+* Support Consul 1.13 and 1.14
+
 ## 0.5.1 (July 29, 2022)
 
 FEATURES

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2021 HashiCorp, Inc.
+
 Mozilla Public License Version 2.0
 ==================================
 

--- a/modules/dev-server/consul_1_14_compat.tf
+++ b/modules/dev-server/consul_1_14_compat.tf
@@ -1,0 +1,5 @@
+locals {
+  // parse the consul version from the provided image: ["1", "12", "2"]
+  consul_image_version_parts = regex(":.*(\\d+)[.](\\d+)[.](\\d+)", var.consul_image)
+  is_consul_1_14_plus        = tonumber(local.consul_image_version_parts[1]) >= 14
+}

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -402,7 +402,11 @@ exec consul agent -server \
   -hcl='cert_file = "/consul/${var.datacenter}-server-consul-0.pem"' \
   -hcl='key_file = "/consul/${var.datacenter}-server-consul-0-key.pem"' \
   -hcl='auto_encrypt = {allow_tls = true}' \
+%{if local.is_consul_1_14_plus~}
+  -hcl='ports { https = 8501, grpc_tls = 8503 }' \
+%{else~}
   -hcl='ports { https = 8501, grpc = 8502 }' \
+%{endif~}
   -hcl='verify_incoming_rpc = true' \
   -hcl='verify_outgoing = true' \
   -hcl='verify_server_hostname = true' \

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -394,7 +394,6 @@ exec consul agent -server \
 %{endif~}
   -hcl 'node_name = "${local.node_name}"' \
   -hcl='datacenter = "${var.datacenter}"' \
-  -hcl 'telemetry { disable_compat_1.9 = true }' \
   -hcl 'connect { enabled = true }' \
   -hcl 'enable_central_service_config = true' \
 %{if var.tls~}
@@ -433,6 +432,9 @@ exec consul agent -server \
 %{endif~}
 %{if local.enable_mesh_gateway_wan_federation~}
   -hcl='connect { enable_mesh_gateway_wan_federation = true }' \
+%{endif~}
+%{if var.enable_cluster_peering~}
+  -hcl='peering { enabled = true }' \
 %{endif~}
 %{if length(var.primary_gateways) > 0~}
   -hcl='primary_gateways = [

--- a/modules/dev-server/main.tf
+++ b/modules/dev-server/main.tf
@@ -402,7 +402,7 @@ exec consul agent -server \
   -hcl='cert_file = "/consul/${var.datacenter}-server-consul-0.pem"' \
   -hcl='key_file = "/consul/${var.datacenter}-server-consul-0-key.pem"' \
   -hcl='auto_encrypt = {allow_tls = true}' \
-  -hcl='ports { https = 8501 }' \
+  -hcl='ports { https = 8501, grpc = 8502 }' \
   -hcl='verify_incoming_rpc = true' \
   -hcl='verify_outgoing = true' \
   -hcl='verify_server_hostname = true' \

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -195,7 +195,7 @@ variable "primary_datacenter" {
 }
 
 variable "retry_join_wan" {
-  description = "List of WAN addresses to join for Consul cluster peering. Must not be provided when using mesh-gateway WAN federation."
+  description = "List of WAN addresses to join for Consul WAN federation. Must not be provided when using mesh-gateway WAN federation."
   type        = list(string)
   default     = []
 }
@@ -207,7 +207,13 @@ variable "primary_gateways" {
 }
 
 variable "enable_mesh_gateway_wan_federation" {
-  description = "Controls whether or not WAN cluster peering via mesh gateways is enabled. Default is false."
+  description = "Controls whether or not WAN federations via mesh gateways is enabled. Default is false."
+  type        = bool
+  default     = false
+}
+
+variable "enable_cluster_peering" {
+  description = "Controls whether or not cluster peering is enabled. Default is false."
   type        = bool
   default     = false
 }

--- a/modules/gateway-task/templates/consul_agent_defaults.hcl.tpl
+++ b/modules/gateway-task/templates/consul_agent_defaults.hcl.tpl
@@ -20,9 +20,6 @@ retry_join = [
   "${j}",
 %{ endfor ~}
 ]
-telemetry {
-  disable_compat_1.9 = true
-}
 
 %{~ if tls ~}
 auto_encrypt = {

--- a/modules/gateway-task/validation.tf
+++ b/modules/gateway-task/validation.tf
@@ -7,4 +7,5 @@ locals {
   create_xor_modify_security_group = var.lb_create_security_group && var.lb_modify_security_group ? file("ERROR: Only one of lb_create_security_group or lb_modify_security_group may be true") : null
   require_sg_id_for_modify         = var.lb_modify_security_group && var.lb_modify_security_group_id == "" ? file("ERROR: lb_modify_security_group_id is required when lb_modify_security_group is true") : null
   require_acls_if_audit_enabled    = (var.audit_logging && !var.acls) ? file("ERROR: ACLs must be enabled if audit logging is enabled") : null
+  require_consul_http_addr_if_acls = (var.acls && var.consul_http_addr == "") ? file("ERROR: consul_http_addr must be set if acls is true") : null
 }

--- a/modules/mesh-task/templates/consul_agent_defaults.hcl.tpl
+++ b/modules/mesh-task/templates/consul_agent_defaults.hcl.tpl
@@ -20,9 +20,6 @@ retry_join = [
   "${j}",
 %{ endfor ~}
 ]
-telemetry {
-  disable_compat_1.9 = true
-}
 
 %{~ if tls ~}
 auto_encrypt = {

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -14,6 +14,7 @@ type TestConfig struct {
 	Tags               interface{}
 	ClientServiceName  string
 	ServerServiceName  string
+	ConsulVersion      string `json:"consul_version"`
 }
 
 func (t TestConfig) TFVars(ignoreVars ...string) map[string]interface{} {
@@ -39,4 +40,12 @@ func (t TestConfig) TFVars(ignoreVars ...string) map[string]interface{} {
 		delete(vars, v)
 	}
 	return vars
+}
+
+// ConsulImageURI returns the Consul image URI for the configured consul version.
+func (t TestConfig) ConsulImageURI(enterprise bool) string {
+	if enterprise {
+		return "public.ecr.aws/hashicorp/consul-enterprise:" + t.ConsulVersion + "-ent"
+	}
+	return "public.ecr.aws/hashicorp/consul:" + t.ConsulVersion
 }

--- a/test/acceptance/framework/helpers/cloudwatch.go
+++ b/test/acceptance/framework/helpers/cloudwatch.go
@@ -35,10 +35,14 @@ func GetCloudWatchLogEvents(t terratestTesting.TestingT, testConfig *config.Test
 		parts := strings.SplitN(line, "\t", 2)
 		timestamp, err := time.Parse(time.RFC3339, parts[0])
 		if err != nil {
-			t.Errorf("failed to parse timestamp in log line `%s`", line)
+			t.Errorf("failed to parse timestamp in CloudWatch log line: %q", line)
 			return nil, err
 		}
-		result = append(result, LogEvent{timestamp, parts[1]})
+		msg := ""
+		if len(parts) > 1 {
+			msg = parts[1]
+		}
+		result = append(result, LogEvent{timestamp, msg})
 	}
 	return result, nil
 }

--- a/test/acceptance/framework/helpers/helpers.go
+++ b/test/acceptance/framework/helpers/helpers.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/config"
-	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
 )
 
 // ExecuteRemoteCommand executes a command inside a container in the task specified
@@ -29,6 +27,5 @@ func ExecuteRemoteCommand(t *testing.T, testConfig *config.TestConfig, clusterAR
 			command,
 			"--interactive",
 		},
-		Logger: terratestLogger.New(logger.TestLogger{}),
 	})
 }

--- a/test/acceptance/go.mod
+++ b/test/acceptance/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance
 
-go 1.15
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.9
@@ -10,4 +10,47 @@ require (
 	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/consul/sdk v0.9.0
 	github.com/stretchr/testify v1.4.0
+)
+
+require (
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
+	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
+	github.com/aws/aws-sdk-go-v2 v1.16.4 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.12.4 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.11 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.12 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.11.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.16.6 // indirect
+	github.com/aws/smithy-go v1.11.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-hclog v0.12.0 // indirect
+	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
+	github.com/hashicorp/serf v0.9.6 // indirect
+	github.com/hashicorp/terraform-json v0.9.0 // indirect
+	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/zclconf/go-cty v1.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 // indirect
+	golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/test/acceptance/go.sum
+++ b/test/acceptance/go.sum
@@ -276,7 +276,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.8.2 h1:wmFle3D1vu0okesm8BTLVDyJ6/OL9DCLUwn0b2OptiY=
 github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
@@ -541,7 +540,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/test/acceptance/setup-terraform/hcp/main.tf
+++ b/test/acceptance/setup-terraform/hcp/main.tf
@@ -45,7 +45,7 @@ resource "hcp_consul_cluster" "this" {
   hvn_id             = hcp_hvn.server.hvn_id
   tier               = "development"
   public_endpoint    = true
-  min_consul_version = "1.12.0"
+  min_consul_version = var.consul_version
 }
 
 resource "aws_secretsmanager_secret" "bootstrap_token" {

--- a/test/acceptance/setup-terraform/hcp/variables.tf
+++ b/test/acceptance/setup-terraform/hcp/variables.tf
@@ -13,3 +13,7 @@ variable "vpc" {
   type        = any
 }
 
+variable "consul_version" {
+  description = "The Consul server version."
+  type        = string
+}

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -91,7 +91,8 @@ module "hcp" {
   count  = var.enable_hcp ? 1 : 0
   source = "./hcp"
 
-  region = var.region
-  suffix = local.suffix
-  vpc    = module.vpc
+  region         = var.region
+  suffix         = local.suffix
+  vpc            = module.vpc
+  consul_version = var.consul_version
 }

--- a/test/acceptance/setup-terraform/outputs.tf
+++ b/test/acceptance/setup-terraform/outputs.tf
@@ -66,3 +66,7 @@ output "gossip_key_secret_arn" {
 output "consul_ca_cert_secret_arn" {
   value = var.enable_hcp ? module.hcp[0].consul_ca_cert_secret_arn : ""
 }
+
+output "consul_version" {
+  value = var.consul_version
+}

--- a/test/acceptance/setup-terraform/variables.tf
+++ b/test/acceptance/setup-terraform/variables.tf
@@ -37,11 +37,11 @@ variable "instance_type" {
 }
 
 variable "consul_version" {
-  description = "The Consul version. Must a valid MAJOR.MINOR.PATCH version string."
+  description = "The Consul version. Must be a valid MAJOR.MINOR.PATCH version string."
   type        = string
 
   validation {
     condition     = can(regex("^\\d+[.]\\d+[.]\\d+$", var.consul_version))
-    error_message = "Must a valid MAJOR.MINOR.PATCH version string."
+    error_message = "Must be a valid MAJOR.MINOR.PATCH version string."
   }
 }

--- a/test/acceptance/setup-terraform/variables.tf
+++ b/test/acceptance/setup-terraform/variables.tf
@@ -35,3 +35,13 @@ variable "instance_type" {
   type        = string
   default     = "t3a.micro"
 }
+
+variable "consul_version" {
+  description = "The Consul version. Must a valid MAJOR.MINOR.PATCH version string."
+  type        = string
+
+  validation {
+    condition     = can(regex("^\\d+[.]\\d+[.]\\d+$", var.consul_version))
+    error_message = "Must a valid MAJOR.MINOR.PATCH version string."
+  }
+}

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -93,14 +93,16 @@ func TestVolumeVariable(t *testing.T) {
 // TestPassingExistingRoles will create the task definitions to validate
 // creation and passing of IAM roles by mesh-task. It creates two task definitions
 // with mesh-task:
-//  - one which has mesh-task create the roles
-//  - one which passes in existing roles
+//   - one which has mesh-task create the roles
+//   - one which passes in existing roles
+//
 // This test does not start any services.
 //
 // Note: We don't have a validation for create_task_role=true XOR task_role=<non-null>.
-//       If the role is created as part of the terraform plan/apply and passed in to mesh-task,
-//       then the role is an unknown value during the plan, since it is not yet created, and you
-//       can't reliably test its value for validations.
+//
+//	If the role is created as part of the terraform plan/apply and passed in to mesh-task,
+//	then the role is an unknown value during the plan, since it is not yet created, and you
+//	can't reliably test its value for validations.
 func TestPassingExistingRoles(t *testing.T) {
 	t.Parallel()
 
@@ -1100,6 +1102,7 @@ func TestBasic(t *testing.T) {
 					syncLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "consul-ecs-health-sync")
 					require.NoError(r, err)
 					syncLogs = syncLogs.Filter("[INFO]  log out token:")
+					require.GreaterOrEqual(r, len(syncLogs), 2)
 					require.Contains(r, syncLogs[0].Message, "/consul/service-token")
 					require.Contains(r, syncLogs[1].Message, "/consul/client-token")
 				})

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -863,7 +863,7 @@ func TestBasic(t *testing.T) {
 			}
 			tfVars["server_service_name"] = serverServiceName
 
-			image := discoverConsulImage(t, c.enterprise)
+			image := cfg.ConsulImageURI(c.enterprise)
 			t.Logf("using consul image = %s", image)
 			tfVars["consul_image"] = image
 			if c.enterprise {
@@ -1111,25 +1111,6 @@ func TestBasic(t *testing.T) {
 			logger.Log(t, "Test successful!")
 		})
 	}
-}
-
-// discoverConsulEnterpriseImage looks in mesh-task for the default Consul image
-// and uses that same version of the enterprise image.
-func discoverConsulImage(t *testing.T, enterprise bool) string {
-	filepath := "../../../../modules/mesh-task/variables.tf"
-	data, err := os.ReadFile(filepath)
-	require.NoError(t, err)
-
-	// Parse the default consul image from the mesh-task module.
-	re := regexp.MustCompile(`default\s+=\s+"public.ecr.aws/hashicorp/consul:(.*)"`)
-	matches := re.FindSubmatch(data)
-	require.Len(t, matches, 2) // entire match + one submatch
-	version := string(matches[1])
-
-	if enterprise {
-		return "public.ecr.aws/hashicorp/consul-enterprise:" + version + "-ent"
-	}
-	return "public.ecr.aws/hashicorp/consul:" + version
 }
 
 type listTasksResponse struct {

--- a/test/acceptance/tests/hcp/hcp_test.go
+++ b/test/acceptance/tests/hcp/hcp_test.go
@@ -80,7 +80,7 @@ func TestHCP(t *testing.T) {
 	cfg := parseHCPTestConfig(t)
 
 	// generate input variables to the test terraform using the config.
-	ignoreVars := []string{"token", "enable_hcp"}
+	ignoreVars := []string{"token", "enable_hcp", "consul_version"}
 	tfVars := TFVars(cfg, ignoreVars...)
 
 	consulClient, initialConsulState, err := consulClient(t, cfg.ConsulAddr, cfg.ConsulToken)
@@ -108,6 +108,7 @@ func TestHCP(t *testing.T) {
 	serverTask := helpers.NewMeshTask(t, taskConfig)
 
 	tfVars["suffix"] = randomSuffix
+	tfVars["consul_image"] = cfg.ConsulImageURI(true)
 	terraformOptions, _ := terraformInitAndApply(t, "./terraform/hcp-install", tfVars)
 	t.Cleanup(func() { terraformDestroy(t, terraformOptions, suite.Config().NoCleanupOnFailure) })
 
@@ -167,7 +168,7 @@ func TestNamespaces(t *testing.T) {
 	cfg := parseHCPTestConfig(t)
 
 	// generate input variables to the test terraform using the config.
-	ignoreVars := []string{"token", "enable_hcp"}
+	ignoreVars := []string{"token", "enable_hcp", "consul_version"}
 	tfVars := TFVars(cfg, ignoreVars...)
 
 	consulClient, initialConsulState, err := consulClient(t, cfg.ConsulAddr, cfg.ConsulToken)
@@ -198,6 +199,7 @@ func TestNamespaces(t *testing.T) {
 	tfVars["suffix"] = randomSuffix
 	tfVars["client_namespace"] = clientTask.Namespace
 	tfVars["server_namespace"] = serverTask.Namespace
+	tfVars["consul_image"] = cfg.ConsulImageURI(true)
 
 	terraformOptions, _ := terraformInitAndApply(t, "./terraform/ns", tfVars)
 	t.Cleanup(func() { terraformDestroy(t, terraformOptions, suite.Config().NoCleanupOnFailure) })
@@ -226,7 +228,7 @@ func TestAdminPartitions(t *testing.T) {
 	cfg := parseHCPTestConfig(t)
 
 	// generate input variables to the test terraform using the config.
-	ignoreVars := []string{"ecs_cluster_arn", "token", "enable_hcp"}
+	ignoreVars := []string{"ecs_cluster_arn", "token", "enable_hcp", "consul_version"}
 	tfVars := TFVars(cfg, ignoreVars...)
 
 	consulClient, initialConsulState, err := consulClient(t, cfg.ConsulAddr, cfg.ConsulToken)
@@ -263,6 +265,7 @@ func TestAdminPartitions(t *testing.T) {
 	tfVars["suffix_2"] = serverSuffix
 	tfVars["server_partition"] = serverTask.Partition
 	tfVars["server_namespace"] = serverTask.Namespace
+	tfVars["consul_image"] = cfg.ConsulImageURI(true)
 
 	terraformOptions, _ := terraformInitAndApply(t, "./terraform/ap", tfVars)
 	t.Cleanup(func() { terraformDestroy(t, terraformOptions, suite.Config().NoCleanupOnFailure) })
@@ -597,7 +600,7 @@ func restoreConsulState(t *testing.T, consul *api.Client, state ConsulState) err
 func TestAuditLogging(t *testing.T) {
 	cfg := parseHCPTestConfig(t)
 	// generate input variables to the test terraform using the config.
-	ignoreVars := []string{"token", "enable_hcp"}
+	ignoreVars := []string{"token", "enable_hcp", "consul_version"}
 	tfVars := TFVars(cfg, ignoreVars...)
 
 	consulClient, initialConsulState, err := consulClient(t, cfg.ConsulAddr, cfg.ConsulToken)
@@ -625,6 +628,7 @@ func TestAuditLogging(t *testing.T) {
 	serverTask := helpers.NewMeshTask(t, taskConfig)
 
 	tfVars["suffix"] = randomSuffix
+	tfVars["consul_image"] = cfg.ConsulImageURI(true)
 
 	// Enable audit logging
 	tfVars["audit_logging"] = true

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -51,9 +51,8 @@ variable "tags" {
 }
 
 variable "consul_image" {
-  description = "Consul Docker image."
+  description = "Consul Docker image for Consul client agents in ECS."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.6-ent"
 }
 
 variable "consul_ecs_image" {

--- a/test/docker/Makefile
+++ b/test/docker/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME=hashicorpdev/consul-ecs-test
-VERSION=0.3.2
+VERSION=0.3.3
 
 IMAGE_TAG=$(IMAGE_NAME):$(VERSION)
 

--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -29,7 +29,7 @@ After you've pushed the image, logout of the `hashicorpconsul` user.
 
 Then, update the `.circleci/config.yml` to reference the new version of the image:
 
-```
+```diff
 diff --git a/.circleci/config.yml b/.circleci/config.yml
 index 9b8a5cb..649d193 100644
 --- a/.circleci/config.yml

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -1,11 +1,11 @@
 # This Dockerfile includes the dependencies for unit and acceptance tests
 # run in CircleCI.
-FROM cimg/go:1.17
+FROM cimg/go:1.19
 
 # change the user to root so we can install stuff
 USER root
 
-ENV TERRAFORM_VERSION "1.2.2"
+ENV TERRAFORM_VERSION "1.3.4"
 
 # base packages
 RUN apt-get install -y \


### PR DESCRIPTION
## Changes proposed in this PR:

This backports the following to the 0.5.x release branch:

* #140 - To fix a bounds check in test helpers
* #141 - To update test dependencies (including Go 1.19) and improve test logging
* #146 - To test with Consul 1.13 and 1.14
* #138 - To remove the `telemetry.disable_compat_1.9` to support 1.13+, and support cluster peering (1.14+ only)
* #137 - To sync the license copyright to the release branch

## How I've tested this PR:

Acceptance tests

## How I expect reviewers to test this PR:

👀 

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::