### PR TITLE
Prep for 0.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,5 +164,5 @@ workflows:
       - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.2', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.12-EC2", consul_version: '1.12.7', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.4', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.2', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,10 +159,10 @@ workflows:
       # We have a limit of 6 HCP Consul clusters.
       # The following controls whether to enable HCP when testing release branches.
       # HCP is always disabled for tests on PRs.
-      - acceptance: {name: "acceptance-1.12-FARGATE-HCP", consul_version: '1.12.6', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.3', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.1', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.12-EC2", consul_version: '1.12.6', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.3', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.1', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.12-FARGATE-HCP", consul_version: '1.12.7', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.4', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.2', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.12-EC2", consul_version: '1.12.7', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.4', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-## Unreleased
+## 0.5.2 (December 13, 2022)
 
 FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
+  [[GH-142](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/142)]
 
 IMPROVEMENTS
 * Support Consul 1.13 and 1.14
+  [[GH-146](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/146)]
+* modules/mesh-task, modules/dev-server: Update default Consul image to 1.12.7
+  and default Envoy image to 1.21.6.
 
 ## 0.5.1 (July 29, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ FEATURES
   [[GH-142](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/142)]
 
 IMPROVEMENTS
-* Support Consul 1.13 and 1.14
+* Support Consul 1.13 and 1.14.
   [[GH-146](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/146)]
-* modules/mesh-task, modules/dev-server: Update default Consul image to 1.12.7
-  and default Envoy image to 1.21.6.
+* Update default Consul image to 1.12.7 and default Envoy image to 1.21.6.
+  [[GH-148](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/148)]
 
 ## 0.5.1 (July 29, 2022)
 

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -12,13 +12,13 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.2-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.7-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.2"
 }
 
 variable "client_partition" {

--- a/examples/mesh-gateways/datacenter/variables.tf
+++ b/examples/mesh-gateways/datacenter/variables.tf
@@ -94,5 +94,5 @@ variable "replication_token" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.2"
 }

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -108,5 +108,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.2"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -28,7 +28,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.2"
 }
 
 variable "consul_server_startup_timeout" {

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -1,7 +1,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.2"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -58,7 +58,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+  default     = "public.ecr.aws/hashicorp/consul:1.12.7"
 }
 
 variable "consul_license" {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.5.1"
+  version_string = "0.5.2"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -82,19 +82,19 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+  default     = "public.ecr.aws/hashicorp/consul:1.12.7"
 }
 
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.2"
 }
 
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-alpine:v1.21.4"
+  default     = "envoyproxy/envoy-alpine:v1.21.6"
 }
 
 variable "log_configuration" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.5.1"
+  version_string = "0.5.2"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -136,19 +136,19 @@ variable "outbound_only" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+  default     = "public.ecr.aws/hashicorp/consul:1.12.7"
 }
 
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.2"
 }
 
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-alpine:v1.21.4"
+  default     = "envoyproxy/envoy-alpine:v1.21.6"
 }
 
 variable "envoy_public_listener_port" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -61,7 +61,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -61,7 +61,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -57,13 +57,12 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.6-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -62,7 +62,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -58,7 +58,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -58,7 +58,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -53,13 +53,12 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.6-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -58,7 +58,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.5.2"
 }
 
 variable "consul_public_endpoint_url" {


### PR DESCRIPTION
## Changes proposed in this PR:

* Bump default [Envoy image to 1.21.6](https://hub.docker.com/r/envoyproxy/envoy-alpine/tags)
* Bump default Consul image to 1.12.7
* Bump versions of Consul in acceptance tests to 1.12.7, 1.13.4, and 1.14.2 which are the latest available in HCP
* Set the TF module version to 0.5.2
* Bump default Consul ECS image to 0.5.2

## How I've tested this PR:

* CI tests

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::