### PR TITLE
Prep for 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## Unreleased
+## 0.4.3 (December 13, 2022)
 
 FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
+
+IMPROVEMENTS
+* Update default Consul image to 1.11.11 and default Envoy image to 1.20.7.
 
 ## 0.4.2 (Jun 29, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
+  [[GH-142](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/142)]
 
 IMPROVEMENTS
 * Update default Consul image to 1.11.11 and default Envoy image to 1.20.7.
+  [[GH-149](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/149)]
 
 ## 0.4.2 (Jun 29, 2022)
 

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -12,13 +12,13 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.11.4-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.11.11-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.4.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.4.3"
 }
 
 variable "client_partition" {

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -1,7 +1,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.4.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.4.3"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -58,7 +58,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.11.4"
+  default     = "public.ecr.aws/hashicorp/consul:1.11.11"
 }
 
 variable "log_configuration" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.4.2"
+  version_string = "0.4.3"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -120,19 +120,19 @@ variable "outbound_only" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.11.4"
+  default     = "public.ecr.aws/hashicorp/consul:1.11.11"
 }
 
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.4.1"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.4.3"
 }
 
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-alpine:v1.20.2"
+  default     = "envoyproxy/envoy-alpine:v1.20.7"
 }
 
 variable "envoy_public_listener_port" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -49,7 +49,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.3"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -63,7 +63,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.3"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -54,7 +54,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.3"
 }
 
 variable "consul_public_endpoint_url" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -54,7 +54,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.1-dev"
+  default     = "docker.mirror.hashicorp.services/hashicorppreview/consul-ecs:0.4.3"
 }
 
 variable "consul_public_endpoint_url" {


### PR DESCRIPTION
## Changes proposed in this PR:

* Bump default Consul version to 1.11.11
* Bump default Envoy version to 1.20.7
* Set TF module version to 0.4.3
* Bump consul-ecs version to 0.4.3
* Update changelog

## How I've tested this PR:

CI tests

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::