### PR TITLE
Add support for additional_execution_role_policies  in acl-controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
-* modules/acl-controller: Add `additional_execution_role_policies` variable to allow the ECS service execution role to perform
-  more actions.
+* modules/acl-controller: Add `additional_execution_role_policies` variable to support attaching custom policies to the task's execution role.
 
 ## 0.5.1 (July 29, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
+* modules/acl-controller: Add `additional_execution_role_policies` variable to allow the ECS service execution role to perform
+  more actions.
 
 ## 0.5.1 (July 29, 2022)
 

--- a/modules/acl-controller/main.tf
+++ b/modules/acl-controller/main.tf
@@ -165,3 +165,9 @@ resource "aws_iam_role_policy_attachment" "consul-controller-execution" {
   role       = aws_iam_role.this_execution.id
   policy_arn = aws_iam_policy.this_execution.arn
 }
+
+resource "aws_iam_role_policy_attachment" "additional_execution_policies" {
+  count      = length(var.additional_execution_role_policies)
+  role       = aws_iam_role.this_execution.id
+  policy_arn = var.additional_execution_role_policies[count.index]
+}

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -87,3 +87,9 @@ variable "security_groups" {
   type        = list(string)
   default     = []
 }
+
+variable "additional_execution_role_policies" {
+  description = "List of additional policy ARNs to attach to the execution role."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Refers to https://github.com/hashicorp/terraform-aws-consul-ecs/issues/150

## Changes proposed in this PR:

- Add variable `additional_execution_role_policies` to `acl-controller` module

## How I've tested this PR:

- Local environment:
  - [x] acl-controller

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::