### PR TITLE
Improve the logic behind the 'defaulted_check_containers' local creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES
 * modules/acl-controller: Add `additional_execution_role_policies` variable to support attaching custom policies to the task's execution role.
 * modules/mesh-task: Improve the logic behind the `defaulted_check_containers` local creation in order to prevent enabling health checks when
   the task definition passed in `var.container_definitions` has the `healthCheck` set to `null`.
-  [[GH-152]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/152)
+  [[GH-153]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/153)
 
 ## 0.5.1 (July 29, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
 * modules/acl-controller: Add `additional_execution_role_policies` variable to support attaching custom policies to the task's execution role.
+* modules/mesh-task: Improve the logic behind the `defaulted_check_containers` local creation in order to prevent enabling health checks when
+  the task definition passed in `var.container_definitions` has the `healthCheck` set to `null`.
+  [[GH-152]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/152)
 
 ## 0.5.1 (July 29, 2022)
 

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -69,7 +69,7 @@ locals {
   ]
 
   defaulted_check_containers = length(var.checks) == 0 ? [for def in local.container_defs_with_depends_on : def.name
-  if contains(keys(def), "essential") && contains(keys(def), "healthCheck")] : []
+  if contains(keys(def), "essential") && contains(keys(def), "healthCheck") && try(def.healthCheck, null)] : []
   // health-sync is enabled if acls are enabled, in order to run 'consul logout' to cleanup tokens when the task stops
   health_sync_enabled = length(local.defaulted_check_containers) > 0 || var.acls
 

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -69,7 +69,7 @@ locals {
   ]
 
   defaulted_check_containers = length(var.checks) == 0 ? [for def in local.container_defs_with_depends_on : def.name
-  if contains(keys(def), "essential") && contains(keys(def), "healthCheck") && try(def.healthCheck, null)] : []
+  if contains(keys(def), "essential") && contains(keys(def), "healthCheck") && (try(def.healthCheck, null) != null)] : []
   // health-sync is enabled if acls are enabled, in order to run 'consul logout' to cleanup tokens when the task stops
   health_sync_enabled = length(local.defaulted_check_containers) > 0 || var.acls
 


### PR DESCRIPTION
## Changes proposed in this PR:

- Exclude task_def from `defaulted_check_containers` if the `healthCheck` property is present but its null. https://github.com/hashicorp/terraform-aws-consul-ecs/pull/153

## How I've tested this PR:

- Locally.

## How I expect reviewers to test this PR:

Not ideal but this can be tested with this snippet:

```hcl
locals {
  container_defs_with_depends_on = [{
    name        = "x"
    essential   = true
    healthCheck = null
    },
    {
      name      = "y"
      essential = true
      healthCheck = {
        command = ""
      }
    },
    {
      name      = "z"
      essential = true
    }
  ]

  defaulted_check_containers_before = [for def in local.container_defs_with_depends_on : def.name
  if contains(keys(def), "essential") && contains(keys(def), "healthCheck")]

  defaulted_check_containers_now = [for def in local.container_defs_with_depends_on : def.name
  if contains(keys(def), "essential") && contains(keys(def), "healthCheck") && (try(def.healthCheck, null) != null)]
}

output "defaulted_check_containers_before" {
  value       = local.defaulted_check_containers_before
  description = "should contain 'x' and 'y'"
  depends_on  = []
}

output "defaulted_check_containers_now" {
  value       = local.defaulted_check_containers_now
  description = "should contain only 'y'"
  depends_on  = []
}
```

tf plan output:

```log
Changes to Outputs:
  + defaulted_check_containers_before = [
      + "x",
      + "y",
    ]
  + defaulted_check_containers_now    = [
      + "y",
    ]
```

## Checklist:
- [ ] Tests added
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::