### PR TITLE
Only grant read-only access to root file system.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
 * modules/acl-controller: Add `additional_execution_role_policies` variable to support attaching custom policies to the task's execution role.
 
+IMPROVEMENTS
+* module/acl-controller: Restrict container access (read-only) to root file system.
+  [[GH-158](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/158)]
+
 ## 0.5.1 (July 29, 2022)
 
 FEATURES

--- a/modules/acl-controller/main.tf
+++ b/modules/acl-controller/main.tf
@@ -55,6 +55,7 @@ resource "aws_ecs_task_definition" "this" {
           value = var.consul_server_http_addr
         }
       ]
+      readonlyRootFilesystem = true
     },
   ])
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- ACL controller: only grant read-only access to root file system. To avoid trigger the following AWS Security Hub alert:

> [ECS.5] This control checks if ECS containers are limited to read-only access to mounted root filesystems. This control fails if the ReadonlyRootFilesystem parameter in the container definition of ECS task definitions is set to ‘false’. [Remediation instructions](https://docs.aws.amazon.com/console/securityhub/ECS.5/remediation)

https://github.com/hashicorp/terraform-aws-consul-ecs/issues/157

## How I've tested this PR:

- Locally bootstrap the ACL controler with this change and no side effect was detected.

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added 