### PR TITLE
Add support for Consul 1.15.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,10 @@ workflows:
       # We have a limit of 6 HCP Consul clusters.
       # The following controls whether to enable HCP when testing release branches.
       # HCP is always disabled for tests on PRs.
-      - acceptance: {name: "acceptance-1.12-FARGATE-HCP", consul_version: '1.15.0', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.15-FARGATE-HCP", consul_version: '1.15.0', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.6', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.4', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.12-EC2", consul_version: '1.15.0', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.15-EC2", consul_version: '1.15.0', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.6', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.4', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,10 @@ workflows:
       # We have a limit of 6 HCP Consul clusters.
       # The following controls whether to enable HCP when testing release branches.
       # HCP is always disabled for tests on PRs.
-      - acceptance: {name: "acceptance-1.12-FARGATE-HCP", consul_version: '1.12.6', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.3', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.1', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.12-EC2", consul_version: '1.12.6', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.3', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.1', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.12-FARGATE-HCP", consul_version: '1.15.0', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.6', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.4', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.12-EC2", consul_version: '1.15.0', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.6', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.4', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,10 @@ workflows:
       # We have a limit of 6 HCP Consul clusters.
       # The following controls whether to enable HCP when testing release branches.
       # HCP is always disabled for tests on PRs.
-      - acceptance: {name: "acceptance-1.15-FARGATE-HCP", consul_version: '1.15.0', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.6', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.4', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.15-EC2", consul_version: '1.15.0', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.6', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.4', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.15-FARGATE-HCP", consul_version: '1.15.1', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.7', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.5', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.15-EC2", consul_version: '1.15.1', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.7', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.5', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 FEATURES
+* modules/mesh-task and modules/gateway-task: Add support for Consul 1.15.x.
+  [[GH-159]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/159)
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.
 * modules/acl-controller: Add `additional_execution_role_policies` variable to support attaching custom policies to the task's execution role.
 

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -202,7 +202,7 @@ resource "aws_ecs_task_definition" "this" {
               },
             ]
             healthCheck = {
-              command  = ["nc", "-z", "127.0.0.1", tostring(local.lan_port)]
+              command  = ["/consul/consul-ecs", "net-dial", "127.0.0.1", tostring(local.lan_port)]
               interval = 30
               retries  = 3
               timeout  = 5

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -202,7 +202,7 @@ resource "aws_ecs_task_definition" "this" {
               },
             ]
             healthCheck = {
-              command  = ["/consul/consul-ecs", "net-dial", "127.0.0.1", tostring(local.lan_port)]
+              command  = ["/consul/consul-ecs", "net-dial", format("127.0.0.1:%d", local.lan_port)]
               interval = 30
               retries  = 3
               timeout  = 5

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -97,7 +97,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-alpine:v1.21.4"
+  default     = "envoyproxy/envoy-distroless:v1.23.1"
 }
 
 variable "log_configuration" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -294,7 +294,7 @@ resource "aws_ecs_task_definition" "this" {
               },
             ]
             healthCheck = {
-              command  = ["/consul/consul-ecs", "net-dial", "127.0.0.1", tostring(var.envoy_public_listener_port)]
+              command  = ["/consul/consul-ecs", "net-dial", format("127.0.0.1:%d", var.envoy_public_listener_port)]
               interval = 30
               retries  = 3
               timeout  = 5

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -294,7 +294,7 @@ resource "aws_ecs_task_definition" "this" {
               },
             ]
             healthCheck = {
-              command  = ["nc", "-z", "127.0.0.1", tostring(var.envoy_public_listener_port)]
+              command  = ["/consul/consul-ecs", "net-dial", "127.0.0.1", tostring(var.envoy_public_listener_port)]
               interval = 30
               retries  = 3
               timeout  = 5

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -151,7 +151,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-alpine:v1.21.4"
+  default     = "envoyproxy/envoy-distroless:v1.23.1"
 }
 
 variable "envoy_public_listener_port" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -64,8 +64,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  // TODO: default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
-  default = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:cb78e1d"
+  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -64,7 +64,8 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  // TODO: default     = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:latest"
+  default = "docker.mirror.hashicorp.services/hashicorpdev/consul-ecs:cb78e1d"
 }
 
 variable "server_service_name" {


### PR DESCRIPTION
## Changes proposed in this PR:
This PR adds support for:
- Acceptance testing with the latest N-2 Consul versions (Currently, 1.15.0, 1.14.4, and 1.13.6)
- Using the Consul HTTP API to read the client ACL token after performing the `consul login` using the AWS auth method. There is an [issue with using the `consul acl token read -self` on Consul 1.15.0](https://github.com/hashicorp/consul/pull/16445), so `mesh-task` and `gateway-task` have been updated to use the HTTP API instead.
- Bumps the Envoy version to v1.23.1 and switches to distroless
- Uses the new `consul-ecs net-dial` command for ECS health checks on the `sidecar-proxy` container.

## How I've tested this PR:
- Acceptance tests

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests added - Added Consul 1.15.0 to acceptance test matrix.
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::