### PR TITLE
Use supported HCP Consul versions in Acceptance Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,11 @@ workflows:
       # We have a limit of 6 HCP Consul clusters.
       # The following controls whether to enable HCP when testing release branches.
       # HCP is always disabled for tests on PRs.
-      - acceptance: {name: "acceptance-1.15-FARGATE-HCP", consul_version: '1.15.1', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
+      # TODO: - acceptance: {name: "acceptance-1.15-FARGATE-HCP", consul_version: '1.15.1', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.13-FARGATE", consul_version: '1.13.7', enable_hcp: false, launch_type: FARGATE, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.5', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.14-FARGATE-HCP", consul_version: '1.14.4', enable_hcp: true, launch_type: FARGATE, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.15-EC2", consul_version: '1.15.1', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
-      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.7', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
+      - acceptance: {name: "acceptance-1.13-EC2-HCP", consul_version: '1.13.6', enable_hcp: true, launch_type: EC2, <<: *acceptance-common}
       - acceptance: {name: "acceptance-1.14-EC2", consul_version: '1.14.5', enable_hcp: false, launch_type: EC2, <<: *acceptance-common}
 


### PR DESCRIPTION
## Changes proposed in this PR:
HCP Consul does not currently have support for Consul 1.15.x nor the latest Consul patch releases for 1.14.x and 1.13.x. This PR:
- Binds the non-HCP tests to the **latest** Consul 1.15, 1.14 and 1.13 patch releases
- Binds the HCP tests to the **supported** Consul 1.14 and 1.13 patch releases
- Adds a TODO to update HCP Consul for 1.15.x when it is available

## How I've tested this PR:
Acceptance tests

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] Tests changed
- [x] ~CHANGELOG entry added~ Not applicable 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::