### PR TITLE
Use `consul-ecs envoy-entrypoint` to start Envoy for gateway-tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 FEATURES
+* modules/gateway-task: Use `consul-ecs envoy-entrypoint` to start the Envoy process for gateway tasks.
+  [[GH-162]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/162)
 * modules/mesh-task and modules/gateway-task: Add support for Consul 1.15.x.
   [[GH-159]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/159)
 * modules/mesh-task: Add `envoy_public_listener_port` variable to set Envoy's public listener port.

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -184,6 +184,7 @@ resource "aws_ecs_task_definition" "this" {
             image            = var.envoy_image
             essential        = true
             logConfiguration = var.log_configuration
+            entryPoint       = ["/consul/consul-ecs", "envoy-entrypoint"]
             command          = ["envoy", "--config-path", "/consul/envoy-bootstrap.json"]
             portMappings = [
               {


### PR DESCRIPTION
## Changes proposed in this PR:
Use the `consul-ecs envoy-entrypoint` to run and monitor the `envoy` process in `gateway-tasks`. This change bings the gateway task inline with how `mesh-task` starts Envoy and ensures that Envoy is correctly started and monitored.

## How I've tested this PR:
Local Lambda acceptance tests

## How I expect reviewers to test this PR:
:eyes:

## Checklist:
- [x] ~Tests added~ Not applicable
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::