### PR TITLE
Consul ECS 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.6.0 (Mar 15, 2023)
 
 FEATURES
 * modules/gateway-task: Use `consul-ecs envoy-entrypoint` to start the Envoy process for gateway tasks.

--- a/modules/acl-controller/variables.tf
+++ b/modules/acl-controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.6.0"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,7 +61,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+  default     = "public.ecr.aws/hashicorp/consul:1.15.1"
 }
 
 variable "consul_license" {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.5.0-dev"
+  version_string = "0.6.0"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -85,13 +85,13 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+  default     = "public.ecr.aws/hashicorp/consul:1.15.1"
 }
 
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.6.0"
 }
 
 variable "envoy_image" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.5.0-dev"
+  version_string = "0.6.0"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -139,13 +139,13 @@ variable "outbound_only" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.12.2"
+  default     = "public.ecr.aws/hashicorp/consul:1.15.1"
 }
 
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.6.0"
 }
 
 variable "envoy_image" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -60,7 +60,6 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.2-ent"
 }
 
 variable "consul_ecs_image" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -56,7 +56,6 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.2-ent"
 }
 
 variable "consul_ecs_image" {


### PR DESCRIPTION
## Changes proposed in this PR:
This PR updates the Consul on ECS Terraform modules to use `consul-ecs v0.6.0` and the latest 1.15.1 patch release of Consul.

## How I've tested this PR:
Acceptance tests :heavy_check_mark: 

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] ~Tests added~ N/A
- [x] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::