### PR TITLE
Update cache file for setup-go action

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
+          cache-dependency-path: ./test/acceptance/go.sum
       - name: Go CI lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
@@ -150,6 +151,7 @@ jobs:
       uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
       with:
         go-version: ${{ needs.get-go-version.outputs.go-version }}
+        cache-dependency-path: ./test/acceptance/go.sum
     - name: Install base apps
       run: |
         sudo apt-get install -y expect openssl jq


### PR DESCRIPTION
## Changes proposed in this PR:
This PR specifies the path to the `go.sum` file in the `test/acceptance` directory so that the `setup-go` action can successfully find the cache dependency file.

## How I've tested this PR:
Acceptance tests in CI

## How I expect reviewers to test this PR:
:eyes: 

## Checklist:
- [x] ~Tests added~ N/a
- [x] ~CHANGELOG entry added~ N/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::