### PR TITLE
Bump consul and envoy versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS
 * Bump Consul OSS image version to 1.15.4 and Consul enterprise version to 1.15.4-ent
-* Bump envoy image to 1.23.1
+* Bump envoy image to 1.23.10
 
 ## 0.6.0 (Mar 15, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.6.1 (Jul 20, 2023)
 
 IMPROVEMENTS
-* Bump Consul OSS image version to 1.16.0 and Consul enterprise version to 1.16.0-ent
-* Bump envoy image to 1.26.2 
+* Bump Consul OSS image version to 1.15.4 and Consul enterprise version to 1.15.4-ent
+* Bump envoy image to 1.23.1
 
 ## 0.6.0 (Mar 15, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.1 (Jul 20, 2023)
+
+IMPROVEMENTS
+* Bump Consul OSS image version to 1.16.0 and Consul enterprise version to 1.16.0-ent
+* Bump envoy image to 1.26.2 
+
 ## 0.6.0 (Mar 15, 2023)
 
 FEATURES

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -15,7 +15,7 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.12.2-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.16.0-ent"
 }
 
 variable "consul_ecs_image" {

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -15,13 +15,13 @@ variable "tags" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.16.0-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.15.4-ent"
 }
 
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.5.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.6.0"
 }
 
 variable "client_partition" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,7 +61,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.16.0"
+  default     = "public.ecr.aws/hashicorp/consul:1.15.4"
 }
 
 variable "consul_license" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,7 +61,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.15.1"
+  default     = "public.ecr.aws/hashicorp/consul:1.16.0"
 }
 
 variable "consul_license" {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.6.0"
+  version_string = "0.6.1"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -97,7 +97,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-distroless:v1.23.1"
+  default     = "envoyproxy/envoy-distroless:v1.23.10"
 }
 
 variable "log_configuration" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -85,7 +85,7 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.16.0"
+  default     = "public.ecr.aws/hashicorp/consul:1.15.4"
 }
 
 variable "consul_ecs_image" {
@@ -97,7 +97,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-distroless:v1.26.2"
+  default     = "envoyproxy/envoy-distroless:v1.23.1"
 }
 
 variable "log_configuration" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -85,7 +85,7 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.15.1"
+  default     = "public.ecr.aws/hashicorp/consul:1.16.0"
 }
 
 variable "consul_ecs_image" {
@@ -97,7 +97,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-distroless:v1.23.1"
+  default     = "envoyproxy/envoy-distroless:v1.26.2"
 }
 
 variable "log_configuration" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.6.0"
+  version_string = "0.6.1"
 
   gossip_encryption_enabled = var.gossip_key_secret_arn != ""
   consul_data_volume_name   = "consul_data"

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -151,7 +151,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-distroless:v1.23.1"
+  default     = "envoyproxy/envoy-distroless:v1.23.10"
 }
 
 variable "envoy_public_listener_port" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -151,7 +151,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-distroless:v1.26.2"
+  default     = "envoyproxy/envoy-distroless:v1.23.1"
 }
 
 variable "envoy_public_listener_port" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -139,7 +139,7 @@ variable "outbound_only" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.15.1"
+  default     = "public.ecr.aws/hashicorp/consul:1.16.0"
 }
 
 variable "consul_ecs_image" {
@@ -151,7 +151,7 @@ variable "consul_ecs_image" {
 variable "envoy_image" {
   description = "Envoy Docker image."
   type        = string
-  default     = "envoyproxy/envoy-distroless:v1.23.1"
+  default     = "envoyproxy/envoy-distroless:v1.26.2"
 }
 
 variable "envoy_public_listener_port" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -139,7 +139,7 @@ variable "outbound_only" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul:1.16.0"
+  default     = "public.ecr.aws/hashicorp/consul:1.15.4"
 }
 
 variable "consul_ecs_image" {


### PR DESCRIPTION
## Changes proposed in this PR:

- Bump Consul images to it's latest patch release
- Bump Envoy image to the image supported by dataplane 1.2.0

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [X] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::