### PR TITLE
Fix acceptance tests

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -105,44 +105,42 @@ jobs:
       # HCP is always disabled for tests on PRs.
       matrix:
         name:
-          # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           - acceptance-1.15-FARGATE-HCP
-          # - acceptance-1.14-FARGATE-HCP
-          # - acceptance-1.13-FARGATE
-          # - acceptance-1.15-EC2
-          # - acceptance-1.14-EC2
-          # - acceptance-1.13-EC2-HCP
+          - acceptance-1.14-FARGATE-HCP
+          - acceptance-1.13-FARGATE
+          - acceptance-1.15-EC2
+          - acceptance-1.14-EC2
+          - acceptance-1.13-EC2-HCP
         include:
-          # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           - name: acceptance-1.15-FARGATE-HCP
             consul-version: '1.15.4'
             enable-hcp: true
             launch-type: FARGATE
 
-          # - name: acceptance-1.14-FARGATE-HCP
-          #   consul-version: '1.14.7'
-          #   enable-hcp: true
-          #   launch-type: FARGATE
+          - name: acceptance-1.14-FARGATE-HCP
+            consul-version: '1.14.7'
+            enable-hcp: true
+            launch-type: FARGATE
 
-          # - name: acceptance-1.13-FARGATE
-          #   consul-version: '1.13.9'
-          #   enable-hcp: false
-          #   launch-type: FARGATE
+          - name: acceptance-1.13-FARGATE
+            consul-version: '1.13.9'
+            enable-hcp: false
+            launch-type: FARGATE
 
-          # - name: acceptance-1.15-EC2
-          #   consul-version: '1.15.4'
-          #   enable-hcp: false
-          #   launch-type: EC2
+          - name: acceptance-1.15-EC2
+            consul-version: '1.15.4'
+            enable-hcp: false
+            launch-type: EC2
 
-          # - name: acceptance-1.14-EC2
-          #   consul-version: '1.14.8'
-          #   enable-hcp: false
-          #   launch-type: EC2
+          - name: acceptance-1.14-EC2
+            consul-version: '1.14.8'
+            enable-hcp: false
+            launch-type: EC2
 
-          # - name: acceptance-1.13-EC2-HCP
-          #   consul-version: '1.13.8'
-          #   enable-hcp: true
-          #   launch-type: EC2
+          - name: acceptance-1.13-EC2-HCP
+            consul-version: '1.13.8'
+            enable-hcp: true
+            launch-type: EC2
 
     steps:
     - name: Checkout

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -108,9 +108,9 @@ jobs:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # TODO: - acceptance-1.15-FARGATE-HCP
           - acceptance-1.14-FARGATE-HCP
-          # - acceptance-1.13-FARGATE
-          # - acceptance-1.15-EC2
-          # - acceptance-1.14-EC2
+          - acceptance-1.13-FARGATE
+          - acceptance-1.15-EC2
+          - acceptance-1.14-EC2
           - acceptance-1.13-EC2-HCP
         include:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
@@ -124,20 +124,20 @@ jobs:
             enable-hcp: true
             launch-type: FARGATE
 
-          # - name: acceptance-1.13-FARGATE
-          #   consul-version: '1.13.9'
-          #   enable-hcp: false
-          #   launch-type: FARGATE
+          - name: acceptance-1.13-FARGATE
+            consul-version: '1.13.9'
+            enable-hcp: false
+            launch-type: FARGATE
 
-          # - name: acceptance-1.15-EC2
-          #   consul-version: '1.15.4'
-          #   enable-hcp: false
-          #   launch-type: EC2
+          - name: acceptance-1.15-EC2
+            consul-version: '1.15.4'
+            enable-hcp: false
+            launch-type: EC2
 
-          # - name: acceptance-1.14-EC2
-          #   consul-version: '1.14.8'
-          #   enable-hcp: false
-          #   launch-type: EC2
+          - name: acceptance-1.14-EC2
+            consul-version: '1.14.8'
+            enable-hcp: false
+            launch-type: EC2
 
           - name: acceptance-1.13-EC2-HCP
             consul-version: '1.13.8'

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -108,9 +108,9 @@ jobs:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # TODO: - acceptance-1.15-FARGATE-HCP
           #- acceptance-1.14-FARGATE-HCP
-          #- acceptance-1.13-FARGATE
+          - acceptance-1.13-FARGATE
           - acceptance-1.15-EC2
-          #- acceptance-1.14-EC2
+          - acceptance-1.14-EC2
           #- acceptance-1.13-EC2-HCP
         include:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
@@ -124,20 +124,20 @@ jobs:
           #   enable-hcp: true
           #   launch-type: FARGATE
 
-          # - name: acceptance-1.13-FARGATE
-          #   consul-version: '1.13.9'
-          #   enable-hcp: false
-          #   launch-type: FARGATE
+          - name: acceptance-1.13-FARGATE
+            consul-version: '1.13.9'
+            enable-hcp: false
+            launch-type: FARGATE
 
           - name: acceptance-1.15-EC2
             consul-version: '1.15.4'
             enable-hcp: false
             launch-type: EC2
 
-          # - name: acceptance-1.14-EC2
-          #   consul-version: '1.14.8'
-          #   enable-hcp: false
-          #   launch-type: EC2
+          - name: acceptance-1.14-EC2
+            consul-version: '1.14.8'
+            enable-hcp: false
+            launch-type: EC2
 
           # - name: acceptance-1.13-EC2-HCP
           #   consul-version: '1.13.8'
@@ -190,19 +190,16 @@ jobs:
         esac
         terraform init
         terraform apply -auto-approve $VARS
-    - name: Custom step
+    - name: Acceptance tests
       run: |
-        sleep 3m 30s
-    # - name: Acceptance tests
-    #   run: |
-    #     mkdir -p "$TEST_RESULTS"
-    #     cd tests/
-    #     gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
-    # - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-    #   if: always()
-    #   with:
-    #     name: acceptance-test-results
-    #     path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
+        mkdir -p "$TEST_RESULTS"
+        cd tests/
+        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      if: always()
+      with:
+        name: acceptance-test-results
+        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
     - name: terraform destroy
       if: always()
       run: |

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -107,11 +107,11 @@ jobs:
         name:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # TODO: - acceptance-1.15-FARGATE-HCP
-          #- acceptance-1.14-FARGATE-HCP
-          - acceptance-1.13-FARGATE
-          - acceptance-1.15-EC2
-          - acceptance-1.14-EC2
-          #- acceptance-1.13-EC2-HCP
+          - acceptance-1.14-FARGATE-HCP
+          # - acceptance-1.13-FARGATE
+          # - acceptance-1.15-EC2
+          # - acceptance-1.14-EC2
+          - acceptance-1.13-EC2-HCP
         include:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # - name: acceptance-1.15-FARGATE-HCP
@@ -119,30 +119,30 @@ jobs:
           #   enable-hcp: true
           #   launch-type: FARGATE
 
-          # - name: acceptance-1.14-FARGATE-HCP
-          #   consul-version: '1.14.7'
-          #   enable-hcp: true
-          #   launch-type: FARGATE
-
-          - name: acceptance-1.13-FARGATE
-            consul-version: '1.13.9'
-            enable-hcp: false
+          - name: acceptance-1.14-FARGATE-HCP
+            consul-version: '1.14.7'
+            enable-hcp: true
             launch-type: FARGATE
 
-          - name: acceptance-1.15-EC2
-            consul-version: '1.15.4'
-            enable-hcp: false
-            launch-type: EC2
+          # - name: acceptance-1.13-FARGATE
+          #   consul-version: '1.13.9'
+          #   enable-hcp: false
+          #   launch-type: FARGATE
 
-          - name: acceptance-1.14-EC2
-            consul-version: '1.14.8'
-            enable-hcp: false
-            launch-type: EC2
-
-          # - name: acceptance-1.13-EC2-HCP
-          #   consul-version: '1.13.8'
-          #   enable-hcp: true
+          # - name: acceptance-1.15-EC2
+          #   consul-version: '1.15.4'
+          #   enable-hcp: false
           #   launch-type: EC2
+
+          # - name: acceptance-1.14-EC2
+          #   consul-version: '1.14.8'
+          #   enable-hcp: false
+          #   launch-type: EC2
+
+          - name: acceptance-1.13-EC2-HCP
+            consul-version: '1.13.8'
+            enable-hcp: true
+            launch-type: EC2
 
     steps:
     - name: Checkout

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -107,11 +107,11 @@ jobs:
         name:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # TODO: - acceptance-1.15-FARGATE-HCP
-          - acceptance-1.15-FARGATE-HCP
-          - acceptance-1.14-FARGATE
-          - acceptance-1.16-EC2
+          #- acceptance-1.14-FARGATE-HCP
+          #- acceptance-1.13-FARGATE
           - acceptance-1.15-EC2
-          - acceptance-1.14-EC2-HCP
+          #- acceptance-1.14-EC2
+          #- acceptance-1.13-EC2-HCP
         include:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # - name: acceptance-1.15-FARGATE-HCP
@@ -119,30 +119,30 @@ jobs:
           #   enable-hcp: true
           #   launch-type: FARGATE
 
-          - name: acceptance-1.15-FARGATE-HCP
-            consul-version: '1.15.3'
-            enable-hcp: true
-            launch-type: FARGATE
+          # - name: acceptance-1.14-FARGATE-HCP
+          #   consul-version: '1.14.7'
+          #   enable-hcp: true
+          #   launch-type: FARGATE
 
-          - name: acceptance-1.14-FARGATE
-            consul-version: '1.14.7'
-            enable-hcp: false
-            launch-type: FARGATE
-
-          - name: acceptance-1.16-EC2
-            consul-version: '1.16.0'
-            enable-hcp: false
-            launch-type: EC2
+          # - name: acceptance-1.13-FARGATE
+          #   consul-version: '1.13.9'
+          #   enable-hcp: false
+          #   launch-type: FARGATE
 
           - name: acceptance-1.15-EC2
             consul-version: '1.15.4'
             enable-hcp: false
             launch-type: EC2
 
-          - name: acceptance-1.14-EC2-HCP
-            consul-version: '1.14.8'
-            enable-hcp: true
-            launch-type: EC2
+          # - name: acceptance-1.14-EC2
+          #   consul-version: '1.14.8'
+          #   enable-hcp: false
+          #   launch-type: EC2
+
+          # - name: acceptance-1.13-EC2-HCP
+          #   consul-version: '1.13.8'
+          #   enable-hcp: true
+          #   launch-type: EC2
 
     steps:
     - name: Checkout

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -106,43 +106,43 @@ jobs:
       matrix:
         name:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
-          # TODO: - acceptance-1.15-FARGATE-HCP
-          - acceptance-1.14-FARGATE-HCP
-          - acceptance-1.13-FARGATE
-          - acceptance-1.15-EC2
-          - acceptance-1.14-EC2
-          - acceptance-1.13-EC2-HCP
+          - acceptance-1.15-FARGATE-HCP
+          # - acceptance-1.14-FARGATE-HCP
+          # - acceptance-1.13-FARGATE
+          # - acceptance-1.15-EC2
+          # - acceptance-1.14-EC2
+          # - acceptance-1.13-EC2-HCP
         include:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
-          # - name: acceptance-1.15-FARGATE-HCP
-          #   consul-version: '1.15.1'
+          - name: acceptance-1.15-FARGATE-HCP
+            consul-version: '1.15.4'
+            enable-hcp: true
+            launch-type: FARGATE
+
+          # - name: acceptance-1.14-FARGATE-HCP
+          #   consul-version: '1.14.7'
           #   enable-hcp: true
           #   launch-type: FARGATE
 
-          - name: acceptance-1.14-FARGATE-HCP
-            consul-version: '1.14.7'
-            enable-hcp: true
-            launch-type: FARGATE
+          # - name: acceptance-1.13-FARGATE
+          #   consul-version: '1.13.9'
+          #   enable-hcp: false
+          #   launch-type: FARGATE
 
-          - name: acceptance-1.13-FARGATE
-            consul-version: '1.13.9'
-            enable-hcp: false
-            launch-type: FARGATE
+          # - name: acceptance-1.15-EC2
+          #   consul-version: '1.15.4'
+          #   enable-hcp: false
+          #   launch-type: EC2
 
-          - name: acceptance-1.15-EC2
-            consul-version: '1.15.4'
-            enable-hcp: false
-            launch-type: EC2
+          # - name: acceptance-1.14-EC2
+          #   consul-version: '1.14.8'
+          #   enable-hcp: false
+          #   launch-type: EC2
 
-          - name: acceptance-1.14-EC2
-            consul-version: '1.14.8'
-            enable-hcp: false
-            launch-type: EC2
-
-          - name: acceptance-1.13-EC2-HCP
-            consul-version: '1.13.8'
-            enable-hcp: true
-            launch-type: EC2
+          # - name: acceptance-1.13-EC2-HCP
+          #   consul-version: '1.13.8'
+          #   enable-hcp: true
+          #   launch-type: EC2
 
     steps:
     - name: Checkout

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -193,16 +193,16 @@ jobs:
     - name: Custom step
       run: |
         sleep 3m 30s
-    - name: Acceptance tests
-      run: |
-        mkdir -p "$TEST_RESULTS"
-        cd tests/
-        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      if: always()
-      with:
-        name: acceptance-test-results
-        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
+    # - name: Acceptance tests
+    #   run: |
+    #     mkdir -p "$TEST_RESULTS"
+    #     cd tests/
+    #     gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
+    # - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+    #   if: always()
+    #   with:
+    #     name: acceptance-test-results
+    #     path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
     - name: terraform destroy
       if: always()
       run: |

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -107,11 +107,11 @@ jobs:
         name:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # TODO: - acceptance-1.15-FARGATE-HCP
-          - acceptance-1.14-FARGATE-HCP
-          - acceptance-1.13-FARGATE
+          - acceptance-1.15-FARGATE-HCP
+          - acceptance-1.14-FARGATE
+          - acceptance-1.16-EC2
           - acceptance-1.15-EC2
-          - acceptance-1.14-EC2
-          - acceptance-1.13-EC2-HCP
+          - acceptance-1.14-EC2-HCP
         include:
           # TODO: Enable testing on HCP for Consul 1.15.x when it is supported on HCP
           # - name: acceptance-1.15-FARGATE-HCP
@@ -119,28 +119,28 @@ jobs:
           #   enable-hcp: true
           #   launch-type: FARGATE
 
-          - name: acceptance-1.14-FARGATE-HCP
-            consul-version: '1.14.4'
+          - name: acceptance-1.15-FARGATE-HCP
+            consul-version: '1.15.3'
             enable-hcp: true
             launch-type: FARGATE
 
-          - name: acceptance-1.13-FARGATE
-            consul-version: '1.13.7'
+          - name: acceptance-1.14-FARGATE
+            consul-version: '1.14.7'
             enable-hcp: false
             launch-type: FARGATE
 
+          - name: acceptance-1.16-EC2
+            consul-version: '1.16.0'
+            enable-hcp: false
+            launch-type: EC2
+
           - name: acceptance-1.15-EC2
-            consul-version: '1.15.1'
+            consul-version: '1.15.4'
             enable-hcp: false
             launch-type: EC2
 
-          - name: acceptance-1.14-EC2
-            consul-version: '1.14.5'
-            enable-hcp: false
-            launch-type: EC2
-
-          - name: acceptance-1.13-EC2-HCP
-            consul-version: '1.13.6'
+          - name: acceptance-1.14-EC2-HCP
+            consul-version: '1.14.8'
             enable-hcp: true
             launch-type: EC2
 

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -193,16 +193,16 @@ jobs:
     - name: Custom step
       run: |
         sleep 3m 30s
-    # - name: Acceptance tests
-    #   run: |
-    #     mkdir -p "$TEST_RESULTS"
-    #     cd tests/
-    #     gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
-    # - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-    #   if: always()
-    #   with:
-    #     name: acceptance-test-results
-    #     path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
+    - name: Acceptance tests
+      run: |
+        mkdir -p "$TEST_RESULTS"
+        cd tests/
+        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      if: always()
+      with:
+        name: acceptance-test-results
+        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
     - name: terraform destroy
       if: always()
       run: |

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -190,16 +190,19 @@ jobs:
         esac
         terraform init
         terraform apply -auto-approve $VARS
-    - name: Acceptance tests
+    - name: Custom step
       run: |
-        mkdir -p "$TEST_RESULTS"
-        cd tests/
-        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      if: always()
-      with:
-        name: acceptance-test-results
-        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
+        sleep 3m 30s
+    # - name: Acceptance tests
+    #   run: |
+    #     mkdir -p "$TEST_RESULTS"
+    #     cd tests/
+    #     gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
+    # - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+    #   if: always()
+    #   with:
+    #     name: acceptance-test-results
+    #     path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
     - name: terraform destroy
       if: always()
       run: |

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -99,3 +99,13 @@ module "hcp" {
   vpc            = module.vpc
   consul_version = var.consul_version
 }
+
+resource "aws_security_group_rule" "cluster_egress" {
+  description       = "Access to endpoints outside the VPC"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.vpc.default_security_group_id
+}

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -106,6 +106,6 @@ resource "aws_security_group_rule" "cluster_egress" {
   from_port                = 0
   to_port                  = 0
   protocol                 = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks              = ["0.0.0.0/0"]
   security_group_id        = module.vpc.default_security_group_id
 }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -53,7 +53,7 @@ module "vpc" {
       from_port   = 0
       to_port     = 0
       protocol    = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_blocks = "0.0.0.0/0"
     }
   ]
 }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -99,3 +99,12 @@ module "hcp" {
   vpc            = module.vpc
   consul_version = var.consul_version
 }
+
+resource "aws_security_group_rule" "cluster_egress" {
+  description              = "Access to endpoints outside the VPC"
+  type                     = "egress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  security_group_id        = module.vpc.default_security_group_id
+}

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -101,11 +101,11 @@ module "hcp" {
 }
 
 resource "aws_security_group_rule" "cluster_egress" {
-  description              = "Access to endpoints outside the VPC"
-  type                     = "egress"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  cidr_blocks              = ["0.0.0.0/0"]
-  security_group_id        = module.vpc.default_security_group_id
+  description       = "Access to endpoints outside the VPC"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = module.vpc.default_security_group_id
 }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -106,5 +106,6 @@ resource "aws_security_group_rule" "cluster_egress" {
   from_port                = 0
   to_port                  = 0
   protocol                 = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id        = module.vpc.default_security_group_id
 }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -100,12 +100,12 @@ module "hcp" {
   consul_version = var.consul_version
 }
 
-resource "aws_security_group_rule" "cluster_egress" {
-  description       = "Access to endpoints outside the VPC"
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = module.vpc.default_security_group_id
-}
+# resource "aws_security_group_rule" "cluster_egress" {
+#   description       = "Access to endpoints outside the VPC"
+#   type              = "egress"
+#   from_port         = 0
+#   to_port           = 0
+#   protocol          = "-1"
+#   cidr_blocks       = ["0.0.0.0/0"]
+#   security_group_id = module.vpc.default_security_group_id
+# }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -30,7 +30,7 @@ resource "random_shuffle" "azs" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.78.0"
+  version = "5.0.0"
 
   name = local.name
   cidr = "10.0.0.0/16"

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -48,6 +48,14 @@ module "vpc" {
   single_nat_gateway   = true
   enable_dns_hostnames = true
   tags                 = var.tags
+  default_security_group_egress = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  ]
 }
 
 // Create ECS clusters
@@ -99,13 +107,3 @@ module "hcp" {
   vpc            = module.vpc
   consul_version = var.consul_version
 }
-
-# resource "aws_security_group_rule" "cluster_egress" {
-#   description       = "Access to endpoints outside the VPC"
-#   type              = "egress"
-#   from_port         = 0
-#   to_port           = 0
-#   protocol          = "-1"
-#   cidr_blocks       = ["0.0.0.0/0"]
-#   security_group_id = module.vpc.default_security_group_id
-# }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -56,6 +56,14 @@ module "vpc" {
       cidr_blocks = "0.0.0.0/0"
     }
   ]
+  default_security_group_ingress = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = "0.0.0.0/0"
+    }
+  ]
 }
 
 // Create ECS clusters

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -56,14 +56,6 @@ module "vpc" {
       cidr_blocks = "0.0.0.0/0"
     }
   ]
-  default_security_group_ingress = [
-    {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = "0.0.0.0/0"
-    }
-  ]
 }
 
 // Create ECS clusters

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -99,13 +99,3 @@ module "hcp" {
   vpc            = module.vpc
   consul_version = var.consul_version
 }
-
-resource "aws_security_group_rule" "cluster_egress" {
-  description       = "Access to endpoints outside the VPC"
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = module.vpc.default_security_group_id
-}


### PR DESCRIPTION
## Changes proposed in this PR:
- Bump the vpc module to `5.0.0` because the existing version was failing with some unknown input variable related error.
- Bump consul to the latest patch versions for each minor version release.
- For some reason, the default vpc did not contain security group rules for egress and ingress traffic. Added rules to cover the same

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added (Not needed)

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::