### PR TITLE
Fix ingress security group rule

### DIFF
--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -58,10 +58,9 @@ module "vpc" {
   ]
   default_security_group_ingress = [
     {
-      from_port   = 0
-      to_port     = 0
-      protocol    = "-1"
-      cidr_blocks = "0.0.0.0/0"
+      description = "Allow all"
+      protocol = -1
+      self = true
     }
   ]
 }

--- a/test/acceptance/setup-terraform/main.tf
+++ b/test/acceptance/setup-terraform/main.tf
@@ -59,8 +59,8 @@ module "vpc" {
   default_security_group_ingress = [
     {
       description = "Allow all"
-      protocol = -1
-      self = true
+      protocol    = -1
+      self        = true
     }
   ]
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Fixes the existing ingress security group rule for the VPC that gets created for the acceptance tests. Doing so prevents public internet traffic from reaching this vpc network.

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::