### PR TITLE
Changes to support TProxy for ECS EC2

### DIFF
--- a/examples/admin-partitions/terraform/client.tf
+++ b/examples/admin-partitions/terraform/client.tf
@@ -91,7 +91,8 @@ module "example_client" {
       awslogs-stream-prefix = "example_client_${local.client_suffix}"
     }
   }
-  outbound_only = true
+  outbound_only            = true
+  enable_transparent_proxy = false
 
   tls                    = true
   acls                   = true

--- a/examples/admin-partitions/terraform/server.tf
+++ b/examples/admin-partitions/terraform/server.tf
@@ -71,7 +71,8 @@ module "example_server" {
       timeout  = 10
     }
   }]
-  consul_server_hosts = local.server_host
+  consul_server_hosts      = local.server_host
+  enable_transparent_proxy = false
   log_configuration = {
     logDriver = "awslogs"
     options = {

--- a/examples/cluster-peering/client-app.tf
+++ b/examples/cluster-peering/client-app.tf
@@ -18,13 +18,14 @@ locals {
 
 
 module "example_client_app" {
-  source              = "../../modules/mesh-task"
-  family              = local.example_client_app_name
-  port                = "9090"
-  acls                = true
-  consul_server_hosts = module.dc1.dev_consul_server.server_dns
-  tls                 = true
-  consul_ca_cert_arn  = module.dc1.dev_consul_server.ca_cert_arn
+  source                   = "../../modules/mesh-task"
+  family                   = local.example_client_app_name
+  port                     = "9090"
+  acls                     = true
+  consul_server_hosts      = module.dc1.dev_consul_server.server_dns
+  tls                      = true
+  consul_ca_cert_arn       = module.dc1.dev_consul_server.ca_cert_arn
+  enable_transparent_proxy = false
   upstreams = [
     {
       destinationName = "${var.name}-${local.datacenter_2}-example-server-app"

--- a/examples/cluster-peering/server-app.tf
+++ b/examples/cluster-peering/server-app.tf
@@ -14,14 +14,15 @@ locals {
 }
 
 module "example_server_app" {
-  source              = "../../modules/mesh-task"
-  family              = local.example_server_app_name
-  port                = "9090"
-  acls                = true
-  consul_server_hosts = module.dc2.dev_consul_server.server_dns
-  tls                 = true
-  consul_ca_cert_arn  = module.dc2.dev_consul_server.ca_cert_arn
-  log_configuration   = local.example_server_app_log_config
+  source                   = "../../modules/mesh-task"
+  family                   = local.example_server_app_name
+  port                     = "9090"
+  acls                     = true
+  consul_server_hosts      = module.dc2.dev_consul_server.server_dns
+  tls                      = true
+  consul_ca_cert_arn       = module.dc2.dev_consul_server.ca_cert_arn
+  log_configuration        = local.example_server_app_log_config
+  enable_transparent_proxy = false
   container_definitions = [{
     name             = "example-server-app"
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"

--- a/examples/dev-server-ec2/README.md
+++ b/examples/dev-server-ec2/README.md
@@ -108,6 +108,10 @@ ssh -J 'ec2-user@1.2.3.4' 'ec2-user@10.0.1.2'
 
 To explore Consul and the sample application, see the [Fargate Example README](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/examples/dev-server-fargate/README.md#explore).
 
+### Transparent proxy
+
+ECS on EC2 now supports deploying tasks in the [transparent proxy](https://developer.hashicorp.com/consul/docs/k8s/connect/transparent-proxy) mode where you no longer need to explicitly add the sidecar proxy's local listener as an upstream for the client application. By default, `enable_transparent_proxy` variable defaults to `true`. You need to manually disable this for Fargate based deployments.
+
 ## Cleanup
 
 Once you've done testing, be sure to clean up the resources you've created:

--- a/examples/dev-server-ec2/main.tf
+++ b/examples/dev-server-ec2/main.tf
@@ -54,7 +54,7 @@ module "example_client_app" {
   family                   = "${var.name}-example-client-app"
   requires_compatibilities = ["EC2"]
   memory                   = 256
-  port                     = "9090"
+  port                     = 9090
   enable_transparent_proxy = var.enable_transparent_proxy
   enable_consul_dns        = var.enable_transparent_proxy
   exclude_inbound_ports    = var.enable_transparent_proxy ? [9090] : []
@@ -88,7 +88,7 @@ module "example_client_app" {
   }]
   consul_server_hosts = module.dev_consul_server.server_dns
 
-  consul_ecs_config = var.enable_transparent_proxy ? local.client_ecs_config : null
+  consul_ecs_config = local.client_ecs_config
 }
 
 # The server app is part of the service mesh. It's called
@@ -111,7 +111,7 @@ module "example_server_app" {
   family                   = "${var.name}-example-server-app"
   requires_compatibilities = ["EC2"]
   memory                   = 256
-  port                     = "9090"
+  port                     = 9090
   log_configuration        = local.example_server_app_log_config
   enable_transparent_proxy = var.enable_transparent_proxy
   container_definitions = [{
@@ -237,7 +237,7 @@ locals {
 
   # Proxy config needed to expose health endpoints of the client application
   # when traffic redirection rules get applied with transparent proxy.
-  client_ecs_config = {
+  client_ecs_config = var.enable_transparent_proxy ? {
     proxy = {
       expose = {
         paths = [
@@ -250,5 +250,5 @@ locals {
         ]
       }
     }
-  }
+  } : null
 }

--- a/examples/dev-server-ec2/main.tf
+++ b/examples/dev-server-ec2/main.tf
@@ -55,13 +55,11 @@ module "example_client_app" {
   requires_compatibilities = ["EC2"]
   memory                   = 256
   port                     = "9090"
-  upstreams = [
-    {
-      destinationName = "${var.name}-example-server-app"
-      localBindPort   = 1234
-    }
-  ]
-  log_configuration = local.example_client_app_log_config
+  enable_transparent_proxy = var.enable_transparent_proxy
+  enable_consul_dns        = var.enable_transparent_proxy
+  exclude_inbound_ports    = var.enable_transparent_proxy ? [9090] : []
+  upstreams                = var.enable_transparent_proxy ? [] : local.client_app_upstreams
+  log_configuration        = local.example_client_app_log_config
   container_definitions = [{
     name             = "example-client-app"
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
@@ -74,7 +72,7 @@ module "example_client_app" {
       },
       {
         name  = "UPSTREAM_URIS"
-        value = "http://localhost:1234"
+        value = local.server_upstream_uri
       }
     ]
     portMappings = [
@@ -89,6 +87,8 @@ module "example_client_app" {
     volumesFrom = []
   }]
   consul_server_hosts = module.dev_consul_server.server_dns
+
+  consul_ecs_config = var.enable_transparent_proxy ? local.client_ecs_config : null
 }
 
 # The server app is part of the service mesh. It's called
@@ -113,6 +113,7 @@ module "example_server_app" {
   memory                   = 256
   port                     = "9090"
   log_configuration        = local.example_server_app_log_config
+  enable_transparent_proxy = var.enable_transparent_proxy
   container_definitions = [{
     name             = "example-server-app"
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
@@ -221,6 +222,33 @@ locals {
       awslogs-group         = aws_cloudwatch_log_group.log_group.name
       awslogs-region        = var.region
       awslogs-stream-prefix = "client"
+    }
+  }
+
+  client_app_upstreams = [
+    {
+      destinationName = "${var.name}-example-server-app"
+      localBindPort   = 1234
+    }
+  ]
+
+  # Assign the consul DNS name of the server app when transparent proxy is enabled.
+  server_upstream_uri = var.enable_transparent_proxy ? "http://${var.name}-example-server-app.service.consul" : "http://localhost:1234"
+
+  # Proxy config needed to expose health endpoints of the client application
+  # when traffic redirection rules get applied with transparent proxy.
+  client_ecs_config = {
+    proxy = {
+      expose = {
+        paths = [
+          {
+            listenerPort  = 20300
+            path          = "/health"
+            localPathPort = 9090
+            protocol      = "http"
+          }
+        ]
+      }
     }
   }
 }

--- a/examples/dev-server-ec2/variables.tf
+++ b/examples/dev-server-ec2/variables.tf
@@ -23,3 +23,9 @@ variable "public_ssh_key" {
   type        = string
   default     = null
 }
+
+variable "enable_transparent_proxy" {
+  description = "Whether to enable transparent proxy for the services(tasks) deployed in EC2 instances"
+  type        = bool
+  default     = true
+}

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -59,7 +59,8 @@ module "example_client_app" {
       localBindPort   = 1234
     }
   ]
-  log_configuration = local.example_client_app_log_config
+  log_configuration        = local.example_client_app_log_config
+  enable_transparent_proxy = false
   container_definitions = [{
     name             = "example-client-app"
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"
@@ -112,10 +113,11 @@ resource "aws_ecs_service" "example_server_app" {
 }
 
 module "example_server_app" {
-  source            = "../../modules/mesh-task"
-  family            = "${var.name}-example-server-app"
-  port              = "9090"
-  log_configuration = local.example_server_app_log_config
+  source                   = "../../modules/mesh-task"
+  family                   = "${var.name}-example-server-app"
+  port                     = "9090"
+  log_configuration        = local.example_server_app_log_config
+  enable_transparent_proxy = false
   container_definitions = [{
     name             = "example-server-app"
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"

--- a/examples/mesh-gateways/client-app.tf
+++ b/examples/mesh-gateways/client-app.tf
@@ -35,7 +35,8 @@ module "example_client_app" {
       }
     }
   ]
-  log_configuration = local.example_client_app_log_config
+  log_configuration        = local.example_client_app_log_config
+  enable_transparent_proxy = false
   container_definitions = [
     {
       name             = "example-client-app"

--- a/examples/mesh-gateways/server-app.tf
+++ b/examples/mesh-gateways/server-app.tf
@@ -16,14 +16,15 @@ locals {
 }
 
 module "example_server_app" {
-  source              = "../../modules/mesh-task"
-  family              = local.example_server_app_name
-  port                = "9090"
-  acls                = true
-  consul_server_hosts = module.dc2.dev_consul_server.server_dns
-  tls                 = true
-  consul_ca_cert_arn  = aws_secretsmanager_secret.ca_cert.arn
-  log_configuration   = local.example_server_app_log_config
+  source                   = "../../modules/mesh-task"
+  family                   = local.example_server_app_name
+  port                     = "9090"
+  acls                     = true
+  consul_server_hosts      = module.dc2.dev_consul_server.server_dns
+  tls                      = true
+  consul_ca_cert_arn       = aws_secretsmanager_secret.ca_cert.arn
+  log_configuration        = local.example_server_app_log_config
+  enable_transparent_proxy = false
   container_definitions = [{
     name             = "example-server-app"
     image            = "docker.mirror.hashicorp.services/nicholasjackson/fake-service:v0.21.0"

--- a/examples/service-sameness/client-app/client.tf
+++ b/examples/service-sameness/client-app/client.tf
@@ -15,14 +15,15 @@ locals {
 
 
 module "example_client_app" {
-  source              = "../../../modules/mesh-task"
-  family              = local.example_client_app_name
-  consul_service_name = "${var.name}-example-client-app"
-  port                = var.port
-  acls                = true
-  consul_server_hosts = var.consul_server_address
-  tls                 = true
-  consul_ca_cert_arn  = var.consul_server_ca_cert_arn
+  source                   = "../../../modules/mesh-task"
+  family                   = local.example_client_app_name
+  consul_service_name      = "${var.name}-example-client-app"
+  port                     = var.port
+  acls                     = true
+  consul_server_hosts      = var.consul_server_address
+  tls                      = true
+  consul_ca_cert_arn       = var.consul_server_ca_cert_arn
+  enable_transparent_proxy = false
   upstreams = [
     {
       destinationName = "${var.name}-example-server-app"

--- a/examples/service-sameness/server-app/server-app.tf
+++ b/examples/service-sameness/server-app/server-app.tf
@@ -36,9 +36,10 @@ module "example_server_app" {
     ]
   }]
 
-  consul_ecs_image = var.consul_ecs_image
-  consul_partition = var.consul_partition
-  consul_namespace = "default"
+  enable_transparent_proxy = false
+  consul_ecs_image         = var.consul_ecs_image
+  consul_partition         = var.consul_partition
+  consul_namespace         = "default"
 }
 
 resource "aws_ecs_service" "example_server_app" {

--- a/modules/mesh-task/config.tf
+++ b/modules/mesh-task/config.tf
@@ -6,6 +6,7 @@ locals {
   serviceExtra = lookup(var.consul_ecs_config, "service", {})
   proxyExtra   = lookup(var.consul_ecs_config, "proxy", {})
   loginExtra   = lookup(var.consul_ecs_config, "consulLogin", {})
+  tProxyExtra  = lookup(var.consul_ecs_config, "transparentProxy", {})
 
   consulLogin = var.acls ? {
     enabled = var.acls
@@ -26,6 +27,17 @@ locals {
     },
     var.grpc_config
   )
+
+  transparentProxy = {
+    enabled              = var.enable_transparent_proxy
+    excludeInboundPorts  = var.exclude_inbound_ports
+    excludeOutboundPorts = var.exclude_outbound_ports
+    excludeOutboundCIDRs = var.exclude_outbound_cidrs
+    excludeUIDs          = var.exclude_uids
+    consulDNS = {
+      enabled = var.enable_consul_dns
+    }
+  }
 
   config = {
     consulLogin = merge(local.consulLogin, local.loginExtra)
@@ -61,6 +73,7 @@ locals {
       http = local.httpSettings
       grpc = local.grpcSettings
     }
+    transparentProxy = merge(local.tProxyExtra, local.transparentProxy)
   }
 
   encoded_config = jsonencode(local.config)

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -75,6 +75,65 @@ locals {
 
   defaulted_check_containers = [for def in local.container_defs_with_depends_on : def.name
   if contains(keys(def), "essential") && contains(keys(def), "healthCheck") && (try(def.healthCheck, null) != null)]
+
+  control_plane_container_definition = {
+    name             = "consul-ecs-control-plane"
+    image            = var.consul_ecs_image
+    essential        = false
+    logConfiguration = var.log_configuration
+    command          = ["control-plane"]
+    mountPoints = [
+      local.consul_data_mount_read_write,
+      {
+        sourceVolume  = local.consul_binary_volume_name
+        containerPath = "/bin/consul-inject"
+        readOnly      = true
+      }
+    ]
+    cpu         = 0
+    volumesFrom = []
+    environment = [
+      {
+        name  = "CONSUL_ECS_CONFIG_JSON",
+        value = local.encoded_config
+      }
+    ]
+    linuxParameters = {
+      initProcessEnabled = true
+      capabilities       = var.enable_transparent_proxy ? { add = ["NET_ADMIN"] } : {}
+    }
+    healthCheck = {
+      command  = ["CMD-SHELL", "curl localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
+      interval = 30
+      retries  = 10
+      timeout  = 5
+    }
+    secrets = flatten(
+      concat(
+        var.tls ? [
+          concat(
+            local.https_ca_cert_arn != "" ? [
+              {
+                name      = "CONSUL_HTTPS_CACERT_PEM"
+                valueFrom = local.https_ca_cert_arn
+              },
+            ] : [],
+            local.grpc_ca_cert_arn != "" ? [
+              {
+                name      = "CONSUL_GRPC_CACERT_PEM"
+                valueFrom = local.grpc_ca_cert_arn
+              }
+            ] : [],
+            []
+          )
+        ] : [],
+        []
+      )
+    )
+  }
+
+  additional_user_attr                         = var.enable_transparent_proxy ? { user = "0" } : {}
+  finalized_control_plane_container_definition = merge(local.control_plane_container_definition, local.additional_user_attr)
 }
 
 resource "aws_ecs_task_definition" "this" {
@@ -174,64 +233,12 @@ resource "aws_ecs_task_definition" "this" {
       concat(
         local.container_defs_with_depends_on,
         [
-          {
-            name             = "consul-ecs-control-plane"
-            image            = var.consul_ecs_image
-            essential        = false
-            logConfiguration = var.log_configuration
-            command          = ["control-plane"]
-            mountPoints = [
-              local.consul_data_mount_read_write,
-              {
-                sourceVolume  = local.consul_binary_volume_name
-                containerPath = "/bin/consul-inject"
-                readOnly      = true
-              }
-            ]
-            cpu         = 0
-            volumesFrom = []
-            environment = [
-              {
-                name  = "CONSUL_ECS_CONFIG_JSON",
-                value = local.encoded_config
-              }
-            ]
-            linuxParameters = {
-              initProcessEnabled = true
-            }
-            healthCheck = {
-              command  = ["CMD-SHELL", "curl localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
-              interval = 30
-              retries  = 10
-              timeout  = 5
-            }
-            secrets = flatten(
-              concat(
-                var.tls ? [
-                  concat(
-                    local.https_ca_cert_arn != "" ? [
-                      {
-                        name      = "CONSUL_HTTPS_CACERT_PEM"
-                        valueFrom = local.https_ca_cert_arn
-                      },
-                    ] : [],
-                    local.grpc_ca_cert_arn != "" ? [
-                      {
-                        name      = "CONSUL_GRPC_CACERT_PEM"
-                        valueFrom = local.grpc_ca_cert_arn
-                      }
-                    ] : [],
-                    []
-                  )
-                ] : [],
-                []
-              )
-            )
-          },
+          local.finalized_control_plane_container_definition,
           {
             name             = "consul-dataplane"
             image            = var.consul_dataplane_image
             essential        = false
+            user             = "5995"
             logConfiguration = var.log_configuration
             entryPoint       = ["/consul/consul-ecs", "envoy-entrypoint"]
             command          = ["consul-dataplane", "-config-file", "/consul/consul-dataplane.json"] # consul-ecs-control-plane dumps the dataplane's config into consul-dataplane.json

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -132,6 +132,8 @@ locals {
     )
   }
 
+  # Additional user attribute that needs to be added to run the control-plane
+  # container with root access.
   additional_user_attr                         = var.enable_transparent_proxy ? { user = "0" } : {}
   finalized_control_plane_container_definition = merge(local.control_plane_container_definition, local.additional_user_attr)
 }

--- a/modules/mesh-task/validation.tf
+++ b/modules/mesh-task/validation.tf
@@ -8,5 +8,5 @@ locals {
   require_partition_if_namespace_is_set                     = (var.consul_namespace != "" && var.consul_partition == "") ? file("ERROR: consul_partition must be set if consul_namespace is set") : null
   require_no_additional_task_policies_with_passed_role      = (!var.create_task_role && length(var.additional_task_role_policies) > 0) ? file("ERROR: cannot set additional_task_role_policies when create_task_role=false") : null
   require_no_additional_execution_policies_with_passed_role = (!var.create_execution_role && length(var.additional_execution_role_policies) > 0) ? file("ERROR: cannot set additional_execution_role_policies when create_execution_role=false") : null
-  require_ec2_for_tproxy_support                            = var.enable_transparent_proxy && length(var.requires_compatibilities) == 1 && var.requires_compatibilities[0] != "EC2" ? file("ERROR: transparent proxy is supported only in ECS EC2 mode") : null
+  require_ec2_compability_for_tproxy_support                = var.enable_transparent_proxy && (length(var.requires_compatibilities) != 1 || var.requires_compatibilities[0] != "EC2") ? file("ERROR: transparent proxy is supported only in ECS EC2 mode") : null
 }

--- a/modules/mesh-task/validation.tf
+++ b/modules/mesh-task/validation.tf
@@ -8,4 +8,5 @@ locals {
   require_partition_if_namespace_is_set                     = (var.consul_namespace != "" && var.consul_partition == "") ? file("ERROR: consul_partition must be set if consul_namespace is set") : null
   require_no_additional_task_policies_with_passed_role      = (!var.create_task_role && length(var.additional_task_role_policies) > 0) ? file("ERROR: cannot set additional_task_role_policies when create_task_role=false") : null
   require_no_additional_execution_policies_with_passed_role = (!var.create_execution_role && length(var.additional_execution_role_policies) > 0) ? file("ERROR: cannot set additional_execution_role_policies when create_execution_role=false") : null
+  require_ec2_for_tproxy_support                            = var.enable_transparent_proxy && length(var.requires_compatibilities) == 1 && var.requires_compatibilities[0] != "EC2" ? file("ERROR: transparent proxy is supported only in ECS EC2 mode") : null
 }

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "ganeshrockz/ecs-tproxy"
 }
 
 variable "consul_dataplane_image" {
@@ -337,10 +337,10 @@ variable "consul_ecs_config" {
   EOT
 
   validation {
-    error_message = "Only the 'service', 'proxy', and 'consulLogin' fields are allowed in consul_ecs_config."
+    error_message = "Only the 'service', 'proxy', 'transparentProxy' and 'consulLogin' fields are allowed in consul_ecs_config."
     condition = alltrue([
       for key in keys(var.consul_ecs_config) :
-      contains(["service", "proxy", "consulLogin"], key)
+      contains(["service", "proxy", "consulLogin", "transparentProxy"], key)
     ])
   }
 
@@ -422,6 +422,23 @@ variable "consul_ecs_config" {
     ]))
   }
 
+  validation {
+    error_message = "Only the 'enabled','excludeInboundPorts','excludeOutboundPorts','excludeOutboundCIDRs', 'excludeUIDs' and 'consulDNS' fields are allowed in consul_ecs_config.transparentProxy."
+    condition = alltrue([
+      for key in keys(lookup(var.consul_ecs_config, "transparentProxy", {})) :
+      contains(["enabled", "excludeInboundPorts", "excludeOutboundPorts", "excludeUIDs", "excludeOutboundCIDRs", "consulDNS"], key)
+    ])
+  }
+
+  validation {
+    error_message = "Only the 'enabled' field is allowed in consul_ecs_config.transparentProxy.consulDNS."
+    condition = alltrue(flatten([
+      for tproxy in [lookup(var.consul_ecs_config, "transparentProxy", {})] : [
+        for key in keys(lookup(tproxy, "consulDNS", {})) :
+        contains(["enabled"], key)
+      ]
+    ]))
+  }
 }
 
 variable "http_config" {
@@ -458,4 +475,40 @@ variable "grpc_config" {
       contains(["port", "tls", "tlsServerName", "caCertFile"], key)
     ])
   }
+}
+
+variable "enable_transparent_proxy" {
+  description = "Whether transparent proxy should be enabled for this task. Defaults to true"
+  type        = bool
+  default     = true
+}
+
+variable "enable_consul_dns" {
+  description = "Whether Consul DNS should be configured for this task. This rewrites the /etc/resolv.conf file to point to the Consul dataplane's DNS server as the primary nameserver. Defaults to false"
+  type        = bool
+  default     = false
+}
+
+variable "exclude_inbound_ports" {
+  description = "List of inbound ports to exclude from traffic redirection."
+  type        = list(number)
+  default     = []
+}
+
+variable "exclude_outbound_ports" {
+  description = "List of outbound ports to exclude from traffic redirection."
+  type        = list(number)
+  default     = []
+}
+
+variable "exclude_outbound_cidrs" {
+  description = "List of additional IP CIDRs to exclude from outbound traffic redirection."
+  type        = list(string)
+  default     = []
+}
+
+variable "exclude_uids" {
+  description = "List of additional UIDs to exclude from outbound traffic redirection."
+  type        = list(string)
+  default     = []
 }

--- a/test/acceptance/tests/validation/terraform/tproxy-ec2-validate/main.tf
+++ b/test/acceptance/tests/validation/terraform/tproxy-ec2-validate/main.tf
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "requires_compatibilities" {
+  description = "Set of launch types required by the task."
+  type        = list(string)
+}
+
+module "test_client" {
+  source = "../../../../../../modules/mesh-task"
+  family = "family"
+  container_definitions = [{
+    name = "basic"
+  }]
+  outbound_only            = true
+  consul_server_hosts      = "consul.dc1.host"
+  requires_compatibilities = var.requires_compatibilities
+  enable_transparent_proxy = true
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Modified mesh-task submodule to support TProxy. The following are the changes
   - Added a `enable_transparent_proxy` input that defaults to `true`
   - Adds individual variables to support multiple parts of the `transparentProxy` config.

- Modified existing examples to support tproxy.

## How I've tested this PR:

Manual deployment

## How I expect reviewers to test this PR:

👀 

## Checklist:
- [ ] Tests added (Will add acceptance tests in the next PR)
- [ ] CHANGELOG entry added - N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::