### PR TITLE
Expose `gateway_count` in gateway module

### DIFF
--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -184,7 +184,7 @@ resource "aws_ecs_service" "this" {
   name            = local.service_name
   cluster         = var.ecs_cluster_arn
   task_definition = aws_ecs_task_definition.this.arn
-  desired_count   = 1
+  desired_count   = var.gateway_count
   network_configuration {
     subnets          = var.subnets
     security_groups  = local.security_groups

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -6,6 +6,12 @@ variable "family" {
   type        = string
 }
 
+variable "gateway_count" {
+  description = "Number of gateways to deploy to ECS."
+  type        = number
+  default     = 1
+}
+
 variable "ecs_cluster_arn" {
   description = "The ARN of the ECS cluster where the gateway will be running."
   type        = string

--- a/test/acceptance/tests/validation/terraform/mesh-gateway-validate/main.tf
+++ b/test/acceptance/tests/validation/terraform/mesh-gateway-validate/main.tf
@@ -60,6 +60,10 @@ variable "lb_modify_security_group_id" {
   default = ""
 }
 
+variable "gateway_count" {
+  type    = number
+  default = 1
+}
 
 module "test_gateway" {
   source                             = "../../../../../../modules/gateway-task"
@@ -68,6 +72,7 @@ module "test_gateway" {
   subnets                            = ["subnets"]
   security_groups                    = var.security_groups
   kind                               = var.kind
+  gateway_count                      = var.gateway_count 
   consul_server_hosts                = "localhost:8500"
   enable_mesh_gateway_wan_federation = var.enable_mesh_gateway_wan_federation
   tls                                = var.tls

--- a/test/acceptance/tests/validation/terraform/mesh-gateway-validate/main.tf
+++ b/test/acceptance/tests/validation/terraform/mesh-gateway-validate/main.tf
@@ -72,7 +72,7 @@ module "test_gateway" {
   subnets                            = ["subnets"]
   security_groups                    = var.security_groups
   kind                               = var.kind
-  gateway_count                      = var.gateway_count 
+  gateway_count                      = var.gateway_count
   consul_server_hosts                = "localhost:8500"
   enable_mesh_gateway_wan_federation = var.enable_mesh_gateway_wan_federation
   tls                                = var.tls

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -824,7 +824,7 @@ func TestValidation_MeshGateway(t *testing.T) {
 			kind:      "mesh-gateway",
 			lbEnabled: true,
 			lbSubnets: []string{"subnet"},
-			lbVpcID:   "vpc"
+			lbVpcID:   "vpc",
 		},
 		"lb_enabled and no lb subnets": {
 			kind:      "mesh-gateway",

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -786,7 +786,7 @@ func TestValidation_MeshGateway(t *testing.T) {
 		lbModifySecGroup        bool
 		lbModifySecGroupID      string
 		expError                string
-		gatewayCount           int
+		gatewayCount            int
 	}{
 		"kind is required": {
 			kind:                    "",
@@ -824,7 +824,7 @@ func TestValidation_MeshGateway(t *testing.T) {
 			kind:      "mesh-gateway",
 			lbEnabled: true,
 			lbSubnets: []string{"subnet"},
-			lbVpcID:   "vpc",		},
+			lbVpcID:   "vpc"},
 		"lb_enabled and no lb subnets": {
 			kind:      "mesh-gateway",
 			lbEnabled: true,
@@ -869,10 +869,10 @@ func TestValidation_MeshGateway(t *testing.T) {
 			lbModifySecGroupID: "mod-sg",
 		},
 		"multiple gateways": {
-			kind:      "mesh-gateway",
-			lbEnabled: true,
-			lbSubnets: []string{"subnet"},
-			lbVpcID:   "vpc",
+			kind:         "mesh-gateway",
+			lbEnabled:    true,
+			lbSubnets:    []string{"subnet"},
+			lbVpcID:      "vpc",
 			gatewayCount: 2,
 		},
 	}

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -786,6 +786,7 @@ func TestValidation_MeshGateway(t *testing.T) {
 		lbModifySecGroup        bool
 		lbModifySecGroupID      string
 		expError                string
+		gatewayCount           int
 	}{
 		"kind is required": {
 			kind:                    "",
@@ -823,8 +824,7 @@ func TestValidation_MeshGateway(t *testing.T) {
 			kind:      "mesh-gateway",
 			lbEnabled: true,
 			lbSubnets: []string{"subnet"},
-			lbVpcID:   "vpc",
-		},
+			lbVpcID:   "vpc",		},
 		"lb_enabled and no lb subnets": {
 			kind:      "mesh-gateway",
 			lbEnabled: true,
@@ -868,6 +868,13 @@ func TestValidation_MeshGateway(t *testing.T) {
 			lbModifySecGroup:   true,
 			lbModifySecGroupID: "mod-sg",
 		},
+		"multiple gateways": {
+			kind:      "mesh-gateway",
+			lbEnabled: true,
+			lbSubnets: []string{"subnet"},
+			lbVpcID:   "vpc",
+			gatewayCount: 2,
+		},
 	}
 	for name, c := range cases {
 		c := c
@@ -885,6 +892,7 @@ func TestValidation_MeshGateway(t *testing.T) {
 				"lb_create_security_group":           c.lbCreateSecGroup,
 				"lb_modify_security_group":           c.lbModifySecGroup,
 				"lb_modify_security_group_id":        c.lbModifySecGroupID,
+				"multiple_gateways":                  c.gatewayCount,
 			}
 			if len(c.kind) > 0 {
 				tfVars["kind"] = c.kind

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -892,7 +892,7 @@ func TestValidation_MeshGateway(t *testing.T) {
 				"lb_create_security_group":           c.lbCreateSecGroup,
 				"lb_modify_security_group":           c.lbModifySecGroup,
 				"lb_modify_security_group_id":        c.lbModifySecGroupID,
-				"multiple_gateways":                  c.gatewayCount,
+				"gateway_count":                      c.gatewayCount,
 			}
 			if len(c.kind) > 0 {
 				tfVars["kind"] = c.kind

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -824,7 +824,8 @@ func TestValidation_MeshGateway(t *testing.T) {
 			kind:      "mesh-gateway",
 			lbEnabled: true,
 			lbSubnets: []string{"subnet"},
-			lbVpcID:   "vpc"},
+			lbVpcID:   "vpc"
+		},
 		"lb_enabled and no lb subnets": {
 			kind:      "mesh-gateway",
 			lbEnabled: true,


### PR DESCRIPTION
## Changes proposed in this PR:
- Makes the count of gateway ECS tasks configurable, to enable more than one load balanced gateways.

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::