### PR TITLE
Reference ECS release candidate images for examples and submodules

### DIFF
--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -24,6 +24,17 @@ on:
         description: "Whether to create a HCP cluster for running acceptance tests"
         required: true
         type: boolean
+    secrets:
+      aws-ecs-region:
+        required: true
+      aws-ecs-role-arn:
+        required: true
+      aws-ecs-access-key-id:
+        required: true
+      aws-ecs-secret-access-key:
+        required: true
+      hcp-project-id:
+        required: true
 
 
 env:
@@ -66,10 +77,10 @@ jobs:
     - name: Assume AWS IAM Role
       uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
       with:
-        role-to-assume: ${{ secrets.AWS_ECS_ROLE_ARN }}
-        aws-region: "us-west-2"
-        aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.aws-ecs-role-arn }}
+        aws-region: ${{ secrets.aws-ecs-region }}
+        aws-access-key-id: ${{ secrets.aws-ecs-access-key-id }}
+        aws-secret-access-key: ${{ secrets.aws-ecs-secret-access-key }}
         role-duration-seconds: 7200
     - name: terraform init & apply
       run: |
@@ -77,7 +88,7 @@ jobs:
         VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
         VARS+=' -var launch_type=${{ inputs.launch-type }}'
         VARS+=' -var consul_version=${{ inputs.consul-version }}'
-        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
+        VARS+=' -var hcp_project_id=${{ secrets.hcp-project-id }}'
         case $GITHUB_REF_NAME in
             main | release/*) VARS+=" -var enable_hcp=${{ inputs.enable-hcp }}";;
             *) VARS+=" -var enable_hcp=false";;
@@ -101,7 +112,7 @@ jobs:
         VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
         VARS+=' -var launch_type=${{ inputs.launch-type }}'
         VARS+=' -var consul_version=${{ inputs.consul-version }}'
-        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
+        VARS+=' -var hcp_project_id=${{ secrets.hcp-project-id }}'
         case $GITHUB_REF_NAME in
             main | release/*) VARS+=" -var enable_hcp=${{ inputs.enable-hcp }}";;
             *) VARS+=" -var enable_hcp=false";;

--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -67,7 +67,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
       with:
         role-to-assume: ${{ secrets.AWS_ECS_ROLE_ARN }}
-        aws-region: ${{ secrets.AWS_ECS_REGION }}
+        aws-region: "us-west-2"
         aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
         role-duration-seconds: 7200

--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -1,0 +1,109 @@
+name: reusable-ecs-acceptance
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: "The name of the job that runs the tests"
+        required: true
+        type: string
+      go-version:
+        description: "Version of Go to use to run the tests"
+        required: true
+        type: string
+      launch-type:
+        description: "The ECS launch type. Can be either EC2 or FARGATE"
+        required: false
+        type: string
+        default: "FARGATE"
+      consul-version:
+        required: false
+        type: string
+        default: "1.16.2"
+      enable-hcp:
+        description: "Whether to create a HCP cluster for running acceptance tests"
+        required: true
+        type: boolean
+
+
+env:
+  TEST_RESULTS: /tmp/test-results
+  GOTESTSUM_VERSION: 1.8.0
+
+jobs:
+  acceptance-tests:
+    name: ${{ inputs.name }}
+    runs-on: ['ubuntu-latest']
+    defaults:
+      run:
+        working-directory: ./test/acceptance
+    steps:
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Setup Go
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache-dependency-path: ./test/acceptance/go.sum
+    - name: Install base apps
+      run: |
+        sudo apt-get install -y expect openssl jq
+    - name: Install gotestsum
+      run: |
+        curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${{ env.GOTESTSUM_VERSION }}/gotestsum_${{ env.GOTESTSUM_VERSION }}_linux_amd64.tar.gz" | \
+        tar -xz --overwrite -C /usr/local/bin gotestsum
+    - name: Install AWS CLI
+      run: |
+        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+        sudo dpkg -i session-manager-plugin.deb
+        aws --version
+        echo session-manager-plugin version "$(session-manager-plugin --version)"
+    - name: Install AWS ECS CLI
+      run: |
+        curl -sSL "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest" -o /usr/local/bin/ecs-cli
+        chmod +x /usr/local/bin/ecs-cli
+        ecs-cli --version
+    - name: Assume AWS IAM Role
+      uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
+      with:
+        role-to-assume: ${{ secrets.AWS_ECS_ROLE_ARN }}
+        aws-region: ${{ secrets.AWS_ECS_REGION }}
+        aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 7200
+    - name: terraform init & apply
+      run: |
+        cd setup-terraform/
+        VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
+        VARS+=' -var launch_type=${{ inputs.launch-type }}'
+        VARS+=' -var consul_version=${{ inputs.consul-version }}'
+        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
+        case $GITHUB_REF_NAME in
+            main | release/*) VARS+=" -var enable_hcp=${{ inputs.enable-hcp }}";;
+            *) VARS+=" -var enable_hcp=false";;
+        esac
+        terraform init
+        terraform apply -auto-approve $VARS
+    - name: Acceptance tests
+      run: |
+        mkdir -p "$TEST_RESULTS"
+        cd tests/
+        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      if: always()
+      with:
+        name: acceptance-test-results
+        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
+    - name: terraform destroy
+      if: always()
+      run: |
+        cd setup-terraform/
+        VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
+        VARS+=' -var launch_type=${{ inputs.launch-type }}'
+        VARS+=' -var consul_version=${{ inputs.consul-version }}'
+        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
+        case $GITHUB_REF_NAME in
+            main | release/*) VARS+=" -var enable_hcp=${{ inputs.enable-hcp }}";;
+            *) VARS+=" -var enable_hcp=false";;
+        esac
+        terraform destroy -auto-approve $VARS

--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -35,11 +35,20 @@ on:
         required: true
       hcp-project-id:
         required: true
+      consul-license:
+        required: true
+      hcp-client-id:
+        required: true
+      hcp-client-secret:
+        required: true
 
 
 env:
   TEST_RESULTS: /tmp/test-results
   GOTESTSUM_VERSION: 1.8.0
+  CONSUL_LICENSE: ${{ secrets.consul-license }}
+  HCP_CLIENT_ID: ${{ secrets.hcp-client-id }}
+  HCP_CLIENT_SECRET: ${{ secrets.hcp-client-secret }}
 
 jobs:
   acceptance-tests:

--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -24,31 +24,14 @@ on:
         description: "Whether to create a HCP cluster for running acceptance tests"
         required: true
         type: boolean
-    secrets:
-      aws-ecs-region:
-        required: true
-      aws-ecs-role-arn:
-        required: true
-      aws-ecs-access-key-id:
-        required: true
-      aws-ecs-secret-access-key:
-        required: true
-      hcp-project-id:
-        required: true
-      consul-license:
-        required: true
-      hcp-client-id:
-        required: true
-      hcp-client-secret:
-        required: true
 
 
 env:
   TEST_RESULTS: /tmp/test-results
   GOTESTSUM_VERSION: 1.8.0
-  CONSUL_LICENSE: ${{ secrets.consul-license }}
-  HCP_CLIENT_ID: ${{ secrets.hcp-client-id }}
-  HCP_CLIENT_SECRET: ${{ secrets.hcp-client-secret }}
+  CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
+  HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+  HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
 
 jobs:
   acceptance-tests:
@@ -86,10 +69,10 @@ jobs:
     - name: Assume AWS IAM Role
       uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
       with:
-        role-to-assume: ${{ secrets.aws-ecs-role-arn }}
-        aws-region: ${{ secrets.aws-ecs-region }}
-        aws-access-key-id: ${{ secrets.aws-ecs-access-key-id }}
-        aws-secret-access-key: ${{ secrets.aws-ecs-secret-access-key }}
+        role-to-assume: ${{ secrets.AWS_ECS_ROLE_ARN }}
+        aws-region: ${{ secrets.AWS_ECS_REGION }}
+        aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
         role-duration-seconds: 7200
     - name: terraform init & apply
       run: |
@@ -97,7 +80,7 @@ jobs:
         VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
         VARS+=' -var launch_type=${{ inputs.launch-type }}'
         VARS+=' -var consul_version=${{ inputs.consul-version }}'
-        VARS+=' -var hcp_project_id=${{ secrets.hcp-project-id }}'
+        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
         case $GITHUB_REF_NAME in
             main | release/*) VARS+=" -var enable_hcp=${{ inputs.enable-hcp }}";;
             *) VARS+=" -var enable_hcp=false";;
@@ -121,7 +104,7 @@ jobs:
         VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
         VARS+=' -var launch_type=${{ inputs.launch-type }}'
         VARS+=' -var consul_version=${{ inputs.consul-version }}'
-        VARS+=' -var hcp_project_id=${{ secrets.hcp-project-id }}'
+        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
         case $GITHUB_REF_NAME in
             main | release/*) VARS+=" -var enable_hcp=${{ inputs.enable-hcp }}";;
             *) VARS+=" -var enable_hcp=false";;

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -107,7 +107,7 @@ jobs:
           - name: acceptance-1.16-FARGATE
             enable-hcp: false
             launch-type: FARGATE
-    uses: ./github/workflows/reusable-ecs-acceptance.yml
+    uses: ./.github/workflows/reusable-ecs-acceptance.yml
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
       name: ${{ matrix.name }}
@@ -133,7 +133,7 @@ jobs:
           - name: acceptance-1.16-EC2
             enable-hcp: false
             launch-type: EC2
-    uses: ./github/workflows/reusable-ecs-acceptance.yml
+    uses: ./.github/workflows/reusable-ecs-acceptance.yml
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
       name: ${{ matrix.name }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -11,10 +11,7 @@ on:
     branches:
       - 'main'
       - 'release/**'
-env:
-  CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
-  HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
-  HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
+
 permissions: {}
 jobs:
   action-lint:
@@ -119,6 +116,9 @@ jobs:
       aws-ecs-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
       aws-ecs-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
       hcp-project-id: ${{ secrets.HCP_PROJECT_ID }}
+      consul-license: ${{ secrets.CONSUL_LICENSE }}
+      hcp-client-id: ${{ secrets.HCP_CLIENT_ID }}
+      hcp-client-secret: ${{ secrets.HCP_CLIENT_SECRET }}
   acceptance-ec2:
     needs:
       - get-go-version
@@ -151,3 +151,6 @@ jobs:
       aws-ecs-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
       aws-ecs-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
       hcp-project-id: ${{ secrets.HCP_PROJECT_ID }}
+      consul-license: ${{ secrets.CONSUL_LICENSE }}
+      hcp-client-id: ${{ secrets.HCP_CLIENT_ID }}
+      hcp-client-secret: ${{ secrets.HCP_CLIENT_SECRET }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -104,6 +104,7 @@ jobs:
           - name: acceptance-1.16-FARGATE
             enable-hcp: false
             launch-type: FARGATE
+      fail-fast: false
     uses: ./.github/workflows/reusable-ecs-acceptance.yml
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
@@ -131,6 +132,7 @@ jobs:
           - name: acceptance-1.16-EC2
             enable-hcp: false
             launch-type: EC2
+      fail-fast: false
     uses: ./.github/workflows/reusable-ecs-acceptance.yml
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -113,29 +113,29 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
-  acceptance-ec2:
-    runs-on: ubuntu-latest
-    needs:
-      - acceptance-fargate
-    strategy:
-      # We have a limit of 6 HCP Consul clusters.
-      # The following controls whether to enable HCP when testing release branches.
-      # HCP is always disabled for tests on PRs.
-      matrix:
-        name:
-          - acceptance-1.16-EC2-HCP
-          - acceptance-1.16-EC2
-        include:
-          - name: acceptance-1.16-EC2-HCP
-            enable-hcp: true
-            launch-type: EC2
+  # acceptance-ec2:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - acceptance-fargate
+  #   strategy:
+  #     # We have a limit of 6 HCP Consul clusters.
+  #     # The following controls whether to enable HCP when testing release branches.
+  #     # HCP is always disabled for tests on PRs.
+  #     matrix:
+  #       name:
+  #         - acceptance-1.16-EC2-HCP
+  #         - acceptance-1.16-EC2
+  #       include:
+  #         - name: acceptance-1.16-EC2-HCP
+  #           enable-hcp: true
+  #           launch-type: EC2
 
-          - name: acceptance-1.16-EC2
-            enable-hcp: false
-            launch-type: EC2
-    uses: ./.github/workflows/reusable-ecs-acceptance.yml
-    with:
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
-      name: ${{ matrix.name }}
-      launch-type: ${{ matrix.launch-type }}
-      enable-hcp: ${{ matrix.enable-hcp }}
+  #         - name: acceptance-1.16-EC2
+  #           enable-hcp: false
+  #           launch-type: EC2
+  #   uses: ./.github/workflows/reusable-ecs-acceptance.yml
+  #   with:
+  #     go-version: ${{ needs.get-go-version.outputs.go-version }}
+  #     name: ${{ matrix.name }}
+  #     launch-type: ${{ matrix.launch-type }}
+  #     enable-hcp: ${{ matrix.enable-hcp }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -94,12 +94,12 @@ jobs:
       # HCP is always disabled for tests on PRs.
       matrix:
         name:
-          #- acceptance-1.16-FARGATE-HCP
+          - acceptance-1.16-FARGATE-HCP
           - acceptance-1.16-FARGATE
         include:
-          # - name: acceptance-1.16-FARGATE-HCP
-          #   enable-hcp: true
-          #   launch-type: FARGATE
+          - name: acceptance-1.16-FARGATE-HCP
+            enable-hcp: true
+            launch-type: FARGATE
 
           - name: acceptance-1.16-FARGATE
             enable-hcp: false
@@ -110,15 +110,7 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
-    secrets:
-      aws-ecs-region: ${{ secrets.AWS_ECS_REGION }}
-      aws-ecs-role-arn: ${{ secrets.AWS_ECS_ROLE_ARN }}
-      aws-ecs-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
-      aws-ecs-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
-      hcp-project-id: ${{ secrets.HCP_PROJECT_ID }}
-      consul-license: ${{ secrets.CONSUL_LICENSE }}
-      hcp-client-id: ${{ secrets.HCP_CLIENT_ID }}
-      hcp-client-secret: ${{ secrets.HCP_CLIENT_SECRET }}
+    secrets: inherit
   acceptance-ec2:
     needs:
       - get-go-version
@@ -129,12 +121,12 @@ jobs:
       # HCP is always disabled for tests on PRs.
       matrix:
         name:
-          #- acceptance-1.16-EC2-HCP
+          - acceptance-1.16-EC2-HCP
           - acceptance-1.16-EC2
         include:
-          # - name: acceptance-1.16-EC2-HCP
-          #   enable-hcp: true
-          #   launch-type: EC2
+          - name: acceptance-1.16-EC2-HCP
+            enable-hcp: true
+            launch-type: EC2
 
           - name: acceptance-1.16-EC2
             enable-hcp: false
@@ -145,12 +137,4 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
-    secrets:
-      aws-ecs-region: ${{ secrets.AWS_ECS_REGION }}
-      aws-ecs-role-arn: ${{ secrets.AWS_ECS_ROLE_ARN }}
-      aws-ecs-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
-      aws-ecs-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
-      hcp-project-id: ${{ secrets.HCP_PROJECT_ID }}
-      consul-license: ${{ secrets.CONSUL_LICENSE }}
-      hcp-client-id: ${{ secrets.HCP_CLIENT_ID }}
-      hcp-client-secret: ${{ secrets.HCP_CLIENT_SECRET }}
+    secrets: inherit

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -113,6 +113,12 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
+    secrets:
+      aws-ecs-region: ${{ secrets.AWS_ECS_REGION }}
+      aws-ecs-role-arn: ${{ secrets.AWS_ECS_ROLE_ARN }}
+      aws-ecs-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
+      aws-ecs-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
+      hcp-project-id: ${{ secrets.HCP_PROJECT_ID }}
   acceptance-ec2:
     needs:
       - get-go-version
@@ -139,3 +145,9 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
+    secrets:
+      aws-ecs-region: ${{ secrets.AWS_ECS_REGION }}
+      aws-ecs-role-arn: ${{ secrets.AWS_ECS_ROLE_ARN }}
+      aws-ecs-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
+      aws-ecs-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
+      hcp-project-id: ${{ secrets.HCP_PROJECT_ID }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -86,117 +86,56 @@ jobs:
         terraform_version: 1.4.2
     - name: Validate
       run: terraform fmt -check -recursive .
-  acceptance:
-    name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
-    env:
-      TEST_RESULTS: /tmp/test-results
-      GOTESTSUM_VERSION: 1.8.0
+  acceptance-fargate:
     needs:
       - get-go-version
       - terraform-fmt
       - go-fmt-and-lint-acceptance
-    defaults:
-      run:
-        working-directory: ./test/acceptance
     strategy:
       # We have a limit of 6 HCP Consul clusters.
       # The following controls whether to enable HCP when testing release branches.
       # HCP is always disabled for tests on PRs.
       matrix:
         name:
-          - acceptance-1.16-FARGATE-HCP
-          - acceptance-1.16-EC2-HCP
+          #- acceptance-1.16-FARGATE-HCP
           - acceptance-1.16-FARGATE
-          - acceptance-1.16-EC2
         include:
-          - name: acceptance-1.16-FARGATE-HCP
-            consul-version: '1.16.1'
-            enable-hcp: true
-            launch-type: FARGATE
-
-          - name: acceptance-1.16-EC2-HCP
-            consul-version: '1.16.1'
-            enable-hcp: true
-            launch-type: EC2
+          # - name: acceptance-1.16-FARGATE-HCP
+          #   enable-hcp: true
+          #   launch-type: FARGATE
 
           - name: acceptance-1.16-FARGATE
-            consul-version: '1.16.1'
             enable-hcp: false
             launch-type: FARGATE
-
-          - name: acceptance-1.16-EC2
-            consul-version: '1.16.1'
-            enable-hcp: false
+    uses: ./github/workflows/reusable-ecs-acceptance.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      name: ${{ matrix.name }}
+      launch-type: ${{ matrix.launch-type }}
+      enable-hcp: ${{ matrix.enable-hcp }}
+  acceptance-ec2:
+    runs-on: ubuntu-latest
+    needs:
+      - acceptance-fargate
+    strategy:
+      # We have a limit of 6 HCP Consul clusters.
+      # The following controls whether to enable HCP when testing release branches.
+      # HCP is always disabled for tests on PRs.
+      matrix:
+        name:
+          - acceptance-1.16-EC2-HCP
+          - acceptance-1.16-EC2
+        include:
+          - name: acceptance-1.16-EC2-HCP
+            enable-hcp: true
             launch-type: EC2
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-    - name: Setup Go
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-      with:
-        go-version: ${{ needs.get-go-version.outputs.go-version }}
-        cache-dependency-path: ./test/acceptance/go.sum
-    - name: Install base apps
-      run: |
-        sudo apt-get install -y expect openssl jq
-    - name: Install gotestsum
-      run: |
-        curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${{ env.GOTESTSUM_VERSION }}/gotestsum_${{ env.GOTESTSUM_VERSION }}_linux_amd64.tar.gz" | \
-        tar -xz --overwrite -C /usr/local/bin gotestsum
-    - name: Install AWS CLI
-      run: |
-        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-        sudo dpkg -i session-manager-plugin.deb
-        aws --version
-        echo session-manager-plugin version "$(session-manager-plugin --version)"
-    - name: Install AWS ECS CLI
-      run: |
-        curl -sSL "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest" -o /usr/local/bin/ecs-cli
-        chmod +x /usr/local/bin/ecs-cli
-        ecs-cli --version
-    - name: Assume AWS IAM Role
-      uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4.0.0
-      with:
-        role-to-assume: ${{ secrets.AWS_ECS_ROLE_ARN }}
-        aws-region: ${{ secrets.AWS_ECS_REGION }}
-        aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
-        role-duration-seconds: 3600
-    - name: terraform init & apply
-      run: |
-        cd setup-terraform/
-        VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
-        VARS+=' -var launch_type=${{ matrix.launch-type }}'
-        VARS+=' -var consul_version=${{ matrix.consul-version }}'
-        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
-        case $GITHUB_REF_NAME in
-            main | release/*) VARS+=" -var enable_hcp=${{ matrix.enable-hcp }}";;
-            *) VARS+=" -var enable_hcp=false";;
-        esac
-        terraform init
-        terraform apply -auto-approve $VARS
-    - name: Acceptance tests
-      run: |
-        mkdir -p "$TEST_RESULTS"
-        cd tests/
-        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-      if: always()
-      with:
-        name: acceptance-test-results
-        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml
-    - name: terraform destroy
-      if: always()
-      run: |
-        cd setup-terraform/
-        VARS="-var tags={\"build_url\":\"$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}"
-        VARS+=' -var launch_type=${{ matrix.launch-type }}'
-        VARS+=' -var consul_version=${{ matrix.consul-version }}'
-        VARS+=' -var hcp_project_id=${{ secrets.HCP_PROJECT_ID }}'
-        case $GITHUB_REF_NAME in
-            main | release/*) VARS+=" -var enable_hcp=${{ matrix.enable-hcp }}";;
-            *) VARS+=" -var enable_hcp=false";;
-        esac
-        terraform destroy -auto-approve $VARS
+          - name: acceptance-1.16-EC2
+            enable-hcp: false
+            launch-type: EC2
+    uses: ./github/workflows/reusable-ecs-acceptance.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      name: ${{ matrix.name }}
+      launch-type: ${{ matrix.launch-type }}
+      enable-hcp: ${{ matrix.enable-hcp }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -115,6 +115,7 @@ jobs:
       enable-hcp: ${{ matrix.enable-hcp }}
   acceptance-ec2:
     needs:
+      - get-go-version
       - acceptance-fargate
     strategy:
       # We have a limit of 6 HCP Consul clusters.

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -113,29 +113,28 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
-  # acceptance-ec2:
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - acceptance-fargate
-  #   strategy:
-  #     # We have a limit of 6 HCP Consul clusters.
-  #     # The following controls whether to enable HCP when testing release branches.
-  #     # HCP is always disabled for tests on PRs.
-  #     matrix:
-  #       name:
-  #         - acceptance-1.16-EC2-HCP
-  #         - acceptance-1.16-EC2
-  #       include:
-  #         - name: acceptance-1.16-EC2-HCP
-  #           enable-hcp: true
-  #           launch-type: EC2
+  acceptance-ec2:
+    needs:
+      - acceptance-fargate
+    strategy:
+      # We have a limit of 6 HCP Consul clusters.
+      # The following controls whether to enable HCP when testing release branches.
+      # HCP is always disabled for tests on PRs.
+      matrix:
+        name:
+          #- acceptance-1.16-EC2-HCP
+          - acceptance-1.16-EC2
+        include:
+          # - name: acceptance-1.16-EC2-HCP
+          #   enable-hcp: true
+          #   launch-type: EC2
 
-  #         - name: acceptance-1.16-EC2
-  #           enable-hcp: false
-  #           launch-type: EC2
-  #   uses: ./.github/workflows/reusable-ecs-acceptance.yml
-  #   with:
-  #     go-version: ${{ needs.get-go-version.outputs.go-version }}
-  #     name: ${{ matrix.name }}
-  #     launch-type: ${{ matrix.launch-type }}
-  #     enable-hcp: ${{ matrix.enable-hcp }}
+          - name: acceptance-1.16-EC2
+            enable-hcp: false
+            launch-type: EC2
+    uses: ./.github/workflows/reusable-ecs-acceptance.yml
+    with:
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+      name: ${{ matrix.name }}
+      launch-type: ${{ matrix.launch-type }}
+      enable-hcp: ${{ matrix.enable-hcp }}

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_dataplane_image" {

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -102,7 +102,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_dataplane_image" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -64,7 +64,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -65,7 +65,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -61,7 +61,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -61,7 +61,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorpdev/consul-ecs:latest"
+  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_address" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Bump ECS image variables to refer to the latest release candidate's name
- Split existing acceptance test matrix into Fargate and EC2 to reduce flakiness

## How I've tested this PR:
CI

## How I expect reviewers to test this PR:
👁️ 

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::