### PR TITLE
Point terraform modules to use latest Consul images

### DIFF
--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -19,7 +19,7 @@ on:
       consul-version:
         required: false
         type: string
-        default: "1.16.2"
+        default: "1.17.0-rc1"
       enable-hcp:
         description: "Whether to create a HCP cluster for running acceptance tests"
         required: true

--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -19,7 +19,7 @@ on:
       consul-version:
         required: false
         type: string
-        default: "1.17.0-rc1"
+        default: "1.16.2"
       enable-hcp:
         description: "Whether to create a HCP cluster for running acceptance tests"
         required: true

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,13 +20,13 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorppreview/consul-dataplane:1.3.0-rc1"
+  default     = "hashicorp/consul-dataplane:1.3.0-rc1"
 }
 
 variable "client_partition" {

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/datacenter/variables.tf
+++ b/examples/service-sameness/datacenter/variables.tf
@@ -49,7 +49,7 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.16.1-ent"
+  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.17.0-rc1-ent"
 }
 
 variable "consul_license" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,7 +61,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorppreview/consul:1.17.0-rc1"
+  default     = "hashicorp/consul:1.17.0-rc1"
 }
 
 variable "consul_license" {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.7.0-dev"
+  version_string = "0.7.0-rc1"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -91,7 +91,7 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorppreview/consul:1.17.0-rc1"
+  default     = "hashicorp/consul:1.17.0-rc1"
 }
 
 variable "consul_server_hosts" {
@@ -108,13 +108,13 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorppreview/consul-dataplane:1.3.0-rc1"
+  default     = "hashicorp/consul-dataplane:1.3.0-rc1"
 }
 
 variable "envoy_readiness_port" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.7.0-dev"
+  version_string = "0.7.0-rc1"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,13 +145,13 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorppreview/consul-dataplane:1.3.0-rc1"
+  default     = "hashicorp/consul-dataplane:1.3.0-rc1"
 }
 
 variable "envoy_public_listener_port" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -64,7 +64,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -65,7 +65,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -61,7 +61,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -61,7 +61,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-rc1"
+  default     = "hashicorp/consul-ecs:0.7.0-rc1"
 }
 
 variable "consul_server_address" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Modify images to point to the release candidate images. This is needed to release 0.7.0-rc1 of the terraform-aws-consul-ecs submodules.

## How I've tested this PR:

CI, Manual

## How I expect reviewers to test this PR:

👀 

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::