### PR TITLE
Change IAM execution policy condition to require consul_ca_cert_arn instead of tls

### DIFF
--- a/modules/gateway-task/iam.tf
+++ b/modules/gateway-task/iam.tf
@@ -93,7 +93,7 @@ resource "aws_iam_policy" "execution" {
 {
   "Version": "2012-10-17",
   "Statement": [
-%{if var.consul_ca_cert_arn~}
+%{if var.consul_ca_cert_arn != ""~}
     {
       "Effect": "Allow",
       "Action": [

--- a/modules/gateway-task/iam.tf
+++ b/modules/gateway-task/iam.tf
@@ -93,7 +93,7 @@ resource "aws_iam_policy" "execution" {
 {
   "Version": "2012-10-17",
   "Statement": [
-%{if var.tls~}
+%{if var.consul_ca_cert_arn~}
     {
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Changes proposed in this PR:
- Changes the condition in the IAM execution policy on whether the `"secretsmanager:GetSecretValue"` statement is added to the existence of the `var.consul_ca_cert_arn`.   This makes it so that TLS can be enabled without passing that value and uses the logic used for the other statements in that IAM policy.
-

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::