### PR TITLE
Update gateway submodule to support API gateways

### DIFF
--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -19,7 +19,7 @@ on:
       consul-version:
         required: false
         type: string
-        default: "1.16.2"
+        default: "1.17.0"
       enable-hcp:
         description: "Whether to create a HCP cluster for running acceptance tests"
         required: true

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -94,14 +94,14 @@ jobs:
       # HCP is always disabled for tests on PRs.
       matrix:
         name:
-          - acceptance-1.16-FARGATE-HCP
-          - acceptance-1.16-FARGATE
+          - acceptance-1.17-FARGATE-HCP
+          - acceptance-1.17-FARGATE
         include:
-          - name: acceptance-1.16-FARGATE-HCP
+          - name: acceptance-1.17-FARGATE-HCP
             enable-hcp: true
             launch-type: FARGATE
 
-          - name: acceptance-1.16-FARGATE
+          - name: acceptance-1.17-FARGATE
             enable-hcp: false
             launch-type: FARGATE
       fail-fast: false
@@ -122,14 +122,14 @@ jobs:
       # HCP is always disabled for tests on PRs.
       matrix:
         name:
-          - acceptance-1.16-EC2-HCP
-          - acceptance-1.16-EC2
+          - acceptance-1.17-EC2-HCP
+          - acceptance-1.17-EC2
         include:
-          - name: acceptance-1.16-EC2-HCP
+          - name: acceptance-1.17-EC2-HCP
             enable-hcp: true
             launch-type: EC2
 
-          - name: acceptance-1.16-EC2
+          - name: acceptance-1.17-EC2
             enable-hcp: false
             launch-type: EC2
       fail-fast: false

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -68,7 +68,7 @@ jobs:
           working-directory: ./test/acceptance
       - name: Lint Consul retry
         run: |
-          go install github.com/hashicorp/lint-consul-retry@latest
+          go install github.com/hashicorp/lint-consul-retry@v1.3.0
           lint-consul-retry
   terraform-fmt:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+FEATURES
+* Add support for provisioning API gateways as ECS tasks [[GH-234](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/234)]
+  - Add `api-gateway` as an acceptable `kind` input.
+  - Add `custom_load_balancer_config` input variable which can be used to feed in custom load balancer target group config that can be attached to the gateway's ECS task.
+  - Add `consul.hashicorp.com.gateway-kind` as a tag to the gateway task's IAM Role. This field will hold the type of the gateway that is getting deployed to the ECS task and will be used by the configured IAM auth method to mint tokens
+  with appropriate permissions when individual tasks perform a Consul login.
+
 ## 0.7.0 (Nov 8, 2023)
 
 BREAKING CHANGES

--- a/modules/gateway-task/iam.tf
+++ b/modules/gateway-task/iam.tf
@@ -22,6 +22,7 @@ resource "aws_iam_role" "task" {
   tags = {
     "consul.hashicorp.com.service-name" = local.service_name
     "consul.hashicorp.com.namespace"    = local.consul_namespace
+    "consul.hashicorp.com.gateway-kind" = var.kind
   }
 }
 

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -36,7 +36,7 @@ locals {
     target_group_arn = aws_lb_target_group.this[0].arn
     container_name   = "consul-dataplane"
     container_port   = local.lan_port
-  }] : []
+  }] : var.custom_load_balancer_config
 
   security_groups = var.lb_create_security_group ? concat(
     var.security_groups,

--- a/modules/gateway-task/validation.tf
+++ b/modules/gateway-task/validation.tf
@@ -9,4 +9,6 @@ locals {
 
   create_xor_modify_security_group = var.lb_create_security_group && var.lb_modify_security_group ? file("ERROR: Only one of lb_create_security_group or lb_modify_security_group may be true") : null
   require_sg_id_for_modify         = var.lb_modify_security_group && var.lb_modify_security_group_id == "" ? file("ERROR: lb_modify_security_group_id is required when lb_modify_security_group is true") : null
+
+  custom_lb_config_check = var.lb_enabled && length(var.custom_load_balancer_config) > 0 ? file("ERROR: custom_load_balancer_config must only be supplied when var.lb_enabled is false") : null
 }

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -114,7 +114,7 @@ variable "consul_ecs_image" {
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorp/consul-dataplane:1.4.0-dev"
+  default     = "hashicorppreview/consul-dataplane:1.4.0-dev"
 }
 
 variable "envoy_readiness_port" {
@@ -196,8 +196,8 @@ variable "kind" {
   type        = string
 
   validation {
-    error_message = "Gateway kind must be 'mesh-gateway'."
-    condition     = contains(["mesh-gateway"], var.kind)
+    error_message = "Gateway kind must be one of 'mesh-gateway' or 'api-gateway'."
+    condition     = contains(["mesh-gateway", "api-gateway"], var.kind)
   }
 }
 
@@ -288,6 +288,22 @@ variable "lb_modify_security_group_id" {
   description = "The ID of the security group to modify with an ingress rule for the gateway task. Required when lb_modify_security_group is true."
   type        = string
   default     = ""
+}
+
+variable "custom_load_balancer_config" {
+  description = <<-EOT
+  Load balancer config that will applied to the ECS service backing the gateway task.
+  The gateway submodule by default creates an NLB with backing listeners that attach the LB
+  to the gateway ECS task. When configuring API gateways, users might need to deploy an ALB
+  and add listeners that target the API gateway's ECS task. This field can be used to supply
+  target group related configuration for such use cases.
+  EOT
+  type = list(object({
+    target_group_arn = string
+    container_name   = string
+    container_port   = number
+  }))
+  default = []
 }
 
 variable "consul_ecs_config" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -151,7 +151,7 @@ variable "consul_ecs_image" {
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorp/consul-dataplane:1.4.0-dev"
+  default     = "hashicorppreview/consul-dataplane:1.4.0-dev"
 }
 
 variable "envoy_public_listener_port" {

--- a/test/acceptance/tests/validation/terraform/api-gateway-validate/main.tf
+++ b/test/acceptance/tests/validation/terraform/api-gateway-validate/main.tf
@@ -1,0 +1,52 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "kind" {
+  type = string
+}
+
+variable "lb_enabled" {
+  description = "Whether to create an Elastic Load Balancer for the task to allow public ingress to the gateway."
+  type        = bool
+  default     = false
+}
+
+variable "lb_vpc_id" {
+  type    = string
+  default = ""
+}
+
+variable "lb_subnets" {
+  type    = list(string)
+  default = []
+}
+
+variable "custom_lb_config" {
+  type    = any
+  default = []
+}
+
+variable "gateway_count" {
+  type    = number
+  default = 1
+}
+
+module "test_gateway" {
+  source                      = "../../../../../../modules/gateway-task"
+  family                      = "family"
+  ecs_cluster_arn             = "cluster"
+  subnets                     = ["subnets"]
+  kind                        = var.kind
+  gateway_count               = var.gateway_count
+  consul_server_hosts         = "localhost:8500"
+  tls                         = true
+  lb_enabled                  = var.lb_enabled
+  lb_vpc_id                   = var.lb_vpc_id
+  lb_subnets                  = var.lb_subnets
+  custom_load_balancer_config = var.custom_lb_config
+  lb_create_security_group    = var.lb_enabled
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds changes to the `gateway-task` submodule to support configuring API gateways on ECS.
- Adds `consul.hashicorp.com.gateway-kind` as a tag to the gateway task's IAM Role. This field will hold the type of the gateway that is getting deployed to the ECS task and will be used by the configured IAM auth method to mint tokens
- Update CI to test against Consul 1.17
- Adds a `custom_lb_config` input to the gateway-task submodule to ease configuration of LBs for API GWs

## How I've tested this PR:

Manually deploying API GWs on ECS

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::