### PR TITLE
Effort to reduce flakiness in ECS acceptance tests

### DIFF
--- a/examples/api-gateway/controller.tf
+++ b/examples/api-gateway/controller.tf
@@ -12,7 +12,6 @@ module "ecs_controller" {
   consul_server_hosts = module.dc1.dev_consul_server.server_dns
   consul_ca_cert_arn  = module.dc1.dev_consul_server.ca_cert_arn
   launch_type         = "FARGATE"
-  consul_ecs_image    = "ganeshrockz/api-gateway"
 
   consul_bootstrap_token_secret_arn = module.dc1.dev_consul_server.bootstrap_token_secret_arn
 

--- a/examples/api-gateway/echo-service/variables.tf
+++ b/examples/api-gateway/echo-service/variables.tf
@@ -21,12 +21,6 @@ variable "consul_ca_cert_arn" {
   type        = string
 }
 
-variable "consul_ecs_image" {
-  description = "Consul ECS image to used for the controller task."
-  type        = string
-  default     = "ganeshrockz/api-gateway"
-}
-
 variable "private_subnets" {
   description = "List of private subnet ids."
   type        = list(string)

--- a/examples/api-gateway/gateway.tf
+++ b/examples/api-gateway/gateway.tf
@@ -34,8 +34,6 @@ module "api_gateway" {
     container_port   = 8443
     target_group_arn = aws_lb_target_group.this.arn
   }]
-
-  consul_ecs_image = "ganeshrockz/api-gateway"
 }
 
 # Ingress rule for the API Gateway task that accepts traffic from the API gateway's LB

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -8,7 +8,8 @@ type TestConfig struct {
 	NoCleanupOnFailure bool
 	ECSClusterARNs     []string    `json:"ecs_cluster_arns"`
 	LaunchType         string      `json:"launch_type"`
-	Subnets            interface{} `json:"subnets"`
+	PrivateSubnets     interface{} `json:"private_subnets"`
+	PublicSubnets      interface{} `json:"public_subnets"`
 	Suffix             string
 	Region             string   `json:"region"`
 	VpcID              string   `json:"vpc_id"`
@@ -24,7 +25,8 @@ func (t TestConfig) TFVars(ignoreVars ...string) map[string]interface{} {
 	vars := map[string]interface{}{
 		"ecs_cluster_arns": t.ECSClusterARNs,
 		"launch_type":      t.LaunchType,
-		"subnets":          t.Subnets,
+		"private_subnets":  t.PrivateSubnets,
+		"public_subnets":   t.PublicSubnets,
 		"region":           t.Region,
 		"log_group_name":   t.LogGroupName,
 		"vpc_id":           t.VpcID,

--- a/test/acceptance/framework/flags/flags.go
+++ b/test/acceptance/framework/flags/flags.go
@@ -17,7 +17,8 @@ const (
 	flagNoCleanupOnFailure = "no-cleanup-on-failure"
 	flagECSClusterARNs     = "ecs-cluster-arns"
 	flagLaunchType         = "launch-type"
-	flagSubnets            = "subnets"
+	flagPrivateSubnets     = "private-subnets"
+	flagPublicSubnets      = "public-subnets"
 	flagRegion             = "region"
 	flagLogGroupName       = "log-group-name"
 	// flagTFTags is named to disambiguate from the --tags flags used
@@ -32,7 +33,8 @@ type TestFlags struct {
 	flagNoCleanupOnFailure bool
 	flagECSClusterARNs     string
 	flagLaunchType         string
-	flagSubnets            string
+	flagPrivateSubnets     string
+	flagPublicSubnets      string
 	flagRegion             string
 	flagLogGroupName       string
 	flagTFTags             string
@@ -54,7 +56,8 @@ func (t *TestFlags) init() {
 			"Note this flag must be run with -failfast flag, otherwise subsequent tests will fail.")
 	flag.StringVar(&t.flagECSClusterARNs, flagECSClusterARNs, "", "ECS Cluster ARNs. In TF Var form, e.g. '[<arn>, <arn>]'")
 	flag.StringVar(&t.flagLaunchType, flagLaunchType, "", "The ECS launch type to test: 'FARGATE' or 'EC2'.")
-	flag.StringVar(&t.flagSubnets, flagSubnets, "", "Subnets to deploy into. In TF var form, e.g. '[\"sub1\",\"sub2\"]'.")
+	flag.StringVar(&t.flagPrivateSubnets, flagPrivateSubnets, "", "Private subnets to deploy into. In TF var form, e.g. '[\"sub1\",\"sub2\"]'.")
+	flag.StringVar(&t.flagPublicSubnets, flagPublicSubnets, "", "Private subnets to deploy into. In TF var form, e.g. '[\"sub1\",\"sub2\"]'.")
 	flag.StringVar(&t.flagRegion, flagRegion, "", "Region.")
 	flag.StringVar(&t.flagLogGroupName, flagLogGroupName, "", "CloudWatch log group name.")
 	flag.StringVar(&t.flagTFTags, flagTFTags, "", "Tags to add to resources. In TF var form, e.g. '{key=val,key2=val2}'.")
@@ -121,7 +124,8 @@ func (t *TestFlags) TestConfigFromFlags() (*config.TestConfig, error) {
 			NoCleanupOnFailure: t.flagNoCleanupOnFailure,
 			ECSClusterARNs:     arns,
 			LaunchType:         t.flagLaunchType,
-			Subnets:            t.flagSubnets,
+			PrivateSubnets:     t.flagPrivateSubnets,
+			PublicSubnets:      t.flagPublicSubnets,
 			Region:             t.flagRegion,
 			LogGroupName:       t.flagLogGroupName,
 			Tags:               t.flagTFTags,

--- a/test/acceptance/setup-terraform/outputs.tf
+++ b/test/acceptance/setup-terraform/outputs.tf
@@ -13,8 +13,12 @@ output "launch_type" {
   value = var.launch_type
 }
 
-output "subnets" {
+output "private_subnets" {
   value = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
 }
 
 output "suffix" {

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -112,7 +112,7 @@ func TestBasic(t *testing.T) {
 			// Wait for consul server to be up.
 			var consulServerTaskARN string
 			retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
-				tasks, err := helpers.ListTasks(t, c.ecsClusterARN, cfg.Region, fmt.Sprintf("consul_server_%s", randomSuffix))
+				tasks, err := helpers.ListTasks(t, c.ecsClusterARN, cfg.Region, fmt.Sprintf("consul-server-%s", randomSuffix))
 
 				r.Check(err)
 				require.NotNil(r, tasks)

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -11,9 +11,14 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "subnets" {
+variable "private_subnets" {
   type        = list(string)
-  description = "Subnets to deploy into."
+  description = "Private subnets to deploy into."
+}
+
+variable "public_subnets" {
+  type        = list(string)
+  description = "Public subnets to deploy into."
 }
 
 variable "suffix" {
@@ -86,18 +91,20 @@ locals {
 }
 
 module "consul_server" {
-  source          = "../../../../../../modules/dev-server"
-  lb_enabled      = false
-  ecs_cluster_arn = var.ecs_cluster_arn
-  subnet_ids      = var.subnets
-  vpc_id          = var.vpc_id
-  name            = "consul_server_${var.suffix}"
+  source                      = "../../../../../../modules/dev-server"
+  lb_enabled                  = true
+  lb_subnets                  = var.public_subnets
+  lb_ingress_rule_cidr_blocks = ["0.0.0.0/0"]
+  ecs_cluster_arn             = var.ecs_cluster_arn
+  subnet_ids                  = var.private_subnets
+  vpc_id                      = var.vpc_id
+  name                        = "consul-server-${var.suffix}"
   log_configuration = {
     logDriver = "awslogs"
     options = {
       awslogs-group         = var.log_group_name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "consul_server_${var.suffix}"
+      awslogs-stream-prefix = "consul-server-${var.suffix}"
     }
   }
   launch_type = var.launch_type
@@ -133,6 +140,8 @@ resource "aws_security_group_rule" "consul_server_ingress" {
 }
 
 module "ecs_controller" {
+  depends_on = [module.consul_server]
+
   count  = var.secure ? 1 : 0
   source = "../../../../../../modules/controller"
   log_configuration = {
@@ -150,7 +159,7 @@ module "ecs_controller" {
   consul_https_ca_cert_arn          = module.consul_server.ca_cert_arn
   ecs_cluster_arn                   = var.ecs_cluster_arn
   region                            = var.region
-  subnets                           = var.subnets
+  subnets                           = var.private_subnets
   name_prefix                       = var.suffix
   consul_ecs_image                  = var.consul_ecs_image
   consul_partitions_enabled         = local.enterprise_enabled
@@ -163,7 +172,7 @@ resource "aws_ecs_service" "test_client" {
   task_definition = module.test_client.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"
@@ -173,6 +182,8 @@ resource "aws_ecs_service" "test_client" {
 }
 
 module "test_client" {
+  depends_on = [module.consul_server]
+
   source = "../../../../../../modules/mesh-task"
   // mesh-task will lower case this to `test_client_<suffix>` for the service name.
   family = "Test_Client_${var.suffix}"
@@ -255,7 +266,7 @@ resource "aws_ecs_service" "test_server" {
   task_definition = module.test_server.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"
@@ -265,6 +276,8 @@ resource "aws_ecs_service" "test_server" {
 }
 
 module "test_server" {
+  depends_on = [module.consul_server]
+
   source              = "../../../../../../modules/mesh-task"
   family              = "test_server_${var.suffix}"
   consul_service_name = "${var.server_service_name}_${var.suffix}"

--- a/test/acceptance/tests/hcp/terraform/ap/main.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/main.tf
@@ -26,7 +26,7 @@ module "ecs_controller_1" {
   consul_server_hosts               = var.consul_server_address
   ecs_cluster_arn                   = local.ecs_cluster_1_arn
   region                            = var.region
-  subnets                           = var.subnets
+  subnets                           = var.private_subnets
   name_prefix                       = var.suffix_1
   consul_ecs_image                  = var.consul_ecs_image
   consul_partitions_enabled         = true
@@ -48,7 +48,7 @@ resource "aws_ecs_service" "test_client" {
   task_definition = module.test_client.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"
@@ -125,7 +125,7 @@ module "ecs_controller_2" {
   consul_server_hosts               = var.consul_server_address
   ecs_cluster_arn                   = local.ecs_cluster_2_arn
   region                            = var.region
-  subnets                           = var.subnets
+  subnets                           = var.private_subnets
   name_prefix                       = var.suffix_2
   consul_ecs_image                  = var.consul_ecs_image
   consul_partitions_enabled         = true
@@ -147,7 +147,7 @@ resource "aws_ecs_service" "test_server" {
   task_definition = module.test_server.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -36,8 +36,13 @@ variable "route_table_ids" {
   type        = list(string)
 }
 
-variable "subnets" {
-  description = "Subnets to deploy into."
+variable "private_subnets" {
+  description = "Private subnets to deploy into."
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "Public subnets to deploy into."
   type        = list(string)
 }
 

--- a/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/main.tf
@@ -25,7 +25,7 @@ module "ecs_controller" {
   consul_server_hosts               = var.consul_server_address
   ecs_cluster_arn                   = local.ecs_cluster_arn
   region                            = var.region
-  subnets                           = var.subnets
+  subnets                           = var.private_subnets
   name_prefix                       = var.suffix
   consul_ecs_image                  = var.consul_ecs_image
   consul_partitions_enabled         = true
@@ -46,7 +46,7 @@ resource "aws_ecs_service" "test_client" {
   task_definition = module.test_client.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"
@@ -112,7 +112,7 @@ resource "aws_ecs_service" "test_server" {
   task_definition = module.test_server.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -21,9 +21,14 @@ variable "route_table_ids" {
   type        = list(string)
 }
 
-variable "subnets" {
+variable "private_subnets" {
+  description = "Private subnets to deploy into."
   type        = list(string)
-  description = "Subnets to deploy into."
+}
+
+variable "public_subnets" {
+  description = "Public subnets to deploy into."
+  type        = list(string)
 }
 
 variable "launch_type" {

--- a/test/acceptance/tests/hcp/terraform/ns/main.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/main.tf
@@ -25,7 +25,7 @@ module "controller" {
   consul_server_hosts               = var.consul_server_address
   ecs_cluster_arn                   = local.ecs_cluster_arn
   region                            = var.region
-  subnets                           = var.subnets
+  subnets                           = var.private_subnets
   name_prefix                       = var.suffix
   consul_ecs_image                  = var.consul_ecs_image
   consul_partitions_enabled         = true
@@ -46,7 +46,7 @@ resource "aws_ecs_service" "test_client" {
   task_definition = module.test_client.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"
@@ -113,7 +113,7 @@ resource "aws_ecs_service" "test_server" {
   task_definition = module.test_server.task_definition_arn
   desired_count   = 1
   network_configuration {
-    subnets = var.subnets
+    subnets = var.private_subnets
   }
   launch_type            = var.launch_type
   propagate_tags         = "TASK_DEFINITION"

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -21,9 +21,14 @@ variable "route_table_ids" {
   type        = list(string)
 }
 
-variable "subnets" {
+variable "private_subnets" {
+  description = "Private subnets to deploy into."
   type        = list(string)
-  description = "Subnets to deploy into."
+}
+
+variable "public_subnets" {
+  description = "Public subnets to deploy into."
+  type        = list(string)
 }
 
 variable "launch_type" {


### PR DESCRIPTION
## Changes proposed in this PR:
- A majority of our tests in the ECS acceptance test suite are flaky. Upon investigation, it was found that a majority of these failures are linked to the scenario where ECS mesh tasks are unable to reach the Consul server. The main reason for this is that we deploy both the server and individual mesh tasks in parallel with terraform and servers generally take a bit of time before their CloudMap DNS name gets resolved to a private IP.

This PR adds two changes to fix this issue
- Associate the server with an ALB and query `/v1/catalog/services` for its readiness
- Make sure that the ECS controller and other application task submodules depend on the server module's completion. This will ensure that the client workload tasks only get deployed after the server's ECS service and task are up and running thus making sure that the clients always connect to the server without any issues.

In order to associate the LB to the Consul server task, we'd need to be aware of the public_subnet details of the VPC and there are changes added to this PR to consume the same in the individual test's terraform configs.

## How I've tested this PR:

Manual

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::