### PR TITLE
Fix health check command for mesh and gateway task submodules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ FEATURES
 * examples/api-gateway: Add example terraform to demonstrate exposing mesh tasks in ECS via Consul API gateway deployed as an ECS task. [[GH-235]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/235)
 * examples/terminating-gateway: Add example terraform to demonstrate the use of terminating gateways deployed as ECS tasks to facilitate communication between mesh and non mesh services. [[GH-238]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/238)
 
+BUG FIXES
+* Fixes a bug in the health check logic of the `consul-ecs-control-plane` container in `mesh-task` and `gateway-task` submodule. Because of the bug, the ECS agent tries to start up the `consul-dataplane` container before the `consul-ecs-control-plane` container writes the Consul ECS binary to a shared volume. [[GH-241]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/241)
+
 ## 0.7.0 (Nov 8, 2023)
 
 BREAKING CHANGES

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -105,7 +105,7 @@ resource "aws_ecs_task_definition" "this" {
               initProcessEnabled = true
             }
             healthCheck = {
-              command  = ["CMD-SHELL", "curl localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
+              command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health || exit 1"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
               interval = 30
               retries  = 10
               timeout  = 5

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -105,7 +105,7 @@ resource "aws_ecs_task_definition" "this" {
               initProcessEnabled = true
             }
             healthCheck = {
-              command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health || exit 1"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
+              command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
               interval = 30
               retries  = 10
               timeout  = 5

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -200,7 +200,7 @@ resource "aws_ecs_task_definition" "this" {
               initProcessEnabled = true
             }
             healthCheck = {
-              command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health || exit 1"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
+              command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
               interval = 30
               retries  = 10
               timeout  = 5

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -200,7 +200,7 @@ resource "aws_ecs_task_definition" "this" {
               initProcessEnabled = true
             }
             healthCheck = {
-              command  = ["CMD-SHELL", "curl localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
+              command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health || exit 1"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
               interval = 30
               retries  = 10
               timeout  = 5


### PR DESCRIPTION
## Changes proposed in this PR:
- The ECS health check logic relies on the command returning a non zero exit code. In the current state, even when `consul-ecs-control-plane` returns back a `500` the `curl` command treats it a successful response and returns a non zero code. Here's an example of the same

```zsh
ganeshseetharaman@ganeshseetharaman-DFCQN60JDW % curl -v httpbin.org/status/500 
*   Trying 3.95.102.170:80...
* Connected to httpbin.org (3.95.102.170) port 80 (#0)
> GET /status/500 HTTP/1.1
> Host: httpbin.org
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 500 INTERNAL SERVER ERROR
< Date: Fri, 15 Dec 2023 08:26:54 GMT
< Content-Type: text/html; charset=utf-8
< Content-Length: 0
< Connection: keep-alive
< Server: gunicorn/19.9.0
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< 
* Connection #0 to host httpbin.org left intact
ganeshseetharaman@ganeshseetharaman-DFCQN60JDW % echo $?                                                          
0
```

This caused the `consul-dataplane` container to start up before the consul binary became available in the shared volume. In an ideal world, consul-dataplane should only start up after the control-plane container writes the Consul ECS binary to the shared volume and returns back a `200` response code for the `/consul-ecs/health` endpoint.

This PR fixes the same by adding a `-f` flag to curl.  

```zsh
ganeshseetharaman@ganeshseetharaman-DFCQN60JDW % curl -v -f httpbin.org/status/500
*   Trying 18.214.18.233:80...
* Connected to httpbin.org (18.214.18.233) port 80 (#0)
> GET /status/500 HTTP/1.1
> Host: httpbin.org
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 500 INTERNAL SERVER ERROR
< Date: Fri, 15 Dec 2023 08:30:02 GMT
< Content-Type: text/html; charset=utf-8
< Content-Length: 0
< Connection: keep-alive
< Server: gunicorn/19.9.0
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
* The requested URL returned error: 500
* Closing connection 0
curl: (22) The requested URL returned error: 500
ganeshseetharaman@ganeshseetharaman-DFCQN60JDW % echo $?                          
22
```

## How I've tested this PR:

Manual deployment

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added n/a
- [X] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::