### PR TITLE
Remove dev tag from  Consul ECS image version

### DIFF
--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_dataplane_image" {

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -26,7 +26,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_startup_timeout" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.7.1-dev"
+  version_string = "0.7.1"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -108,7 +108,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.7.1-dev"
+  version_string = "0.7.1"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_dataplane_image" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorp/consul-ecs:0.7.0"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -65,7 +65,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorp/consul-ecs:0.7.0"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.7.1-dev"
+  default     = "hashicorppreview/consul-ecs:0.7.1"
 }
 
 variable "consul_server_address" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Make changes to Consul ECS images to use the `0.7.1` preview image.

## How I've tested this PR:
CI

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added n/a
- [ ] CHANGELOG entry added n/a

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::