### PR TITLE
Validation framework for terraform examples

### DIFF
--- a/.github/workflows/nightly-ecs-examples-validator.yml
+++ b/.github/workflows/nightly-ecs-examples-validator.yml
@@ -104,7 +104,9 @@ jobs:
 
         - name: Locality Aware Routing
           scenario: LOCALITY_AWARE_ROUTING
-          
+
+        - name: Service Sameness
+          scenario: SERVICE_SAMENESS
       fail-fast: false
     uses: ./.github/workflows/reusable-ecs-example-validator.yml
     with:

--- a/.github/workflows/nightly-ecs-examples-validator.yml
+++ b/.github/workflows/nightly-ecs-examples-validator.yml
@@ -60,6 +60,7 @@ jobs:
     needs:
     - terraform-fmt
     - go-fmt-and-lint-acceptance
+    - get-go-version
     strategy:
       matrix:
         name:
@@ -85,6 +86,7 @@ jobs:
   multi-cluster:
     needs:
     - single-cluster
+    - get-go-version
     strategy:
       matrix:
         name:

--- a/.github/workflows/nightly-ecs-examples-validator.yml
+++ b/.github/workflows/nightly-ecs-examples-validator.yml
@@ -1,0 +1,114 @@
+name: Nighly ECS example validator
+on:
+  # schedule:
+  #   - cron: '0 0 * * *' # Runs every day at midnight UTC
+  workflow_dispatch:
+  push:
+
+jobs:
+  get-go-version:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./test/acceptance
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Determine Go version
+      id: get-go-version
+      run: |
+        echo "Building with Go $(cat .go-version)"
+        echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+  go-fmt-and-lint-acceptance:
+    runs-on: ubuntu-latest
+    needs:
+      - get-go-version
+    defaults:
+      run:
+        working-directory: ./test/acceptance
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ needs.get-go-version.outputs.go-version }}
+        cache-dependency-path: ./test/acceptance/go.sum
+    - name: Go CI lint
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+      with:
+        args: "--verbose --enable gofmt"
+        only-new-issues: false
+        skip-pkg-cache: true
+        skip-build-cache: true
+        working-directory: ./test/acceptance
+    - name: Lint Consul retry
+      run: |
+        go install github.com/hashicorp/lint-consul-retry@v1.3.0
+        lint-consul-retry
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.4.2
+    - name: Validate
+      run: terraform fmt -check -recursive .
+  single-cluster:
+    needs:
+    - terraform-fmt
+    - go-fmt-and-lint-acceptance
+    strategy:
+      matrix:
+        name:
+          - Consul ECS on Fargate
+          - Consul ECS on EC2
+          - Consul ECS with HCP
+        include:
+          - name: Consul ECS on Fargate
+            scenario: FARGATE
+
+          - name: Consul ECS on EC2
+            scenario: EC2
+
+          - name: Consul ECS with HCP
+            scenario: HCP
+      fail-fast: false
+    uses: ./.github/workflows/reusable-ecs-example-validator.yml
+    with:
+      name: ${{ matrix.name }}
+      scenario: ${{ matrix.scenario }}
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+    secrets: inherit
+  multi-cluster:
+    needs:
+    - single-cluster
+    strategy:
+      matrix:
+        name:
+        - Cluster Peering
+        - WAN Federation with Mesh gateways
+        - Locality Aware Routing
+        - Service Sameness
+        include:
+        - name: Cluster Peering
+          scenario: CLUSTER_PEERING
+
+        - name: WAN Federation with Mesh gateways
+          scenario: WAN_FEDERATION
+
+        - name: Locality Aware Routing
+          scenario: LOCALITY_AWARE_ROUTING
+          
+      fail-fast: false
+    uses: ./.github/workflows/reusable-ecs-example-validator.yml
+    with:
+      name: ${{ matrix.name }}
+      scenario: ${{ matrix.scenario }}
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+    secrets: inherit

--- a/.github/workflows/nightly-ecs-examples-validator.yml
+++ b/.github/workflows/nightly-ecs-examples-validator.yml
@@ -1,9 +1,6 @@
 name: Nighly ECS example validator
 on:
-  # schedule:
-  #   - cron: '0 0 * * *' # Runs every day at midnight UTC
   workflow_dispatch:
-  push:
 
 jobs:
   get-go-version:

--- a/.github/workflows/reusable-ecs-example-validator.yml
+++ b/.github/workflows/reusable-ecs-example-validator.yml
@@ -1,0 +1,74 @@
+name: reusable-ecs-example-validator
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: "The name of the job"
+        required: true
+        type: string        
+      scenario:
+        description: "The name of the scenario that needs to be tested on ECS. This will be passed as an environment variable to the test."
+        required: true
+        type: string
+      go-version:
+        description: "Version of Go to use to run the tests"
+        required: true
+        type: string
+
+env:
+  TEST_RESULTS: /tmp/test-results
+  GOTESTSUM_VERSION: 1.8.0
+  CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
+  HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+  HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
+  HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
+  TEST_SCENARIO: ${{ inputs.scenario }}
+
+jobs:
+  example-validator:
+    name: ${{ inputs.name }}
+    runs-on: ['ubuntu-latest']
+    defaults:
+      run:
+        working-directory: ./test/acceptance/examples
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache-dependency-path: ./test/acceptance/go.sum
+    - name: Install gotestsum
+      run: |
+        curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${{ env.GOTESTSUM_VERSION }}/gotestsum_${{ env.GOTESTSUM_VERSION }}_linux_amd64.tar.gz" | \
+        tar -xz --overwrite -C /usr/local/bin gotestsum
+    - name: Install AWS CLI
+      run: |
+        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+        sudo dpkg -i session-manager-plugin.deb
+        aws --version
+        echo session-manager-plugin version "$(session-manager-plugin --version)"
+    - name: Install AWS ECS CLI
+      run: |
+        curl -sSL "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest" -o /usr/local/bin/ecs-cli
+        chmod +x /usr/local/bin/ecs-cli
+        ecs-cli --version
+    - name: Assume AWS IAM Role
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        role-to-assume: ${{ secrets.AWS_ECS_ROLE_ARN }}
+        aws-region: ${{ secrets.AWS_ECS_REGION }}
+        aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 7200
+    - name: Validation
+      run: |
+        mkdir -p "$TEST_RESULTS"
+        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      if: always()
+      with:
+        name: acceptance-test-results
+        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -50,6 +50,8 @@ resource "aws_ecs_service" "example_client_app" {
 }
 
 module "example_client_app" {
+  depends_on = [ module.dev_consul_server ]
+  
   source = "../../modules/mesh-task"
   family = "${var.name}-example-client-app"
   port   = "9090"
@@ -112,6 +114,8 @@ resource "aws_ecs_service" "example_server_app" {
 }
 
 module "example_server_app" {
+  depends_on = [ module.dev_consul_server ]
+
   source            = "../../modules/mesh-task"
   family            = "${var.name}-example-server-app"
   port              = "9090"

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -50,8 +50,8 @@ resource "aws_ecs_service" "example_client_app" {
 }
 
 module "example_client_app" {
-  depends_on = [ module.dev_consul_server ]
-  
+  depends_on = [module.dev_consul_server]
+
   source = "../../modules/mesh-task"
   family = "${var.name}-example-client-app"
   port   = "9090"
@@ -114,7 +114,7 @@ resource "aws_ecs_service" "example_server_app" {
 }
 
 module "example_server_app" {
-  depends_on = [ module.dev_consul_server ]
+  depends_on = [module.dev_consul_server]
 
   source            = "../../modules/mesh-task"
   family            = "${var.name}-example-server-app"

--- a/examples/locality-aware-routing/README.md
+++ b/examples/locality-aware-routing/README.md
@@ -79,6 +79,7 @@ Changes to Outputs:
   + client_lb_address             = (known after apply)
   + consul_server_bootstrap_token = (sensitive value)
   + consul_server_url             = (known after apply)
+  + ecs_cluster_arn = (known after apply)
 ```
 
 Type `yes` to apply the changes.
@@ -97,6 +98,7 @@ Outputs:
 client_lb_address = "http://example-client-app-1959503271.us-west-2.elb.amazonaws.com:9090/ui"
 consul_server_bootstrap_token = <sensitive>
 consul_server_url = "http://ecs-dc1-consul-server-713584774.us-west-2.elb.amazonaws.com:8500"
+ecs_cluster_arn = "arn:aws:ecs:us-east-1:123456789012:cluster/my-ecs-cluster"
 ```
 
 ### Explore
@@ -115,7 +117,7 @@ to view the Consul UI and log in using the `consul_server_bootstrap_token` above
 
 If you browse to the URL of the `client_lb_address`, the example application UI should be displayed:
 
-![Example App UI](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/_docs/locality-aware-dc1-ui.png?raw=true)
+![Example App UI](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/_docs/locality-aware-app-ui.png?raw=true)
 
 Notice the IP of the upstream server application's task. Because of the locality parameters added during the service registration, Consul takes care of routing traffic from the client application to the server application task within the same availability zone. You can read more about the locality aware routing feature [here](https://developer.hashicorp.com/consul/docs/v1.17.x/connect/manage-traffic/route-to-local-upstreams?ajs_aid=54615e8b-87b1-40fa-aecc-3e16280d6a88&product_intent=consul)
 

--- a/examples/locality-aware-routing/outputs.tf
+++ b/examples/locality-aware-routing/outputs.tf
@@ -13,3 +13,7 @@ output "consul_server_bootstrap_token" {
 output "client_lb_address" {
   value = "http://${aws_lb.example_client_app.dns_name}:9090/ui"
 }
+
+output "ecs_cluster_arn" {
+  value = module.cluster.ecs_cluster.arn
+}

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -1,6 +1,6 @@
 ## Acceptance Tests
 
-These tests run the Terraform code.
+These tests run the Terraform code. For scenario based tests please refer to [this](./examples/README.md) document.
 
 ### Prerequisites
 
@@ -27,9 +27,9 @@ The following prerequisites are needed to run the acceptance tests:
 1. Now you can run the tests. The tests accept flags for passing in information about the
    VPC and ECS cluster you've just created.
 
-   Switch back to the `test/acceptance` directory:
+   Switch back to the `test/acceptance/tests` directory:
 
-1. To run the tests, use `go test` from the `test/acceptance` directory:
+1. To run the tests, use `go test` from the `test/acceptance/tests` directory:
 
    For tests that use Consul Enterprise outside of HCP, you must set the
    `CONSUL_LICENSE` environment variable to a Consul Enterprise license key.

--- a/test/acceptance/examples/README.md
+++ b/test/acceptance/examples/README.md
@@ -38,8 +38,8 @@ The following prerequisites are needed to run the acceptance tests:
 
 ### Adding a new scenario
 
-1. We expect every scenario to implement the `Scenario` interface present [here](./scenarios/scenario.go). Similar to existing examples, add a new folder corresponding to your scenario under the `scenarios/` subfolder and add relevant code into the same.
+1. We expect every scenario to register itself to the scenario registry. Similar to existing examples, add a new folder corresponding to your scenario under the `scenarios/` subfolder and add relevant code into the same.
 
-1. Make sure to add the scenario as part of the `scenarioFuncs` map in [this](./main.go) file.
+1. Make sure to call the function that adds the scenario to the registry from [main_test.go](./main_test.go).
 
 1. If you want your scenario to run as part of CI, make sure to add it to the matrix list in [this](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/.github/workflows/nightly-ecs-examples-validator.yml) workflow file. If the number of parallel jobs within a matrix exceeds 4, make sure to create a new matrix job that is dependent on the existing ones and add your scenario there.

--- a/test/acceptance/examples/README.md
+++ b/test/acceptance/examples/README.md
@@ -1,0 +1,45 @@
+## Scenario based tests
+
+These tests deploy the terraform code present under the `examples/` folder and performs custom validations on the same.
+
+These tests are run as part of [CI](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/.github/workflows/nightly-ecs-examples-validator.yml). The workflow is setup in a way that deployments happen in multiple stages one after the other. We made a conscious choice to run atmost 4 parallel deployments/test jobs in the CI to make sure that we don't exceed the VPC limits set up in the target AWS account.
+
+### Prerequisites
+
+The following prerequisites are needed to run the acceptance tests:
+
+- [Go](https://go.dev/dl/) (`go test`)
+- [Terraform](https://www.terraform.io/downloads) (`terraform`)
+   - [Authentication for AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication)
+   - [Authentication for HCP provider](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/auth)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) (`aws`)
+   - [AWS Session Manager Plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+- [Amazon ECS CLI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html) (`ecs-cli`)
+
+### Instructions
+
+1. Make sure to set relevant environment variables to configure AWS and HCP (if you are running HCP based scenarios) credentials.
+
+1. Make sure to set the `TEST_SCENARIO` environment variable. This must match one of the scenarios listed in the `scenarioFuncs` map present in [main.go](./main_test.go).
+
+1. To run the tests, use `go test` from the `test/acceptance/examples` directory:
+
+   For tests that use Consul Enterprise outside of HCP, you must set the
+   `CONSUL_LICENSE` environment variable to a Consul Enterprise license key.
+
+   ```sh
+   export CONSUL_LICENSE=$(cat path/to/license-file)
+   TEST_SCENARIO=EC2 go test -run TestScenario -p 1 -timeout 30m -v
+   ```
+
+   You may want to set the `NO_CLEANUP_ON_FAILURE` environment variable if you're debugging
+   a failing test. Without this variable, the tests will delete all resources
+   regardless of passing or failing.
+
+### Adding a new scenario
+
+1. We expect every scenario to implement the `Scenario` interface present [here](./scenarios/scenario.go). Similar to existing examples, add a new folder corresponding to your scenario under the `scenarios/` subfolder and add relevant code into the same.
+
+1. Make sure to add the scenario as part of the `scenarioFuncs` map in [this](./main.go) file.
+
+1. If you want your scenario to run as part of CI, make sure to add it to the matrix list in [this](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/.github/workflows/nightly-ecs-examples-validator.yml) workflow file. If the number of parallel jobs within a matrix exceeds 4, make sure to create a new matrix job that is dependent on the existing ones and add your scenario there.

--- a/test/acceptance/examples/main_test.go
+++ b/test/acceptance/examples/main_test.go
@@ -13,7 +13,13 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	clusterpeering "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/cluster-peering"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/ec2"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/fargate"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/hcp"
+	localityawarerouting "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/locality-aware-routing"
+	sameness "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/service-sameness"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/wan-federation"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
 	"github.com/stretchr/testify/require"
 )
@@ -72,6 +78,12 @@ func setupScenarios() scenarios.ScenarioRegistry {
 	reg := scenarios.NewScenarioRegistry()
 
 	fargate.RegisterScenario(reg)
+	ec2.RegisterScenario(reg)
+	clusterpeering.RegisterScenario(reg)
+	hcp.RegisterScenario(reg)
+	sameness.RegisterScenario(reg)
+	wan.RegisterScenario(reg)
+	localityawarerouting.RegisterScenario(reg)
 
 	return reg
 }

--- a/test/acceptance/examples/main_test.go
+++ b/test/acceptance/examples/main_test.go
@@ -6,50 +6,33 @@ package examples
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
 	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
-	clusterpeering "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/cluster-peering"
-	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/ec2"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/fargate"
-	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/hcp"
-	localityawarerouting "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/locality-aware-routing"
-	sameness "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/service-sameness"
-	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/wan-federation"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
 	"github.com/stretchr/testify/require"
 )
-
-type ScenarioFunc func(string) scenarios.Scenario
-
-var scenarioFuncs = map[string]ScenarioFunc{
-	"FARGATE":                fargate.New,
-	"EC2":                    ec2.New,
-	"HCP":                    hcp.New,
-	"CLUSTER_PEERING":        clusterpeering.New,
-	"WAN_FEDERATION":         wan.New,
-	"LOCALITY_AWARE_ROUTING": localityawarerouting.New,
-	"SERVICE_SAMENESS":       sameness.New,
-}
 
 // TestRunScenario accepts a single scenario name as an environment
 // variable and executes tests for the same. We want to run each
 // scenario as a separate GitHub Action job.
 func TestRunScenario(t *testing.T) {
+	// Setup scenario registry
+	scenarioRegistry := setupScenarios()
+
 	scenarioName := os.Getenv("TEST_SCENARIO")
 	require.NotEmpty(t, scenarioName)
 
-	scenario := getScenario(scenarioName)
-	require.NotNil(t, scenario, "unexpected scenario name")
+	scenario, err := scenarioRegistry.Retrieve(scenarioName)
+	require.NoError(t, err)
 
 	initOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		TerraformDir: fmt.Sprintf("../../../examples/%s", scenario.GetFolderName()),
+		TerraformDir: fmt.Sprintf("../../../examples/%s", scenario.FolderName),
 		NoColor:      true,
 	})
 	terraform.Init(t, initOptions)
@@ -57,7 +40,7 @@ func TestRunScenario(t *testing.T) {
 	var tfVars map[string]interface{}
 	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
 		var err error
-		tfVars, err = scenario.GetTerraformVars()
+		tfVars, err = scenario.TerraformInputVars()
 		require.NoError(r, err)
 	})
 
@@ -85,15 +68,10 @@ func TestRunScenario(t *testing.T) {
 	logger.Log(t, "validation successful!!")
 }
 
-func getScenario(name string) scenarios.Scenario {
-	// This name will be passed as the name input to the terraform apply call.
-	// This name can be modified inside the individual scenarios too according
-	// to the scenario's needs.
-	terraformResourcesName := fmt.Sprintf("ecs-%s", strings.ToLower(random.UniqueId()))
+func setupScenarios() scenarios.ScenarioRegistry {
+	reg := scenarios.NewScenarioRegistry()
 
-	if scenario, ok := scenarioFuncs[name]; ok {
-		return scenario(terraformResourcesName)
-	}
+	fargate.RegisterScenario(reg)
 
-	return nil
+	return reg
 }

--- a/test/acceptance/examples/main_test.go
+++ b/test/acceptance/examples/main_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package examples
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	clusterpeering "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/cluster-peering"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/ec2"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/fargate"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/hcp"
+	localityawarerouting "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/locality-aware-routing"
+	sameness "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/service-sameness"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/wan-federation"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type ScenarioFunc func(string) scenarios.Scenario
+
+var scenarioFuncs = map[string]ScenarioFunc{
+	"FARGATE":                fargate.New,
+	"EC2":                    ec2.New,
+	"HCP":                    hcp.New,
+	"CLUSTER_PEERING":        clusterpeering.New,
+	"WAN_FEDERATION":         wan.New,
+	"LOCALITY_AWARE_ROUTING": localityawarerouting.New,
+	"SERVICE_SAMENESS":       sameness.New,
+}
+
+// TestRunScenario accepts a single scenario name as an environment
+// variable and executes tests for the same. We want to run each
+// scenario as a separate GitHub Action job.
+func TestRunScenario(t *testing.T) {
+	scenarioName := os.Getenv("TEST_SCENARIO")
+	require.NotEmpty(t, scenarioName)
+
+	scenario := getScenario(scenarioName)
+	require.NotNil(t, scenario, "unexpected scenario name")
+
+	initOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: fmt.Sprintf("../../../examples/%s", scenario.GetFolderName()),
+		NoColor:      true,
+	})
+	terraform.Init(t, initOptions)
+
+	var tfVars map[string]interface{}
+	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+		var err error
+		tfVars, err = scenario.GetTerraformVars()
+		require.NoError(r, err)
+	})
+
+	applyOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: initOptions.TerraformDir,
+		Vars:         tfVars,
+		NoColor:      true,
+	})
+
+	t.Cleanup(func() {
+		if os.Getenv("NO_CLEANUP_ON_FAILURE") != "true" {
+			terraform.Destroy(t, applyOptions)
+		}
+	})
+	terraform.Apply(t, applyOptions)
+
+	outputs := terraform.OutputAll(t, &terraform.Options{
+		TerraformDir: initOptions.TerraformDir,
+		NoColor:      true,
+		Logger:       terratestLogger.Default,
+	})
+
+	logger.Log(t, "running validation for scenario")
+	scenario.Validate(t, outputs)
+	logger.Log(t, "validation successful!!")
+}
+
+func getScenario(name string) scenarios.Scenario {
+	// This name will be passed as the name input to the terraform apply call.
+	// This name can be modified inside the individual scenarios too according
+	// to the scenario's needs.
+	terraformResourcesName := fmt.Sprintf("ecs-%s", strings.ToLower(random.UniqueId()))
+
+	if scenario, ok := scenarioFuncs[name]; ok {
+		return scenario(terraformResourcesName)
+	}
+
+	return nil
+}

--- a/test/acceptance/examples/main_test.go
+++ b/test/acceptance/examples/main_test.go
@@ -4,6 +4,7 @@
 package examples
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -69,8 +70,13 @@ func TestRunScenario(t *testing.T) {
 		Logger:       terratestLogger.Default,
 	})
 
+	// Marshal the output into a json so that individual
+	// scenarios can unmarshal it into their required format.
+	outputJSON, err := json.Marshal(outputs)
+	require.NoError(t, err)
+
 	logger.Log(t, "running validation for scenario")
-	scenario.Validate(t, outputs)
+	scenario.Validate(t, outputJSON)
 	logger.Log(t, "validation successful!!")
 }
 

--- a/test/acceptance/examples/scenarios/cluster-peering/main.go
+++ b/test/acceptance/examples/scenarios/cluster-peering/main.go
@@ -14,69 +14,68 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type clusterPeering struct {
-	name string
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResourcesName := common.GenerateRandomStr(4)
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "CLUSTER_PEERING",
+		FolderName:         "cluster-peering",
+		TerraformInputVars: getTerraformVars(tfResourcesName),
+		Validate:           validate(tfResourcesName),
+	})
 }
 
-func New(name string) scenarios.Scenario {
-	// We go ahead with a simple name due to AWS restrictions
-	// on character length of resource names for certain resources.
-	return &clusterPeering{
-		name: "ecs",
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-2",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
 	}
 }
 
-func (c *clusterPeering) GetFolderName() string {
-	return "cluster-peering"
-}
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, tfOutput map[string]interface{}) {
+		logger.Log(t, "Fetching required output terraform variables")
+		getOutputVariableValue := func(name string) string {
+			val, ok := tfOutput[name].(string)
+			require.True(t, ok)
+			return val
+		}
 
-func (c *clusterPeering) GetTerraformVars() (map[string]interface{}, error) {
-	vars := map[string]interface{}{
-		"region": "us-east-2",
-		"name":   c.name,
+		dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
+		dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
+		dc1ConsulServerToken := getOutputVariableValue("dc1_server_bootstrap_token")
+		dc2ConsulServerToken := getOutputVariableValue("dc2_server_bootstrap_token")
+
+		meshClientLBAddr := getOutputVariableValue("client_lb_address")
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul clients")
+		consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+		require.NoError(t, err)
+
+		consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc2ConsulServerToken))
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-dc1-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-dc2-example-server-app", tfResName)
+
+		consulClientOne.EnsureServiceReadiness(clientAppName, nil)
+		consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
+		consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", tfResName), nil)
+		consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", tfResName), nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app in the peer cluster is reachable")
+		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 	}
-
-	publicIP, err := common.GetPublicIP()
-	if err != nil {
-		return nil, err
-	}
-	vars["lb_ingress_ip"] = publicIP
-
-	return vars, nil
-}
-
-func (c *clusterPeering) Validate(t *testing.T, outputVars map[string]interface{}) {
-	logger.Log(t, "Fetching required output terraform variables")
-	getOutputVariableValue := func(name string) string {
-		val, ok := outputVars[name].(string)
-		require.True(t, ok)
-		return val
-	}
-
-	dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
-	dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
-	dc1ConsulServerToken := getOutputVariableValue("dc1_server_bootstrap_token")
-	dc2ConsulServerToken := getOutputVariableValue("dc2_server_bootstrap_token")
-
-	meshClientLBAddr := getOutputVariableValue("client_lb_address")
-	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
-
-	logger.Log(t, "Setting up the Consul clients")
-	consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
-	require.NoError(t, err)
-
-	consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc2ConsulServerToken))
-	require.NoError(t, err)
-
-	clientAppName := fmt.Sprintf("%s-dc1-example-client-app", c.name)
-	serverAppName := fmt.Sprintf("%s-dc2-example-server-app", c.name)
-
-	consulClientOne.EnsureServiceReadiness(clientAppName, nil)
-	consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
-	consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", c.name), nil)
-	consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", c.name), nil)
-
-	// Perform assertions by hitting the client app's LB
-	logger.Log(t, "calling client app's load balancer to see if the server app in the peer cluster is reachable")
-	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 }

--- a/test/acceptance/examples/scenarios/cluster-peering/main.go
+++ b/test/acceptance/examples/scenarios/cluster-peering/main.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package clusterpeering
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type clusterPeering struct {
+	name string
+}
+
+func New(name string) scenarios.Scenario {
+	// We go ahead with a simple name due to AWS restrictions
+	// on character length of resource names for certain resources.
+	return &clusterPeering{
+		name: "ecs",
+	}
+}
+
+func (c *clusterPeering) GetFolderName() string {
+	return "cluster-peering"
+}
+
+func (c *clusterPeering) GetTerraformVars() (map[string]interface{}, error) {
+	vars := map[string]interface{}{
+		"region": "us-east-2",
+		"name":   c.name,
+	}
+
+	publicIP, err := common.GetPublicIP()
+	if err != nil {
+		return nil, err
+	}
+	vars["lb_ingress_ip"] = publicIP
+
+	return vars, nil
+}
+
+func (c *clusterPeering) Validate(t *testing.T, outputVars map[string]interface{}) {
+	logger.Log(t, "Fetching required output terraform variables")
+	getOutputVariableValue := func(name string) string {
+		val, ok := outputVars[name].(string)
+		require.True(t, ok)
+		return val
+	}
+
+	dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
+	dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
+	dc1ConsulServerToken := getOutputVariableValue("dc1_server_bootstrap_token")
+	dc2ConsulServerToken := getOutputVariableValue("dc2_server_bootstrap_token")
+
+	meshClientLBAddr := getOutputVariableValue("client_lb_address")
+	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+	logger.Log(t, "Setting up the Consul clients")
+	consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+	require.NoError(t, err)
+
+	consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc2ConsulServerToken))
+	require.NoError(t, err)
+
+	clientAppName := fmt.Sprintf("%s-dc1-example-client-app", c.name)
+	serverAppName := fmt.Sprintf("%s-dc2-example-server-app", c.name)
+
+	consulClientOne.EnsureServiceRegistration(clientAppName, nil)
+	consulClientTwo.EnsureServiceRegistration(serverAppName, nil)
+	consulClientOne.EnsureServiceRegistration(fmt.Sprintf("%s-dc1-mesh-gateway", c.name), nil)
+	consulClientTwo.EnsureServiceRegistration(fmt.Sprintf("%s-dc2-mesh-gateway", c.name), nil)
+
+	// Perform assertions by hitting the client app's LB
+	logger.Log(t, "calling client app's load balancer to see if the server app in the peer cluster is reachable")
+	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+}

--- a/test/acceptance/examples/scenarios/cluster-peering/main.go
+++ b/test/acceptance/examples/scenarios/cluster-peering/main.go
@@ -71,10 +71,10 @@ func (c *clusterPeering) Validate(t *testing.T, outputVars map[string]interface{
 	clientAppName := fmt.Sprintf("%s-dc1-example-client-app", c.name)
 	serverAppName := fmt.Sprintf("%s-dc2-example-server-app", c.name)
 
-	consulClientOne.EnsureServiceRegistration(clientAppName, nil)
-	consulClientTwo.EnsureServiceRegistration(serverAppName, nil)
-	consulClientOne.EnsureServiceRegistration(fmt.Sprintf("%s-dc1-mesh-gateway", c.name), nil)
-	consulClientTwo.EnsureServiceRegistration(fmt.Sprintf("%s-dc2-mesh-gateway", c.name), nil)
+	consulClientOne.EnsureServiceReadiness(clientAppName, nil)
+	consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
+	consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", c.name), nil)
+	consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", c.name), nil)
 
 	// Perform assertions by hitting the client app's LB
 	logger.Log(t, "calling client app's load balancer to see if the server app in the peer cluster is reachable")

--- a/test/acceptance/examples/scenarios/common/common.go
+++ b/test/acceptance/examples/scenarios/common/common.go
@@ -5,7 +5,14 @@ package common
 
 import (
 	"io"
+	"math/rand"
 	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	characterSet = "abcdefghijklmnopqrstuvwxyz"
 )
 
 // This method relies on a third party API to retrieve
@@ -23,4 +30,17 @@ func GetPublicIP() (string, error) {
 	}
 
 	return string(ip), nil
+}
+
+// GenerateRandomStr generate a random string of a given length
+// from the predefined characterSet.
+//
+// Note: The resulting string is always lowercased.
+func GenerateRandomStr(length int) string {
+	rand.Seed(time.Now().UnixNano())
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = characterSet[rand.Intn(len(characterSet))]
+	}
+	return strings.ToLower(string(result))
 }

--- a/test/acceptance/examples/scenarios/common/common.go
+++ b/test/acceptance/examples/scenarios/common/common.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"io"
+	"net/http"
+)
+
+// This method relies on a third party API to retrieve
+// the public IP of the host where this test runs.
+func GetPublicIP() (string, error) {
+	resp, err := http.Get("https://api64.ipify.org?format=text")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	ip, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(ip), nil
+}

--- a/test/acceptance/examples/scenarios/common/consul.go
+++ b/test/acceptance/examples/scenarios/common/consul.go
@@ -1,0 +1,133 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type ConsulClientWrapper struct {
+	t      *testing.T
+	client *api.Client
+}
+
+type ClientOpts func(*api.Config)
+
+// SetupConsulClient sets up a consul client that can be used to directly
+// interact with the consul server.
+func SetupConsulClient(t *testing.T, serverAddr string, opts ...ClientOpts) (*ConsulClientWrapper, error) {
+	cfg := api.DefaultConfig()
+	cfg.Address = serverAddr
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &ConsulClientWrapper{
+		t:      t,
+		client: client,
+	}, nil
+}
+
+func WithToken(token string) ClientOpts {
+	return func(c *api.Config) {
+		c.Token = token
+	}
+}
+
+// EnsureServiceRegistration makes sure that a service with a given name
+// is registered as part of Consul's catalog
+func (ccw *ConsulClientWrapper) EnsureServiceRegistration(name string, queryOpts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if service %s is registered in Consul", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		exists, err := ccw.serviceExists(name, queryOpts)
+		require.NoError(r, err)
+		require.True(r, exists)
+	})
+}
+
+// EnsureServiceDeregistration makes sure that a service with a given name
+// is registered as part of Consul's catalog
+func (ccw *ConsulClientWrapper) EnsureServiceDeregistration(name string, queryOpts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if service %s is deregistered from Consul", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		exists, err := ccw.serviceExists(name, queryOpts)
+		require.NoError(r, err)
+		require.False(r, exists)
+	})
+}
+
+// EnsureHealthyService polls the catalog endpoint to understand a service's health status.
+// Note that the health of a service is an accumulation of all the health checks associated
+// with that of the service instances of that service.
+func (ccw *ConsulClientWrapper) EnsureHealthyService(name string, opts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if all instances of %s are healthy", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		healthy, err := ccw.isServiceHealthy(name, opts)
+		require.NoError(r, err)
+		require.True(r, healthy)
+	})
+}
+
+// EnsureServiceInstances verifies if the number of service instances for a service
+// in Consul catalog matches the expected count.
+func (ccw *ConsulClientWrapper) EnsureServiceInstances(name string, expectedCount int, queryOpts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if service %s has two instances registered", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		instances, err := ccw.listServiceInstances(name, nil)
+		require.NoError(r, err)
+		require.Len(r, instances, expectedCount)
+	})
+}
+
+// serviceExists verifies if a service with a given name exists in Consul's catalog.
+func (ccw *ConsulClientWrapper) serviceExists(serviceName string, queryOpts *api.QueryOptions) (bool, error) {
+	services, err := ccw.listServices(queryOpts)
+	if err != nil {
+		return false, err
+	}
+
+	_, ok := services[serviceName]
+	return ok, nil
+}
+
+// isServiceHealthy verifies if all service instances of a service with a given name are healthy in Consul's catalog.
+func (ccw *ConsulClientWrapper) isServiceHealthy(serviceName string, queryOpts *api.QueryOptions) (bool, error) {
+	res, _, err := ccw.client.Health().Checks(serviceName, queryOpts)
+	if err != nil {
+		return false, err
+	}
+
+	return res.AggregatedStatus() == api.HealthPassing, nil
+}
+
+// ListServiceInstances returns the list of service instances for a given service
+func (c *ConsulClientWrapper) listServiceInstances(serviceName string, queryOpts *api.QueryOptions) ([]*api.CatalogService, error) {
+	instances, _, err := c.client.Catalog().Service(serviceName, "", queryOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return instances, nil
+}
+
+func (c *ConsulClientWrapper) listServices(opts *api.QueryOptions) (map[string][]string, error) {
+	services, _, err := c.client.Catalog().Services(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return services, nil
+}

--- a/test/acceptance/examples/scenarios/common/ecs.go
+++ b/test/acceptance/examples/scenarios/common/ecs.go
@@ -1,0 +1,131 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/gruntwork-io/terratest/modules/shell"
+)
+
+type ECSClientWrapper struct {
+	client     *ecs.Client
+	clusterARN string
+}
+
+type ECSClientWrapperOpts func(*ECSClientWrapper)
+
+func NewECSClient(opts ...ECSClientWrapperOpts) (*ECSClientWrapper, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	ew := &ECSClientWrapper{
+		client: ecs.NewFromConfig(cfg),
+	}
+
+	for _, opt := range opts {
+		opt(ew)
+	}
+
+	return ew, nil
+}
+
+func WithClusterARN(arn string) ECSClientWrapperOpts {
+	return func(ew *ECSClientWrapper) {
+		ew.clusterARN = arn
+	}
+}
+
+func (e *ECSClientWrapper) WithClusterARN(clusterARN string) *ECSClientWrapper {
+	e.clusterARN = clusterARN
+	return e
+}
+
+// ListTasksForService returns back the taskARN list for a given service
+func (e *ECSClientWrapper) ListTasksForService(service string) ([]string, error) {
+	taskARNs := make([]string, 0)
+	var nextToken *string
+	for {
+		req := &ecs.ListTasksInput{
+			Cluster:     &e.clusterARN,
+			ServiceName: &service,
+			NextToken:   nextToken,
+		}
+
+		res, err := e.client.ListTasks(context.TODO(), req)
+		if err != nil {
+			return nil, err
+		}
+		nextToken = res.NextToken
+
+		taskARNs = append(taskARNs, res.TaskArns...)
+		if nextToken == nil {
+			break
+		}
+	}
+
+	return taskARNs, nil
+}
+
+// DescribeTasks returns back a detailed description of all the tasks passed as input.
+func (e *ECSClientWrapper) DescribeTasks(taskIDs []string) (*ecs.DescribeTasksOutput, error) {
+	req := &ecs.DescribeTasksInput{
+		Tasks:   taskIDs,
+		Cluster: &e.clusterARN,
+	}
+
+	return e.client.DescribeTasks(context.TODO(), req)
+}
+
+// StopTask stops a given task with a reason
+func (e *ECSClientWrapper) StopTask(taskID, reason string) error {
+	req := &ecs.StopTaskInput{
+		Task:    &taskID,
+		Cluster: &e.clusterARN,
+		Reason:  &reason,
+	}
+
+	_, err := e.client.StopTask(context.TODO(), req)
+	return err
+}
+
+func (e *ECSClientWrapper) UpdateService(serviceName string, desiredCount int32) error {
+	req := &ecs.UpdateServiceInput{
+		Service:      &serviceName,
+		Cluster:      &e.clusterARN,
+		DesiredCount: &desiredCount,
+	}
+
+	_, err := e.client.UpdateService(context.TODO(), req)
+	return err
+}
+
+// ExecuteCommandInteractive runs the provided command inside a container in the ECS task
+// and returns back the results.
+//
+// Note: Ideally we should try to use the SDK for this but it wasn't straight forward and
+// there was no clear documentation around the same.
+func (e *ECSClientWrapper) ExecuteCommandInteractive(t *testing.T, taskARN, container, command string) (string, error) {
+	return shell.RunCommandAndGetOutputE(t, shell.Command{
+		Command: "aws",
+		Args: []string{
+			"ecs",
+			"execute-command",
+			"--cluster",
+			e.clusterARN,
+			"--task",
+			taskARN,
+			fmt.Sprintf("--container=%s", container),
+			"--command",
+			command,
+			"--interactive",
+		},
+	})
+}

--- a/test/acceptance/examples/scenarios/common/fake_service.go
+++ b/test/acceptance/examples/scenarios/common/fake_service.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+)
+
+type FakeServiceResponse struct {
+	Body          string                          `json:"body"`
+	Code          int                             `json:"code"`
+	UpstreamCalls map[string]UpstreamCallResponse `json:"upstream_calls"`
+}
+
+type UpstreamCallResponse struct {
+	Name        string   `json:"name"`
+	Body        string   `json:"body"`
+	IpAddresses []string `json:"ip_addresses,omitempty"`
+	Code        int      `json:"code"`
+}
+
+// ValidateFakeServiceResponse takes in the client application's address(typically
+// the address of the ALB infront of the client app's ECS task) and performs a
+// HTTP GET against the same. It also verifies if the response matches the
+// success criteria and also verifies if the expected upstream app was hit.
+func ValidateFakeServiceResponse(t *testing.T, lbURL, expectedUpstream string) *UpstreamCallResponse {
+	var upstreamResp UpstreamCallResponse
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+		resp, err := GetFakeServiceResponse(lbURL)
+		require.NoError(r, err)
+
+		require.Equal(r, 200, resp.Code)
+		require.Equal(r, "Hello World", resp.Body)
+		require.NotNil(r, resp.UpstreamCalls)
+
+		upstreamResp = resp.UpstreamCalls["http://localhost:1234"]
+		require.NotNil(r, upstreamResp)
+		require.Equal(r, expectedUpstream, upstreamResp.Name)
+		require.Equal(r, 200, upstreamResp.Code)
+		require.Equal(r, "Hello World", upstreamResp.Body)
+	})
+
+	return &upstreamResp
+}
+
+// GetFakeServiceResponse takes in the client application's address(typically
+// the address of the ALB infront of the client app's ECS task) and performs
+// a HTTP GET against the same. It returns back some fields of the response
+// json which can be used by the caller to validate if the request went
+// through as expected.
+func GetFakeServiceResponse(addr string) (*FakeServiceResponse, error) {
+	resp, err := httpGet(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	var fakeSvcResp *FakeServiceResponse
+	err = json.Unmarshal(resp, &fakeSvcResp)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling json %w", err)
+	}
+
+	return fakeSvcResp, nil
+}
+
+func httpGet(addr string) ([]byte, error) {
+	resp, err := http.Get(addr)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}

--- a/test/acceptance/examples/scenarios/common/fake_service_test.go
+++ b/test/acceptance/examples/scenarios/common/fake_service_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFakeServiceResponse(t *testing.T) {
+	cases := map[string]struct {
+		httpRespCode int
+		respStr      string
+		wantErr      bool
+		errStr       string
+		expectedResp *FakeServiceResponse
+	}{
+		"non success error code": {
+			httpRespCode: http.StatusInternalServerError,
+			wantErr:      true,
+		},
+		"json unmarshalling error": {
+			httpRespCode: http.StatusOK,
+			respStr:      `unsupported-response-format`,
+			wantErr:      true,
+			errStr:       "unmarshalling json",
+		},
+		"failed upstream call": {
+			httpRespCode: http.StatusOK,
+			respStr:      "{\n  \"name\": \"consul-ecs-example-client-app\",\n  \"uri\": \"/\",\n  \"type\": \"HTTP\",\n  \"ip_addresses\": [\n    \"169.254.172.2\",\n    \"10.0.3.165\"\n  ],\n  \"start_time\": \"2023-12-17T13:14:48.498808\",\n  \"end_time\": \"2023-12-17T13:14:48.505297\",\n  \"duration\": \"6.488534ms\",\n  \"body\": \"Hello World\",\n  \"upstream_calls\": {\n    \"http://localhost:1234\": {\n      \"uri\": \"http://localhost:1234\",\n      \"code\": -1,\n      \"error\": \"Error communicating with upstream service: Get \\\"http://localhost:1234/\\\": EOF\"\n    }\n  },\n  \"code\": 500\n}",
+			expectedResp: &FakeServiceResponse{
+				Body: "Hello World",
+				Code: 500,
+				UpstreamCalls: map[string]UpstreamCallResponse{
+					"http://localhost:1234": {
+						Code: -1,
+					},
+				},
+			},
+		},
+		"successful upstream call": {
+			httpRespCode: http.StatusOK,
+			respStr:      "{\n  \"name\": \"consul-ecs-example-client-app\",\n  \"uri\": \"/\",\n  \"type\": \"HTTP\",\n  \"ip_addresses\": [\n    \"169.254.172.2\",\n    \"10.0.3.165\"\n  ],\n  \"start_time\": \"2023-12-17T13:01:18.291103\",\n  \"end_time\": \"2023-12-17T13:01:18.306560\",\n  \"duration\": \"15.456478ms\",\n  \"body\": \"Hello World\",\n  \"upstream_calls\": {\n    \"http://localhost:1234\": {\n      \"name\": \"consul-ecs-example-server-app\",\n      \"uri\": \"http://localhost:1234\",\n      \"type\": \"HTTP\",\n      \"ip_addresses\": [\n        \"169.254.172.2\",\n        \"10.0.2.34\"\n      ],\n      \"start_time\": \"2023-12-17T13:01:18.304883\",\n      \"end_time\": \"2023-12-17T13:01:18.305302\",\n      \"duration\": \"418.719µs\",\n      \"headers\": {\n        \"Content-Length\": \"298\",\n        \"Content-Type\": \"text/plain; charset=utf-8\",\n        \"Date\": \"Sun, 17 Dec 2023 13:01:18 GMT\"\n      },\n      \"body\": \"Hello World\",\n      \"code\": 200\n    }\n  },\n  \"code\": 200\n}",
+			expectedResp: &FakeServiceResponse{
+				Body: "Hello World",
+				Code: 200,
+				UpstreamCalls: map[string]UpstreamCallResponse{
+					"http://localhost:1234": {
+						Name: "consul-ecs-example-server-app",
+						Body: "Hello World",
+						Code: 200,
+						IpAddresses: []string{
+							"169.254.172.2",
+							"10.0.2.34",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(c.httpRespCode)
+				_, _ = w.Write([]byte(c.respStr))
+			})
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+
+			resp, err := GetFakeServiceResponse(server.URL)
+			if c.wantErr {
+				require.Error(t, err)
+				if c.errStr != "" {
+					require.Contains(t, err.Error(), c.errStr)
+				}
+			} else {
+				require.NotNil(t, resp)
+				require.True(t, reflect.DeepEqual(resp, c.expectedResp))
+			}
+		})
+	}
+}

--- a/test/acceptance/examples/scenarios/ec2/main.go
+++ b/test/acceptance/examples/scenarios/ec2/main.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type ec2 struct {
+	name string
+}
+
+func New(name string) scenarios.Scenario {
+	return &ec2{
+		name: name,
+	}
+}
+
+func (e *ec2) GetFolderName() string {
+	return "dev-server-ec2"
+}
+
+func (e *ec2) GetTerraformVars() (map[string]interface{}, error) {
+	vars := map[string]interface{}{
+		"region": "us-east-2",
+		"name":   e.name,
+	}
+
+	publicIP, err := common.GetPublicIP()
+	if err != nil {
+		return nil, err
+	}
+	vars["lb_ingress_ip"] = publicIP
+
+	return vars, nil
+}
+
+func (e *ec2) Validate(t *testing.T, outputVars map[string]interface{}) {
+	logger.Log(t, "Fetching required output terraform variables")
+	getOutputVariableValue := func(name string) string {
+		val, ok := outputVars[name].(string)
+		require.True(t, ok)
+		return val
+	}
+
+	consulServerLBAddr := getOutputVariableValue("consul_server_lb_address")
+	meshClientLBAddr := getOutputVariableValue("mesh_client_lb_address")
+	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+	logger.Log(t, "Setting up the Consul client")
+	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
+	require.NoError(t, err)
+
+	clientAppName := fmt.Sprintf("%s-example-client-app", e.name)
+	serverAppName := fmt.Sprintf("%s-example-server-app", e.name)
+
+	consulClient.EnsureServiceRegistration(clientAppName, nil)
+	consulClient.EnsureServiceRegistration(serverAppName, nil)
+
+	// Perform assertions by hitting the client app's LB
+	logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
+	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+}

--- a/test/acceptance/examples/scenarios/ec2/main.go
+++ b/test/acceptance/examples/scenarios/ec2/main.go
@@ -14,58 +14,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type ec2 struct {
-	name string
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResourcesName := fmt.Sprintf("ecs-%s", common.GenerateRandomStr(6))
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "EC2",
+		FolderName:         "dev-server-ec2",
+		TerraformInputVars: getTerraformVars(tfResourcesName),
+		Validate:           validate(tfResourcesName),
+	})
 }
 
-func New(name string) scenarios.Scenario {
-	return &ec2{
-		name: name,
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-2",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
 	}
 }
 
-func (e *ec2) GetFolderName() string {
-	return "dev-server-ec2"
-}
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, tfOutput map[string]interface{}) {
+		logger.Log(t, "Fetching required output terraform variables")
+		getOutputVariableValue := func(name string) string {
+			val, ok := tfOutput[name].(string)
+			require.True(t, ok)
+			return val
+		}
 
-func (e *ec2) GetTerraformVars() (map[string]interface{}, error) {
-	vars := map[string]interface{}{
-		"region": "us-east-2",
-		"name":   e.name,
+		consulServerLBAddr := getOutputVariableValue("consul_server_lb_address")
+		meshClientLBAddr := getOutputVariableValue("mesh_client_lb_address")
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-example-server-app", tfResName)
+
+		consulClient.EnsureServiceReadiness(clientAppName, nil)
+		consulClient.EnsureServiceReadiness(serverAppName, nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
+		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 	}
-
-	publicIP, err := common.GetPublicIP()
-	if err != nil {
-		return nil, err
-	}
-	vars["lb_ingress_ip"] = publicIP
-
-	return vars, nil
-}
-
-func (e *ec2) Validate(t *testing.T, outputVars map[string]interface{}) {
-	logger.Log(t, "Fetching required output terraform variables")
-	getOutputVariableValue := func(name string) string {
-		val, ok := outputVars[name].(string)
-		require.True(t, ok)
-		return val
-	}
-
-	consulServerLBAddr := getOutputVariableValue("consul_server_lb_address")
-	meshClientLBAddr := getOutputVariableValue("mesh_client_lb_address")
-	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
-
-	logger.Log(t, "Setting up the Consul client")
-	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
-	require.NoError(t, err)
-
-	clientAppName := fmt.Sprintf("%s-example-client-app", e.name)
-	serverAppName := fmt.Sprintf("%s-example-server-app", e.name)
-
-	consulClient.EnsureServiceReadiness(clientAppName, nil)
-	consulClient.EnsureServiceReadiness(serverAppName, nil)
-
-	// Perform assertions by hitting the client app's LB
-	logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
-	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 }

--- a/test/acceptance/examples/scenarios/ec2/main.go
+++ b/test/acceptance/examples/scenarios/ec2/main.go
@@ -62,8 +62,8 @@ func (e *ec2) Validate(t *testing.T, outputVars map[string]interface{}) {
 	clientAppName := fmt.Sprintf("%s-example-client-app", e.name)
 	serverAppName := fmt.Sprintf("%s-example-server-app", e.name)
 
-	consulClient.EnsureServiceRegistration(clientAppName, nil)
-	consulClient.EnsureServiceRegistration(serverAppName, nil)
+	consulClient.EnsureServiceReadiness(clientAppName, nil)
+	consulClient.EnsureServiceReadiness(serverAppName, nil)
 
 	// Perform assertions by hitting the client app's LB
 	logger.Log(t, "calling client app's load balancer to see if the server app is reachable")

--- a/test/acceptance/examples/scenarios/fargate/main.go
+++ b/test/acceptance/examples/scenarios/fargate/main.go
@@ -8,64 +8,66 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
 	"github.com/stretchr/testify/require"
 )
 
-type fargate struct {
-	name string
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResourcesName := strings.ToLower(fmt.Sprintf("ecs-%s", random.UniqueId()))
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "FARGATE",
+		FolderName:         "dev-server-fargate",
+		TerraformInputVars: getTerraformVars(tfResourcesName),
+		Validate:           validate(tfResourcesName),
+	})
 }
 
-func New(name string) scenarios.Scenario {
-	return &fargate{
-		name: name,
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-1",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
 	}
 }
 
-func (f *fargate) GetFolderName() string {
-	return "dev-server-fargate"
-}
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, outputVars map[string]interface{}) {
+		logger.Log(t, "Fetching required output terraform variables")
+		getOutputVariableValue := func(name string) string {
+			val, ok := outputVars[name].(string)
+			require.True(t, ok)
+			return val
+		}
 
-func (f *fargate) GetTerraformVars() (map[string]interface{}, error) {
-	vars := map[string]interface{}{
-		"region": "us-east-1",
-		"name":   f.name,
+		consulServerLBAddr := getOutputVariableValue("consul_server_lb_address")
+		meshClientLBAddr := getOutputVariableValue("mesh_client_lb_address")
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-example-server-app", tfResName)
+
+		consulClient.EnsureServiceReadiness(clientAppName, nil)
+		consulClient.EnsureServiceReadiness(serverAppName, nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
+		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 	}
-
-	publicIP, err := common.GetPublicIP()
-	if err != nil {
-		return nil, err
-	}
-	vars["lb_ingress_ip"] = publicIP
-
-	return vars, nil
-}
-
-func (f *fargate) Validate(t *testing.T, outputVars map[string]interface{}) {
-	logger.Log(t, "Fetching required output terraform variables")
-	getOutputVariableValue := func(name string) string {
-		val, ok := outputVars[name].(string)
-		require.True(t, ok)
-		return val
-	}
-
-	consulServerLBAddr := getOutputVariableValue("consul_server_lb_address")
-	meshClientLBAddr := getOutputVariableValue("mesh_client_lb_address")
-	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
-
-	logger.Log(t, "Setting up the Consul client")
-	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
-	require.NoError(t, err)
-
-	clientAppName := fmt.Sprintf("%s-example-client-app", f.name)
-	serverAppName := fmt.Sprintf("%s-example-server-app", f.name)
-
-	consulClient.EnsureServiceReadiness(clientAppName, nil)
-	consulClient.EnsureServiceReadiness(serverAppName, nil)
-
-	// Perform assertions by hitting the client app's LB
-	logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
-	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 }

--- a/test/acceptance/examples/scenarios/fargate/main.go
+++ b/test/acceptance/examples/scenarios/fargate/main.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fargate
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type fargate struct {
+	name string
+}
+
+func New(name string) scenarios.Scenario {
+	return &fargate{
+		name: name,
+	}
+}
+
+func (f *fargate) GetFolderName() string {
+	return "dev-server-fargate"
+}
+
+func (f *fargate) GetTerraformVars() (map[string]interface{}, error) {
+	vars := map[string]interface{}{
+		"region": "us-east-1",
+		"name":   f.name,
+	}
+
+	publicIP, err := common.GetPublicIP()
+	if err != nil {
+		return nil, err
+	}
+	vars["lb_ingress_ip"] = publicIP
+
+	return vars, nil
+}
+
+func (f *fargate) Validate(t *testing.T, outputVars map[string]interface{}) {
+	logger.Log(t, "Fetching required output terraform variables")
+	getOutputVariableValue := func(name string) string {
+		val, ok := outputVars[name].(string)
+		require.True(t, ok)
+		return val
+	}
+
+	consulServerLBAddr := getOutputVariableValue("consul_server_lb_address")
+	meshClientLBAddr := getOutputVariableValue("mesh_client_lb_address")
+	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+	logger.Log(t, "Setting up the Consul client")
+	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
+	require.NoError(t, err)
+
+	clientAppName := fmt.Sprintf("%s-example-client-app", f.name)
+	serverAppName := fmt.Sprintf("%s-example-server-app", f.name)
+
+	consulClient.EnsureServiceRegistration(clientAppName, nil)
+	consulClient.EnsureServiceRegistration(serverAppName, nil)
+
+	// Perform assertions by hitting the client app's LB
+	logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
+	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+}

--- a/test/acceptance/examples/scenarios/fargate/main.go
+++ b/test/acceptance/examples/scenarios/fargate/main.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
@@ -16,7 +15,7 @@ import (
 )
 
 func RegisterScenario(r scenarios.ScenarioRegistry) {
-	tfResourcesName := strings.ToLower(fmt.Sprintf("ecs-%s", random.UniqueId()))
+	tfResourcesName := fmt.Sprintf("ecs-%s", common.GenerateRandomStr(6))
 
 	r.Register(scenarios.ScenarioRegistration{
 		Name:               "FARGATE",

--- a/test/acceptance/examples/scenarios/fargate/main.go
+++ b/test/acceptance/examples/scenarios/fargate/main.go
@@ -4,6 +4,7 @@
 package fargate
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -13,6 +14,11 @@ import (
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
 	"github.com/stretchr/testify/require"
 )
+
+type TFOutputs struct {
+	ConsulServerLBAddr string `json:"consul_server_lb_address"`
+	MeshClientLBAddr   string `json:"mesh_client_lb_address"`
+}
 
 func RegisterScenario(r scenarios.ScenarioRegistry) {
 	tfResourcesName := fmt.Sprintf("ecs-%s", common.GenerateRandomStr(6))
@@ -43,16 +49,14 @@ func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
 }
 
 func validate(tfResName string) scenarios.ValidateHook {
-	return func(t *testing.T, outputVars map[string]interface{}) {
+	return func(t *testing.T, data []byte) {
 		logger.Log(t, "Fetching required output terraform variables")
-		getOutputVariableValue := func(name string) string {
-			val, ok := outputVars[name].(string)
-			require.True(t, ok)
-			return val
-		}
 
-		consulServerLBAddr := getOutputVariableValue("consul_server_lb_address")
-		meshClientLBAddr := getOutputVariableValue("mesh_client_lb_address")
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+
+		consulServerLBAddr := tfOutputs.ConsulServerLBAddr
+		meshClientLBAddr := tfOutputs.MeshClientLBAddr
 		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
 
 		logger.Log(t, "Setting up the Consul client")

--- a/test/acceptance/examples/scenarios/fargate/main.go
+++ b/test/acceptance/examples/scenarios/fargate/main.go
@@ -62,8 +62,8 @@ func (f *fargate) Validate(t *testing.T, outputVars map[string]interface{}) {
 	clientAppName := fmt.Sprintf("%s-example-client-app", f.name)
 	serverAppName := fmt.Sprintf("%s-example-server-app", f.name)
 
-	consulClient.EnsureServiceRegistration(clientAppName, nil)
-	consulClient.EnsureServiceRegistration(serverAppName, nil)
+	consulClient.EnsureServiceReadiness(clientAppName, nil)
+	consulClient.EnsureServiceReadiness(serverAppName, nil)
 
 	// Perform assertions by hitting the client app's LB
 	logger.Log(t, "calling client app's load balancer to see if the server app is reachable")

--- a/test/acceptance/examples/scenarios/hcp/main.go
+++ b/test/acceptance/examples/scenarios/hcp/main.go
@@ -1,0 +1,119 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package hcp
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type hcp struct{}
+
+type service struct {
+	awsRegion     string
+	ecsClusterARN string
+	name          string
+	partition     string
+	namespace     string
+}
+
+func New(name string) scenarios.Scenario {
+	return &hcp{}
+}
+
+func (h *hcp) GetFolderName() string {
+	return "admin-partitions/terraform"
+}
+
+func (h *hcp) GetTerraformVars() (map[string]interface{}, error) {
+	vars := map[string]interface{}{
+		"region": "us-west-2",
+	}
+
+	hcpProjectID := os.Getenv("HCP_PROJECT_ID")
+	if hcpProjectID == "" {
+		return nil, fmt.Errorf("expected HCP_PROJECT_ID to be non empty")
+	}
+	vars["hcp_project_id"] = hcpProjectID
+
+	return vars, nil
+}
+
+func (h *hcp) Validate(t *testing.T, outputVars map[string]interface{}) {
+	logger.Log(t, "Fetching required output terraform variables")
+	getOutputVariableValue := func(name string) string {
+		val, ok := outputVars[name].(string)
+		require.True(t, ok)
+		return val
+	}
+	consulServerLBAddr := getOutputVariableValue("hcp_public_endpoint")
+	consulServerToken := getOutputVariableValue("token")
+
+	clientService := getServiceDetails(t, "client", outputVars)
+	serverService := getServiceDetails(t, "server", outputVars)
+
+	logger.Log(t, "Setting up the Consul client")
+	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr, common.WithToken(consulServerToken))
+	require.NoError(t, err)
+
+	ensureServiceRegistration(consulClient, clientService)
+	ensureServiceRegistration(consulClient, serverService)
+
+	logger.Log(t, "Setting up ECS client")
+
+	ecsClient, err := common.NewECSClient()
+	require.NoError(t, err)
+
+	// List tasks for the client service
+	tasks, err := ecsClient.WithClusterARN(clientService.ecsClusterARN).ListTasksForService(clientService.name)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	// Validate connection between apps by running a remote command inside the container.
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+		res, err := ecsClient.
+			WithClusterARN(clientService.ecsClusterARN).
+			ExecuteCommandInteractive(t, tasks[0], "basic", `/bin/sh -c "curl localhost:1234"`)
+		r.Check(err)
+		if !strings.Contains(res, `"code": 200`) {
+			r.Errorf("response was unexpected: %q", res)
+		}
+	})
+}
+
+func getServiceDetails(t *testing.T, name string, outputVars map[string]interface{}) *service {
+	val, ok := outputVars[name].(map[string]interface{})
+	require.True(t, ok)
+
+	ensureAndReturnNonEmptyVal := func(v interface{}) string {
+		require.NotEmpty(t, v)
+		return v.(string)
+	}
+
+	return &service{
+		name:          ensureAndReturnNonEmptyVal(val["name"]),
+		awsRegion:     ensureAndReturnNonEmptyVal(val["region"]),
+		ecsClusterARN: ensureAndReturnNonEmptyVal(val["ecs_cluster_arn"]),
+		partition:     ensureAndReturnNonEmptyVal(val["partition"]),
+		namespace:     ensureAndReturnNonEmptyVal(val["namespace"]),
+	}
+}
+
+func ensureServiceRegistration(consulClient *common.ConsulClientWrapper, service *service) {
+	opts := &api.QueryOptions{
+		Namespace: service.namespace,
+		Partition: service.partition,
+	}
+	consulClient.EnsureServiceRegistration(service.name, opts)
+}

--- a/test/acceptance/examples/scenarios/hcp/main.go
+++ b/test/acceptance/examples/scenarios/hcp/main.go
@@ -18,8 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type hcp struct{}
-
 type service struct {
 	awsRegion     string
 	ecsClusterARN string
@@ -28,68 +26,73 @@ type service struct {
 	namespace     string
 }
 
-func New(name string) scenarios.Scenario {
-	return &hcp{}
-}
-
-func (h *hcp) GetFolderName() string {
-	return "admin-partitions/terraform"
-}
-
-func (h *hcp) GetTerraformVars() (map[string]interface{}, error) {
-	vars := map[string]interface{}{
-		"region": "us-west-2",
-	}
-
-	hcpProjectID := os.Getenv("HCP_PROJECT_ID")
-	if hcpProjectID == "" {
-		return nil, fmt.Errorf("expected HCP_PROJECT_ID to be non empty")
-	}
-	vars["hcp_project_id"] = hcpProjectID
-
-	return vars, nil
-}
-
-func (h *hcp) Validate(t *testing.T, outputVars map[string]interface{}) {
-	logger.Log(t, "Fetching required output terraform variables")
-	getOutputVariableValue := func(name string) string {
-		val, ok := outputVars[name].(string)
-		require.True(t, ok)
-		return val
-	}
-	consulServerLBAddr := getOutputVariableValue("hcp_public_endpoint")
-	consulServerToken := getOutputVariableValue("token")
-
-	clientService := getServiceDetails(t, "client", outputVars)
-	serverService := getServiceDetails(t, "server", outputVars)
-
-	logger.Log(t, "Setting up the Consul client")
-	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr, common.WithToken(consulServerToken))
-	require.NoError(t, err)
-
-	ensureServiceReadiness(consulClient, clientService)
-	ensureServiceReadiness(consulClient, serverService)
-
-	logger.Log(t, "Setting up ECS client")
-
-	ecsClient, err := common.NewECSClient()
-	require.NoError(t, err)
-
-	// List tasks for the client service
-	tasks, err := ecsClient.WithClusterARN(clientService.ecsClusterARN).ListTasksForService(clientService.name)
-	require.NoError(t, err)
-	require.Len(t, tasks, 1)
-
-	// Validate connection between apps by running a remote command inside the container.
-	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
-		res, err := ecsClient.
-			WithClusterARN(clientService.ecsClusterARN).
-			ExecuteCommandInteractive(t, tasks[0], "basic", `/bin/sh -c "curl localhost:1234"`)
-		r.Check(err)
-		if !strings.Contains(res, `"code": 200`) {
-			r.Errorf("response was unexpected: %q", res)
-		}
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "HCP",
+		FolderName:         "admin-partitions/terraform",
+		TerraformInputVars: getTerraformVars(),
+		Validate:           validate(),
 	})
+}
+
+func getTerraformVars() scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-west-2",
+		}
+
+		hcpProjectID := os.Getenv("HCP_PROJECT_ID")
+		if hcpProjectID == "" {
+			return nil, fmt.Errorf("expected HCP_PROJECT_ID to be non empty")
+		}
+		vars["hcp_project_id"] = hcpProjectID
+
+		return vars, nil
+	}
+}
+
+func validate() scenarios.ValidateHook {
+	return func(t *testing.T, tfOutput map[string]interface{}) {
+		logger.Log(t, "Fetching required output terraform variables")
+		getOutputVariableValue := func(name string) string {
+			val, ok := tfOutput[name].(string)
+			require.True(t, ok)
+			return val
+		}
+		consulServerLBAddr := getOutputVariableValue("hcp_public_endpoint")
+		consulServerToken := getOutputVariableValue("token")
+
+		clientService := getServiceDetails(t, "client", tfOutput)
+		serverService := getServiceDetails(t, "server", tfOutput)
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, consulServerLBAddr, common.WithToken(consulServerToken))
+		require.NoError(t, err)
+
+		ensureServiceReadiness(consulClient, clientService)
+		ensureServiceReadiness(consulClient, serverService)
+
+		logger.Log(t, "Setting up ECS client")
+
+		ecsClient, err := common.NewECSClient()
+		require.NoError(t, err)
+
+		// List tasks for the client service
+		tasks, err := ecsClient.WithClusterARN(clientService.ecsClusterARN).ListTasksForService(clientService.name)
+		require.NoError(t, err)
+		require.Len(t, tasks, 1)
+
+		// Validate connection between apps by running a remote command inside the container.
+		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			res, err := ecsClient.
+				WithClusterARN(clientService.ecsClusterARN).
+				ExecuteCommandInteractive(t, tasks[0], "basic", `/bin/sh -c "curl localhost:1234"`)
+			r.Check(err)
+			if !strings.Contains(res, `"code": 200`) {
+				r.Errorf("response was unexpected: %q", res)
+			}
+		})
+	}
 }
 
 func getServiceDetails(t *testing.T, name string, outputVars map[string]interface{}) *service {

--- a/test/acceptance/examples/scenarios/hcp/main.go
+++ b/test/acceptance/examples/scenarios/hcp/main.go
@@ -67,8 +67,8 @@ func (h *hcp) Validate(t *testing.T, outputVars map[string]interface{}) {
 	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr, common.WithToken(consulServerToken))
 	require.NoError(t, err)
 
-	ensureServiceRegistration(consulClient, clientService)
-	ensureServiceRegistration(consulClient, serverService)
+	ensureServiceReadiness(consulClient, clientService)
+	ensureServiceReadiness(consulClient, serverService)
 
 	logger.Log(t, "Setting up ECS client")
 
@@ -110,10 +110,10 @@ func getServiceDetails(t *testing.T, name string, outputVars map[string]interfac
 	}
 }
 
-func ensureServiceRegistration(consulClient *common.ConsulClientWrapper, service *service) {
+func ensureServiceReadiness(consulClient *common.ConsulClientWrapper, service *service) {
 	opts := &api.QueryOptions{
 		Namespace: service.namespace,
 		Partition: service.partition,
 	}
-	consulClient.EnsureServiceRegistration(service.name, opts)
+	consulClient.EnsureServiceReadiness(service.name, opts)
 }

--- a/test/acceptance/examples/scenarios/locality-aware-routing/main.go
+++ b/test/acceptance/examples/scenarios/locality-aware-routing/main.go
@@ -1,0 +1,197 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package localityAwareRouting
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type localityAwareRouting struct {
+	name string
+}
+
+func New(name string) scenarios.Scenario {
+	return &localityAwareRouting{
+		name: "con",
+	}
+}
+
+func (l *localityAwareRouting) GetFolderName() string {
+	return "locality-aware-routing"
+}
+
+func (l *localityAwareRouting) GetTerraformVars() (map[string]interface{}, error) {
+	vars := map[string]interface{}{
+		"region": "us-west-2",
+		"name":   l.name,
+	}
+
+	publicIP, err := common.GetPublicIP()
+	if err != nil {
+		return nil, err
+	}
+	vars["lb_ingress_ip"] = publicIP
+
+	enterpriseLicense := os.Getenv("CONSUL_LICENSE")
+	if enterpriseLicense == "" {
+		return nil, fmt.Errorf("expected CONSUL_LICENSE to be non empty")
+	}
+	vars["consul_license"] = enterpriseLicense
+
+	return vars, nil
+}
+
+func (l *localityAwareRouting) Validate(t *testing.T, outputVars map[string]interface{}) {
+	logger.Log(t, "Fetching required output terraform variables")
+	getOutputVariableValue := func(name string) string {
+		val, ok := outputVars[name].(string)
+		require.True(t, ok)
+		return val
+	}
+
+	consulServerLBAddr := getOutputVariableValue("consul_server_url")
+	consulServerToken := getOutputVariableValue("consul_server_bootstrap_token")
+	meshClientLBAddr := getOutputVariableValue("client_lb_address")
+	clusterARN := getOutputVariableValue("ecs_cluster_arn")
+
+	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+	logger.Log(t, "Setting up the Consul client")
+	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr, common.WithToken(consulServerToken))
+	require.NoError(t, err)
+
+	clientAppName := "example-client-app"
+	serverAppName := "example-server-app"
+
+	consulClient.EnsureServiceRegistration(clientAppName, nil)
+	consulClient.EnsureServiceRegistration(serverAppName, nil)
+
+	consulClient.EnsureServiceInstances(serverAppName, 2, nil)
+
+	ecsClient, err := common.NewECSClient(common.WithClusterARN(clusterARN))
+	require.NoError(t, err)
+
+	logger.Log(t, "Listing and describing tasks for each ECS service")
+	clientTasks := assertAndListTasks(t, ecsClient, clientAppName, 1)
+	serverTasks := assertAndListTasks(t, ecsClient, serverAppName, 2)
+
+	// Describe the client task
+	tasks := assertAndDescribeTasks(t, ecsClient, clientTasks, 1)
+	clientTask := tasks[0]
+
+	// Describe the server tasks
+	tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
+	serverTaskIPMap := getTaskIPToTaskMap(t, tasks)
+
+	performAssertions := func(expectSameAZ bool) {
+		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			resp, err := common.GetFakeServiceResponse(meshClientLBAddr)
+			require.NoError(r, err)
+
+			require.Equal(r, 200, resp.Code)
+			require.Equal(r, "Hello World", resp.Body)
+			require.NotNil(r, resp.UpstreamCalls)
+
+			upstreamResp := resp.UpstreamCalls["http://localhost:1234"]
+			require.NotNil(r, upstreamResp)
+			require.Equal(r, serverAppName, upstreamResp.Name)
+			require.Equal(r, 200, upstreamResp.Code)
+			require.Equal(r, "Hello World", upstreamResp.Body)
+
+			var upstreamServerTask types.Task
+			var ok bool
+			for _, ip := range upstreamResp.IpAddresses {
+				upstreamServerTask, ok = serverTaskIPMap[ip]
+				if ok {
+					break
+				}
+			}
+
+			// Check if the client app's AZ matches with that of the server task
+			if expectSameAZ {
+				require.Equal(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
+			} else {
+				require.NotEqual(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
+			}
+		})
+	}
+
+	logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
+	performAssertions(true)
+
+	// Stop the server app present in the same AZ as that of the client
+	var serverTaskToStop types.Task
+	for _, v := range tasks {
+		if *v.AvailabilityZone == *clientTask.AvailabilityZone {
+			serverTaskToStop = v
+			break
+		}
+	}
+
+	logger.Log(t, "Stopping the server app's task present in the same AZ as that of the client.")
+	require.NoError(t, ecsClient.StopTask(*serverTaskToStop.TaskArn, "stopping as part of a test"))
+
+	logger.Log(t, "Calling the client app's load balancer to verify if the client app falls back to hit the server app in the other availability zone")
+	performAssertions(false)
+
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+		logger.Log(t, "Waiting for ECS to spin up the previously stopped server app's task")
+		serverTasks, err = ecsClient.ListTasksForService(serverAppName)
+		require.NoError(r, err)
+		require.Len(r, serverTasks, 2)
+	})
+
+	tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
+	serverTaskIPMap = getTaskIPToTaskMap(t, tasks)
+
+	logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
+	performAssertions(true)
+}
+
+func assertAndListTasks(t *testing.T, ecsClient *common.ECSClientWrapper, service string, expectedCount int) []string {
+	tasks, err := ecsClient.ListTasksForService(service)
+	require.NoError(t, err)
+	require.Len(t, tasks, expectedCount)
+
+	return tasks
+}
+
+func assertAndDescribeTasks(t *testing.T, ecsClient *common.ECSClientWrapper, taskIDs []string, expectedCount int) []types.Task {
+	tasks, err := ecsClient.DescribeTasks(taskIDs)
+	require.NoError(t, err)
+	require.NotNil(t, tasks)
+	require.Len(t, tasks.Tasks, expectedCount)
+
+	return tasks.Tasks
+}
+
+func getTaskIPToTaskMap(t *testing.T, tasks []types.Task) map[string]types.Task {
+	serverTaskIPMap := make(map[string]types.Task)
+	for _, task := range tasks {
+		serverTaskIPMap[getTaskPrivateIP(t, task)] = task
+	}
+
+	return serverTaskIPMap
+}
+
+func getTaskPrivateIP(t *testing.T, task types.Task) string {
+	require.NotNil(t, task)
+	require.NotEmpty(t, task.Containers)
+	require.NotEmpty(t, task.Containers[0].NetworkInterfaces)
+
+	ip := task.Containers[0].NetworkInterfaces[0].PrivateIpv4Address
+	require.NotNil(t, ip)
+	return *ip
+}

--- a/test/acceptance/examples/scenarios/locality-aware-routing/main.go
+++ b/test/acceptance/examples/scenarios/locality-aware-routing/main.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package localityAwareRouting
+package localityawarerouting
 
 import (
 	"fmt"
@@ -18,146 +18,146 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type localityAwareRouting struct {
-	name string
-}
-
-func New(name string) scenarios.Scenario {
-	return &localityAwareRouting{
-		name: "con",
-	}
-}
-
-func (l *localityAwareRouting) GetFolderName() string {
-	return "locality-aware-routing"
-}
-
-func (l *localityAwareRouting) GetTerraformVars() (map[string]interface{}, error) {
-	vars := map[string]interface{}{
-		"region": "us-west-2",
-		"name":   l.name,
-	}
-
-	publicIP, err := common.GetPublicIP()
-	if err != nil {
-		return nil, err
-	}
-	vars["lb_ingress_ip"] = publicIP
-
-	enterpriseLicense := os.Getenv("CONSUL_LICENSE")
-	if enterpriseLicense == "" {
-		return nil, fmt.Errorf("expected CONSUL_LICENSE to be non empty")
-	}
-	vars["consul_license"] = enterpriseLicense
-
-	return vars, nil
-}
-
-func (l *localityAwareRouting) Validate(t *testing.T, outputVars map[string]interface{}) {
-	logger.Log(t, "Fetching required output terraform variables")
-	getOutputVariableValue := func(name string) string {
-		val, ok := outputVars[name].(string)
-		require.True(t, ok)
-		return val
-	}
-
-	consulServerLBAddr := getOutputVariableValue("consul_server_url")
-	consulServerToken := getOutputVariableValue("consul_server_bootstrap_token")
-	meshClientLBAddr := getOutputVariableValue("client_lb_address")
-	clusterARN := getOutputVariableValue("ecs_cluster_arn")
-
-	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
-
-	logger.Log(t, "Setting up the Consul client")
-	consulClient, err := common.SetupConsulClient(t, consulServerLBAddr, common.WithToken(consulServerToken))
-	require.NoError(t, err)
-
-	clientAppName := "example-client-app"
-	serverAppName := "example-server-app"
-
-	consulClient.EnsureServiceReadiness(clientAppName, nil)
-	consulClient.EnsureServiceReadiness(serverAppName, nil)
-
-	consulClient.EnsureServiceInstances(serverAppName, 2, nil)
-
-	ecsClient, err := common.NewECSClient(common.WithClusterARN(clusterARN))
-	require.NoError(t, err)
-
-	logger.Log(t, "Listing and describing tasks for each ECS service")
-	clientTasks := assertAndListTasks(t, ecsClient, clientAppName, 1)
-	serverTasks := assertAndListTasks(t, ecsClient, serverAppName, 2)
-
-	// Describe the client task
-	tasks := assertAndDescribeTasks(t, ecsClient, clientTasks, 1)
-	clientTask := tasks[0]
-
-	// Describe the server tasks
-	tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
-	serverTaskIPMap := getTaskIPToTaskMap(t, tasks)
-
-	performAssertions := func(expectSameAZ bool) {
-		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
-			resp, err := common.GetFakeServiceResponse(meshClientLBAddr)
-			require.NoError(r, err)
-
-			require.Equal(r, 200, resp.Code)
-			require.Equal(r, "Hello World", resp.Body)
-			require.NotNil(r, resp.UpstreamCalls)
-
-			upstreamResp := resp.UpstreamCalls["http://localhost:1234"]
-			require.NotNil(r, upstreamResp)
-			require.Equal(r, serverAppName, upstreamResp.Name)
-			require.Equal(r, 200, upstreamResp.Code)
-			require.Equal(r, "Hello World", upstreamResp.Body)
-
-			var upstreamServerTask types.Task
-			var ok bool
-			for _, ip := range upstreamResp.IpAddresses {
-				upstreamServerTask, ok = serverTaskIPMap[ip]
-				if ok {
-					break
-				}
-			}
-
-			// Check if the client app's AZ matches with that of the server task
-			if expectSameAZ {
-				require.Equal(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
-			} else {
-				require.NotEqual(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
-			}
-		})
-	}
-
-	logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
-	performAssertions(true)
-
-	// Stop the server app present in the same AZ as that of the client
-	var serverTaskToStop types.Task
-	for _, v := range tasks {
-		if *v.AvailabilityZone == *clientTask.AvailabilityZone {
-			serverTaskToStop = v
-			break
-		}
-	}
-
-	logger.Log(t, "Stopping the server app's task present in the same AZ as that of the client.")
-	require.NoError(t, ecsClient.StopTask(*serverTaskToStop.TaskArn, "stopping as part of a test"))
-
-	logger.Log(t, "Calling the client app's load balancer to verify if the client app falls back to hit the server app in the other availability zone")
-	performAssertions(false)
-
-	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
-		logger.Log(t, "Waiting for ECS to spin up the previously stopped server app's task")
-		serverTasks, err = ecsClient.ListTasksForService(serverAppName)
-		require.NoError(r, err)
-		require.Len(r, serverTasks, 2)
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResName := common.GenerateRandomStr(4)
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "LOCALITY_AWARE_ROUTING",
+		FolderName:         "locality-aware-routing",
+		TerraformInputVars: getTerraformVars(tfResName),
+		Validate:           validate(tfResName),
 	})
+}
 
-	tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
-	serverTaskIPMap = getTaskIPToTaskMap(t, tasks)
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-west-2",
+			"name":   tfResName,
+		}
 
-	logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
-	performAssertions(true)
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		enterpriseLicense := os.Getenv("CONSUL_LICENSE")
+		if enterpriseLicense == "" {
+			return nil, fmt.Errorf("expected CONSUL_LICENSE to be non empty")
+		}
+		vars["consul_license"] = enterpriseLicense
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, tfOutput map[string]interface{}) {
+		logger.Log(t, "Fetching required output terraform variables")
+		getOutputVariableValue := func(name string) string {
+			val, ok := tfOutput[name].(string)
+			require.True(t, ok)
+			return val
+		}
+
+		consulServerLBAddr := getOutputVariableValue("consul_server_url")
+		consulServerToken := getOutputVariableValue("consul_server_bootstrap_token")
+		meshClientLBAddr := getOutputVariableValue("client_lb_address")
+		clusterARN := getOutputVariableValue("ecs_cluster_arn")
+
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, consulServerLBAddr, common.WithToken(consulServerToken))
+		require.NoError(t, err)
+
+		clientAppName := "example-client-app"
+		serverAppName := "example-server-app"
+
+		consulClient.EnsureServiceReadiness(clientAppName, nil)
+		consulClient.EnsureServiceReadiness(serverAppName, nil)
+
+		consulClient.EnsureServiceInstances(serverAppName, 2, nil)
+
+		ecsClient, err := common.NewECSClient(common.WithClusterARN(clusterARN))
+		require.NoError(t, err)
+
+		logger.Log(t, "Listing and describing tasks for each ECS service")
+		clientTasks := assertAndListTasks(t, ecsClient, clientAppName, 1)
+		serverTasks := assertAndListTasks(t, ecsClient, serverAppName, 2)
+
+		// Describe the client task
+		tasks := assertAndDescribeTasks(t, ecsClient, clientTasks, 1)
+		clientTask := tasks[0]
+
+		// Describe the server tasks
+		tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
+		serverTaskIPMap := getTaskIPToTaskMap(t, tasks)
+
+		performAssertions := func(expectSameAZ bool) {
+			retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+				resp, err := common.GetFakeServiceResponse(meshClientLBAddr)
+				require.NoError(r, err)
+
+				require.Equal(r, 200, resp.Code)
+				require.Equal(r, "Hello World", resp.Body)
+				require.NotNil(r, resp.UpstreamCalls)
+
+				upstreamResp := resp.UpstreamCalls["http://localhost:1234"]
+				require.NotNil(r, upstreamResp)
+				require.Equal(r, serverAppName, upstreamResp.Name)
+				require.Equal(r, 200, upstreamResp.Code)
+				require.Equal(r, "Hello World", upstreamResp.Body)
+
+				var upstreamServerTask types.Task
+				var ok bool
+				for _, ip := range upstreamResp.IpAddresses {
+					upstreamServerTask, ok = serverTaskIPMap[ip]
+					if ok {
+						break
+					}
+				}
+
+				// Check if the client app's AZ matches with that of the server task
+				if expectSameAZ {
+					require.Equal(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
+				} else {
+					require.NotEqual(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
+				}
+			})
+		}
+
+		logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
+		performAssertions(true)
+
+		// Stop the server app present in the same AZ as that of the client
+		var serverTaskToStop types.Task
+		for _, v := range tasks {
+			if *v.AvailabilityZone == *clientTask.AvailabilityZone {
+				serverTaskToStop = v
+				break
+			}
+		}
+
+		logger.Log(t, "Stopping the server app's task present in the same AZ as that of the client.")
+		require.NoError(t, ecsClient.StopTask(*serverTaskToStop.TaskArn, "stopping as part of a test"))
+
+		logger.Log(t, "Calling the client app's load balancer to verify if the client app falls back to hit the server app in the other availability zone")
+		performAssertions(false)
+
+		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			logger.Log(t, "Waiting for ECS to spin up the previously stopped server app's task")
+			serverTasks, err = ecsClient.ListTasksForService(serverAppName)
+			require.NoError(r, err)
+			require.Len(r, serverTasks, 2)
+		})
+
+		tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
+		serverTaskIPMap = getTaskIPToTaskMap(t, tasks)
+
+		logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
+		performAssertions(true)
+	}
 }
 
 func assertAndListTasks(t *testing.T, ecsClient *common.ECSClientWrapper, service string, expectedCount int) []string {

--- a/test/acceptance/examples/scenarios/locality-aware-routing/main.go
+++ b/test/acceptance/examples/scenarios/locality-aware-routing/main.go
@@ -75,8 +75,8 @@ func (l *localityAwareRouting) Validate(t *testing.T, outputVars map[string]inte
 	clientAppName := "example-client-app"
 	serverAppName := "example-server-app"
 
-	consulClient.EnsureServiceRegistration(clientAppName, nil)
-	consulClient.EnsureServiceRegistration(serverAppName, nil)
+	consulClient.EnsureServiceReadiness(clientAppName, nil)
+	consulClient.EnsureServiceReadiness(serverAppName, nil)
 
 	consulClient.EnsureServiceInstances(serverAppName, 2, nil)
 

--- a/test/acceptance/examples/scenarios/registry.go
+++ b/test/acceptance/examples/scenarios/registry.go
@@ -22,6 +22,10 @@ func (s *registry) Register(reg ScenarioRegistration) error {
 		return fmt.Errorf("scenario %s already registered", reg.Name)
 	}
 
+	if err := reg.validate(); err != nil {
+		return err
+	}
+
 	s.scenarios[scenarioName(reg.Name)] = reg
 	return nil
 }

--- a/test/acceptance/examples/scenarios/registry.go
+++ b/test/acceptance/examples/scenarios/registry.go
@@ -17,17 +17,16 @@ func NewScenarioRegistry() ScenarioRegistry {
 	}
 }
 
-func (s *registry) Register(reg ScenarioRegistration) error {
+func (s *registry) Register(reg ScenarioRegistration) {
 	if _, ok := s.scenarios[scenarioName(reg.Name)]; ok {
-		return fmt.Errorf("scenario %s already registered", reg.Name)
+		panic(fmt.Sprintf("scenario %s already registered", reg.Name))
 	}
 
 	if err := reg.validate(); err != nil {
-		return err
+		panic(fmt.Errorf("error validating scenario %w", err))
 	}
 
 	s.scenarios[scenarioName(reg.Name)] = reg
-	return nil
 }
 
 func (s *registry) Retrieve(name string) (ScenarioRegistration, error) {

--- a/test/acceptance/examples/scenarios/registry.go
+++ b/test/acceptance/examples/scenarios/registry.go
@@ -1,0 +1,36 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package scenarios
+
+import "fmt"
+
+type scenarioName string
+
+type registry struct {
+	scenarios map[scenarioName]ScenarioRegistration
+}
+
+func NewScenarioRegistry() ScenarioRegistry {
+	return &registry{
+		scenarios: make(map[scenarioName]ScenarioRegistration),
+	}
+}
+
+func (s *registry) Register(reg ScenarioRegistration) error {
+	if _, ok := s.scenarios[scenarioName(reg.Name)]; ok {
+		return fmt.Errorf("scenario %s already registered", reg.Name)
+	}
+
+	s.scenarios[scenarioName(reg.Name)] = reg
+	return nil
+}
+
+func (s *registry) Retrieve(name string) (ScenarioRegistration, error) {
+	scenario, ok := s.scenarios[scenarioName(name)]
+	if !ok {
+		return ScenarioRegistration{}, fmt.Errorf("scenario %s is not registered", name)
+	}
+
+	return scenario, nil
+}

--- a/test/acceptance/examples/scenarios/registry_test.go
+++ b/test/acceptance/examples/scenarios/registry_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_ScenarioExists(t *testing.T) {
+	registry := NewScenarioRegistry()
+	registry.Register(getTestScenarioRegistrationPayload())
+
+	_, err := registry.Retrieve("TEST_SCENARIO")
+	require.Error(t, err)
+}
+
+func TestRegistry_Register_InvalidScenarioName(t *testing.T) {
+	registry := NewScenarioRegistry()
+	scenario := getTestScenarioRegistrationPayload()
+	scenario.Name = ""
+	err := registry.Register(scenario)
+	require.Error(t, err)
+}
+
+func TestRegistry_Register_InvalidFolderName(t *testing.T) {
+	registry := NewScenarioRegistry()
+	scenario := getTestScenarioRegistrationPayload()
+	scenario.FolderName = ""
+	err := registry.Register(scenario)
+	require.Error(t, err)
+}
+
+func TestRegistry_Register_InvalidInputVarHook(t *testing.T) {
+	registry := NewScenarioRegistry()
+	scenario := getTestScenarioRegistrationPayload()
+	scenario.TerraformInputVars = nil
+	err := registry.Register(scenario)
+	require.Error(t, err)
+}
+
+func TestRegistry_Register_InvalidValidateHook(t *testing.T) {
+	registry := NewScenarioRegistry()
+	scenario := getTestScenarioRegistrationPayload()
+	scenario.Validate = nil
+	err := registry.Register(scenario)
+	require.Error(t, err)
+}
+
+func TestRegistry_RegisterAndRetrieve(t *testing.T) {
+	registry := NewScenarioRegistry()
+	scenario := getTestScenarioRegistrationPayload()
+	err := registry.Register(scenario)
+	require.NoError(t, err)
+
+	actualScenario, err := registry.Retrieve("TEST_SCENARIO")
+	require.NoError(t, err)
+	require.Equal(t, scenario.Name, actualScenario.Name)
+	require.Equal(t, scenario.FolderName, actualScenario.FolderName)
+}
+
+func getTestScenarioRegistrationPayload() ScenarioRegistration {
+	return ScenarioRegistration{
+		Name:       "TEST_SCENARIO",
+		FolderName: "test_folder/test_scenario",
+		TerraformInputVars: func() (map[string]interface{}, error) {
+			return nil, nil
+		},
+		Validate: func(t *testing.T, b []byte) {},
+	}
+}

--- a/test/acceptance/examples/scenarios/registry_test.go
+++ b/test/acceptance/examples/scenarios/registry_test.go
@@ -9,56 +9,99 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegistry_ScenarioExists(t *testing.T) {
-	registry := NewScenarioRegistry()
-	registry.Register(getTestScenarioRegistrationPayload())
+func TestRegistry(t *testing.T) {
+	cases := map[string]struct {
+		scenarioPresent  bool
+		registerScenario bool
+		mutateScenario   func(ScenarioRegistration) ScenarioRegistration
+		shouldPanic      bool
+		wantErr          bool
+	}{
+		"scenario already present": {
+			scenarioPresent:  true,
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"scenario not present": {
+			wantErr: true,
+		},
+		"invalid scenario name": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.Name = ""
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"invalid scenario folder name": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.FolderName = ""
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"invalid scenario TF Vars hook": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.TerraformInputVars = nil
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"invalid scenario Validate hook": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.Validate = nil
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"successful registration and retrieval": {
+			registerScenario: true,
+		},
+	}
 
-	_, err := registry.Retrieve("TEST_SCENARIO")
-	require.Error(t, err)
-}
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Logf("Panic caught: %v", r)
+				}
+			}()
 
-func TestRegistry_Register_InvalidScenarioName(t *testing.T) {
-	registry := NewScenarioRegistry()
-	scenario := getTestScenarioRegistrationPayload()
-	scenario.Name = ""
-	err := registry.Register(scenario)
-	require.Error(t, err)
-}
+			registry := NewScenarioRegistry()
 
-func TestRegistry_Register_InvalidFolderName(t *testing.T) {
-	registry := NewScenarioRegistry()
-	scenario := getTestScenarioRegistrationPayload()
-	scenario.FolderName = ""
-	err := registry.Register(scenario)
-	require.Error(t, err)
-}
+			if c.scenarioPresent {
+				registry.Register(getTestScenarioRegistrationPayload())
+			}
 
-func TestRegistry_Register_InvalidInputVarHook(t *testing.T) {
-	registry := NewScenarioRegistry()
-	scenario := getTestScenarioRegistrationPayload()
-	scenario.TerraformInputVars = nil
-	err := registry.Register(scenario)
-	require.Error(t, err)
-}
+			payload := getTestScenarioRegistrationPayload()
+			if c.mutateScenario != nil {
+				payload = c.mutateScenario(payload)
+			}
 
-func TestRegistry_Register_InvalidValidateHook(t *testing.T) {
-	registry := NewScenarioRegistry()
-	scenario := getTestScenarioRegistrationPayload()
-	scenario.Validate = nil
-	err := registry.Register(scenario)
-	require.Error(t, err)
-}
+			if c.registerScenario {
+				registry.Register(payload)
+			}
 
-func TestRegistry_RegisterAndRetrieve(t *testing.T) {
-	registry := NewScenarioRegistry()
-	scenario := getTestScenarioRegistrationPayload()
-	err := registry.Register(scenario)
-	require.NoError(t, err)
+			actualScenario, err := registry.Retrieve("TEST_SCENARIO")
+			if c.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, payload.Name, actualScenario.Name)
+				require.Equal(t, payload.FolderName, actualScenario.FolderName)
+			}
 
-	actualScenario, err := registry.Retrieve("TEST_SCENARIO")
-	require.NoError(t, err)
-	require.Equal(t, scenario.Name, actualScenario.Name)
-	require.Equal(t, scenario.FolderName, actualScenario.FolderName)
+			// If the test is supposed to panic while registering
+			// a scenario and we reach here, we fail explicitly.
+			if c.shouldPanic {
+				t.FailNow()
+			}
+		})
+	}
 }
 
 func getTestScenarioRegistrationPayload() ScenarioRegistration {

--- a/test/acceptance/examples/scenarios/scenario.go
+++ b/test/acceptance/examples/scenarios/scenario.go
@@ -5,21 +5,6 @@ package scenarios
 
 import "testing"
 
-// Scenario is the interface we expect individual example scenarios
-// present in this repository to implement.
-type Scenario interface {
-	// The name of the example's folder under the `examples/` directory
-	GetFolderName() string
-
-	// List of TF variables that needs to be supplied to the
-	// example's terraform config.
-	GetTerraformVars() (map[string]interface{}, error)
-
-	// Validations that needs to be performed on the deployment. This
-	// hook will only be called after a successful terraform apply.
-	Validate(t *testing.T, tfOutput map[string]interface{})
-}
-
 // ScenarioRegistry helps us interact with the
 // actual registry that holds details about the scenarios.
 type ScenarioRegistry interface {

--- a/test/acceptance/examples/scenarios/scenario.go
+++ b/test/acceptance/examples/scenarios/scenario.go
@@ -19,3 +19,37 @@ type Scenario interface {
 	// hook will only be called after a successful terraform apply.
 	Validate(t *testing.T, tfOutput map[string]interface{})
 }
+
+// ScenarioRegistry helps us interact with the
+// actual registry that holds details about the scenarios.
+type ScenarioRegistry interface {
+	// Register registers a scenario into the registry
+	Register(ScenarioRegistration) error
+
+	// Retrieve retrieves a scenario from the registry
+	Retrieve(name string) (ScenarioRegistration, error)
+}
+
+type TerraformInputVarsHook func() (map[string]interface{}, error)
+type ValidateHook func(t *testing.T, tfOutput map[string]interface{})
+
+// ScenarioRegistration is the struct we expect each individual
+// scenario to use and register themselves by providing valid
+// lifecycle hooks
+type ScenarioRegistration struct {
+	// The name of the scenario. This name should match the value
+	// of TEST_SCENARIO environment variable which the test uses
+	// to determine the scenario to run.
+	Name string
+
+	// The name of the example's folder under the `examples/` directory
+	FolderName string
+
+	// List of TF variables that needs to be supplied to the
+	// example's terraform config.
+	TerraformInputVars TerraformInputVarsHook
+
+	// Validate is the hook called when validations need to be performed on the deployment. This
+	// hook will only be called after a successful terraform apply.
+	Validate ValidateHook
+}

--- a/test/acceptance/examples/scenarios/scenario.go
+++ b/test/acceptance/examples/scenarios/scenario.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package scenarios
+
+import "testing"
+
+// Scenario is the interface we expect individual example scenarios
+// present in this repository to implement.
+type Scenario interface {
+	// The name of the example's folder under the `examples/` directory
+	GetFolderName() string
+
+	// List of TF variables that needs to be supplied to the
+	// example's terraform config.
+	GetTerraformVars() (map[string]interface{}, error)
+
+	// Validations that needs to be performed on the deployment. This
+	// hook will only be called after a successful terraform apply.
+	Validate(t *testing.T, tfOutput map[string]interface{})
+}

--- a/test/acceptance/examples/scenarios/scenario.go
+++ b/test/acceptance/examples/scenarios/scenario.go
@@ -3,7 +3,10 @@
 
 package scenarios
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 // ScenarioRegistry helps us interact with the
 // actual registry that holds details about the scenarios.
@@ -37,4 +40,24 @@ type ScenarioRegistration struct {
 	// Validate is the hook called when validations need to be performed on the deployment. This
 	// hook will only be called after a successful terraform apply.
 	Validate ValidateHook
+}
+
+func (r *ScenarioRegistration) validate() error {
+	if r.Name == "" {
+		return fmt.Errorf("scenario name cannot be empty")
+	}
+
+	if r.FolderName == "" {
+		return fmt.Errorf("scenario %s should have a folder name associated to it", r.Name)
+	}
+
+	if r.TerraformInputVars == nil {
+		return fmt.Errorf("scenario %s should provide hooks for providing terraform input variables", r.Name)
+	}
+
+	if r.Validate == nil {
+		return fmt.Errorf("scenario %s should provide hooks validating the deployment", r.Name)
+	}
+
+	return nil
 }

--- a/test/acceptance/examples/scenarios/scenario.go
+++ b/test/acceptance/examples/scenarios/scenario.go
@@ -19,7 +19,7 @@ type ScenarioRegistry interface {
 }
 
 type TerraformInputVarsHook func() (map[string]interface{}, error)
-type ValidateHook func(t *testing.T, tfOutput map[string]interface{})
+type ValidateHook func(*testing.T, []byte)
 
 // ScenarioRegistration is the struct we expect each individual
 // scenario to use and register themselves by providing valid

--- a/test/acceptance/examples/scenarios/scenario.go
+++ b/test/acceptance/examples/scenarios/scenario.go
@@ -12,7 +12,7 @@ import (
 // actual registry that holds details about the scenarios.
 type ScenarioRegistry interface {
 	// Register registers a scenario into the registry
-	Register(ScenarioRegistration) error
+	Register(ScenarioRegistration)
 
 	// Retrieve retrieves a scenario from the registry
 	Retrieve(name string) (ScenarioRegistration, error)

--- a/test/acceptance/examples/scenarios/service-sameness/main.go
+++ b/test/acceptance/examples/scenarios/service-sameness/main.go
@@ -22,6 +22,10 @@ type sameness struct {
 	name string
 }
 
+const (
+	awsRegion = "us-west-1"
+)
+
 func New(name string) scenarios.Scenario {
 	return &sameness{
 		name: "same",
@@ -34,7 +38,7 @@ func (s *sameness) GetFolderName() string {
 
 func (s *sameness) GetTerraformVars() (map[string]interface{}, error) {
 	vars := map[string]interface{}{
-		"region": "us-west-1",
+		"region": awsRegion,
 		"name":   s.name,
 	}
 
@@ -78,7 +82,7 @@ func (s *sameness) Validate(t *testing.T, outputVars map[string]interface{}) {
 	require.NoError(t, err)
 
 	logger.Log(t, "Setting up ECS Client")
-	ecsClient, err := common.NewECSClient()
+	ecsClient, err := common.NewECSClient(common.WithRegion(awsRegion))
 	require.NoError(t, err)
 
 	ensureAppsReadiness(t, consulClientOne, dc1DefaultPartitionApps)

--- a/test/acceptance/examples/scenarios/service-sameness/main.go
+++ b/test/acceptance/examples/scenarios/service-sameness/main.go
@@ -1,0 +1,313 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sameness
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type sameness struct {
+	name string
+}
+
+func New(name string) scenarios.Scenario {
+	return &sameness{
+		name: "same",
+	}
+}
+
+func (s *sameness) GetFolderName() string {
+	return "service-sameness"
+}
+
+func (s *sameness) GetTerraformVars() (map[string]interface{}, error) {
+	vars := map[string]interface{}{
+		"region": "us-west-1",
+		"name":   s.name,
+	}
+
+	publicIP, err := common.GetPublicIP()
+	if err != nil {
+		return nil, err
+	}
+	vars["lb_ingress_ip"] = publicIP
+
+	enterpriseLicense := os.Getenv("CONSUL_LICENSE")
+	if enterpriseLicense == "" {
+		return nil, fmt.Errorf("expected CONSUL_LICENSE to be non empty")
+	}
+	vars["consul_license"] = enterpriseLicense
+
+	return vars, nil
+}
+
+func (s *sameness) Validate(t *testing.T, outputVars map[string]interface{}) {
+	logger.Log(t, "Fetching required output terraform variables")
+	getOutputVariableValue := func(name string) string {
+		val, ok := outputVars[name].(string)
+		require.True(t, ok)
+		return val
+	}
+
+	dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
+	dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
+	dc1ConsulServerToken := getOutputVariableValue("dc1_server_bootstrap_token")
+	dc2ConsulServerToken := getOutputVariableValue("dc2_server_bootstrap_token")
+
+	dc1DefaultPartitionApps := getAppDetails(t, "dc1_default_partition_apps", outputVars)
+	dc1Part1PartitionApps := getAppDetails(t, "dc1_part1_partition_apps", outputVars)
+	dc2DefaultPartitionApps := getAppDetails(t, "dc2_default_partition_apps", outputVars)
+
+	logger.Log(t, "Setting up the Consul clients")
+	consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+	require.NoError(t, err)
+
+	consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc2ConsulServerToken))
+	require.NoError(t, err)
+
+	logger.Log(t, "Setting up ECS Client")
+	ecsClient, err := common.NewECSClient()
+	require.NoError(t, err)
+
+	ensureAppsReadiness(t, consulClientOne, dc1DefaultPartitionApps)
+	ensureAppsReadiness(t, consulClientOne, dc1Part1PartitionApps)
+	ensureAppsReadiness(t, consulClientTwo, dc2DefaultPartitionApps)
+
+	// Ensure that the gateways are also ready
+	ensureServiceReadiness(t, consulClientOne, fmt.Sprintf("%s-dc1-default-mesh-gateway", s.name), nil)
+	ensureServiceReadiness(t, consulClientOne, fmt.Sprintf("%s-dc1-%s-mesh-gateway", s.name, dc1Part1PartitionApps.partition), &api.QueryOptions{Partition: dc1Part1PartitionApps.partition})
+	ensureServiceReadiness(t, consulClientTwo, fmt.Sprintf("%s-dc2-mesh-gateway", s.name), nil)
+
+	// Begin actual validation
+	clusterAppsList := []*apps{
+		dc1DefaultPartitionApps,
+		dc1Part1PartitionApps,
+		dc2DefaultPartitionApps,
+	}
+
+	var recordedUpstreamCalls map[string]string
+
+	assertUpstreamCall := func(apps *apps, expectedUpstream string) {
+		recordedUpstream, ok := recordedUpstreamCalls[apps.getClientAppName()]
+		require.True(t, ok)
+		require.Equal(t, expectedUpstream, recordedUpstream)
+	}
+
+	// Without making any changes we expect calls from the client apps
+	// to reach the server apps in their local partitions.
+	logger.Log(t, "Calling upstreams from individual client tasks. Calls are expected to hit the local server instances in the same namespace as the client")
+	recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+	assertUpstreamCall(dc1DefaultPartitionApps, dc1DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc1Part1PartitionApps, dc1Part1PartitionApps.getServerAppName())
+	assertUpstreamCall(dc2DefaultPartitionApps, dc2DefaultPartitionApps.getServerAppName())
+
+	// Scaling down server app present in the default partition in DC1. After this, requests from
+	// the client app in the default partition will failover to the server app present in
+	// the part1 partition in DC1.
+	mustScaleDownServerApp(t, ecsClient, consulClientOne, dc1DefaultPartitionApps)
+
+	logger.Log(t, "Scale down complete. Calling upstreams for individual client tasks.")
+	recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+	assertUpstreamCall(dc1DefaultPartitionApps, dc1Part1PartitionApps.getServerAppName())
+	assertUpstreamCall(dc1Part1PartitionApps, dc1Part1PartitionApps.getServerAppName())
+	assertUpstreamCall(dc2DefaultPartitionApps, dc2DefaultPartitionApps.getServerAppName())
+
+	// Scaling down server app present in the part1 partition in DC1. After this,
+	// the client apps present in the default and part1 partition will hit the server app present in
+	// the default partition in DC2.
+	mustScaleDownServerApp(t, ecsClient, consulClientOne, dc1Part1PartitionApps)
+
+	logger.Log(t, "Scale down complete. Calling upstreams for individual client tasks.")
+	recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+	assertUpstreamCall(dc1DefaultPartitionApps, dc2DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc1Part1PartitionApps, dc2DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc2DefaultPartitionApps, dc2DefaultPartitionApps.getServerAppName())
+
+	// Scaling up server app present in the default partition in DC1. After this,
+	// the client app in the default partition will hit the server app present in
+	// the default partition in DC1. The client app in the part1 partition will also
+	// hit the server app present in the default partition in DC1.
+	mustScaleUpServerApp(t, ecsClient, consulClientOne, dc1DefaultPartitionApps)
+
+	logger.Log(t, "Scale up complete. Calling upstreams for individual client tasks.")
+	recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+	assertUpstreamCall(dc1DefaultPartitionApps, dc1DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc1Part1PartitionApps, dc1DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc2DefaultPartitionApps, dc2DefaultPartitionApps.getServerAppName())
+
+	// Scaling down server app present in the default partition in DC2. After this,
+	// the client app present in the default partition in DC2 will hit the server app present in
+	// the default partition in DC1. The client app in the part1 partition should continue to
+	// hit the server app present in the default partition in DC1.
+	mustScaleDownServerApp(t, ecsClient, consulClientTwo, dc2DefaultPartitionApps)
+
+	logger.Log(t, "Scale down complete. Calling upstreams for individual client tasks.")
+	recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+	assertUpstreamCall(dc1DefaultPartitionApps, dc1DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc1Part1PartitionApps, dc1DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc2DefaultPartitionApps, dc1DefaultPartitionApps.getServerAppName())
+
+	// Scaling up server app present in the part1 partition in DC1. After this,
+	// the client app in the part1 partition will hit the server app present in
+	// the part1 partition in DC1. The client app in the default partition will continue to
+	// hit the server app present in the default partition in DC1.
+	mustScaleUpServerApp(t, ecsClient, consulClientOne, dc1Part1PartitionApps)
+
+	logger.Log(t, "Scale up complete. Calling upstreams for individual client tasks.")
+	recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+	assertUpstreamCall(dc1DefaultPartitionApps, dc1DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc1Part1PartitionApps, dc1Part1PartitionApps.getServerAppName())
+	assertUpstreamCall(dc2DefaultPartitionApps, dc1DefaultPartitionApps.getServerAppName())
+
+	// Scaling up server app present in the default partition in DC2. After this,
+	// the client app present in the default partition in DC2 will hit the server app present in
+	// the default partition in DC2. All the other client apps should hit their local server apps
+	mustScaleUpServerApp(t, ecsClient, consulClientTwo, dc2DefaultPartitionApps)
+
+	logger.Log(t, "Scale up complete. Calling upstreams for individual client tasks.")
+	recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+	assertUpstreamCall(dc1DefaultPartitionApps, dc1DefaultPartitionApps.getServerAppName())
+	assertUpstreamCall(dc1Part1PartitionApps, dc1Part1PartitionApps.getServerAppName())
+	assertUpstreamCall(dc2DefaultPartitionApps, dc2DefaultPartitionApps.getServerAppName())
+}
+
+func getAppDetails(t *testing.T, name string, outputVars map[string]interface{}) *apps {
+	val, ok := outputVars[name].(map[string]interface{})
+	require.True(t, ok)
+
+	ensureAndReturnNonEmptyVal := func(v interface{}) string {
+		require.NotEmpty(t, v)
+		return v.(string)
+	}
+
+	clientAppVal := val["client"].(map[string]interface{})
+	require.NotEmpty(t, clientAppVal)
+
+	client := app{
+		name:              ensureAndReturnNonEmptyVal(clientAppVal["name"]),
+		consulServiceName: ensureAndReturnNonEmptyVal(clientAppVal["consul_service_name"]),
+		lbAddr:            ensureAndReturnNonEmptyVal(clientAppVal["lb_address"]),
+	}
+
+	client.lbAddr = strings.TrimSuffix(client.lbAddr, "/ui")
+
+	serverAppVal := val["server"].(map[string]interface{})
+	require.NotEmpty(t, serverAppVal)
+	server := app{
+		name:              ensureAndReturnNonEmptyVal(serverAppVal["name"]),
+		consulServiceName: ensureAndReturnNonEmptyVal(serverAppVal["consul_service_name"]),
+	}
+
+	return &apps{
+		partition:  ensureAndReturnNonEmptyVal(val["partition"]),
+		namespace:  ensureAndReturnNonEmptyVal(val["namespace"]),
+		clusterARN: ensureAndReturnNonEmptyVal(val["ecs_cluster_arn"]),
+		region:     ensureAndReturnNonEmptyVal(val["region"]),
+		client:     client,
+		server:     server,
+	}
+}
+
+func ensureAppsReadiness(t *testing.T, consulClient *common.ConsulClientWrapper, appDetails *apps) {
+	logger.Log(t, fmt.Sprintf("checking if apps in %s partition & %s namespace are registered in Consul", appDetails.partition, appDetails.namespace))
+
+	opts := &api.QueryOptions{
+		Namespace: appDetails.namespace,
+		Partition: appDetails.partition,
+	}
+
+	ensureServiceReadiness(t, consulClient, appDetails.getClientAppConsulName(), opts)
+	ensureServiceReadiness(t, consulClient, appDetails.getServerAppConsulName(), opts)
+}
+
+func ensureServiceReadiness(t *testing.T, client *common.ConsulClientWrapper, name string, opts *api.QueryOptions) {
+	client.EnsureServiceRegistration(name, opts)
+	client.EnsureHealthyService(name, opts)
+}
+
+func recordUpstreams(t *testing.T, apps []*apps) map[string]string {
+	upstreamCalls := make(map[string]string)
+	for _, app := range apps {
+		logger.Log(t, fmt.Sprintf("calling upstream for %s app in %s partition and %s cluster", app.getClientAppName(), app.partition, app.clusterARN))
+		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			logger.Log(t, "hitting client app's load balancer to see if the server app is reachable")
+			resp, err := common.GetFakeServiceResponse(app.getClientAppLBAddr())
+			require.NoError(r, err)
+
+			require.Equal(r, 200, resp.Code)
+			require.Equal(r, "Hello World", resp.Body)
+			require.NotNil(r, resp.UpstreamCalls)
+
+			upstreamResp := resp.UpstreamCalls["http://localhost:1234"]
+			require.NotNil(r, upstreamResp)
+			require.Equal(r, 200, upstreamResp.Code)
+			require.Equal(r, "Hello World", upstreamResp.Body)
+
+			upstreamCalls[app.getClientAppName()] = upstreamResp.Name
+		})
+	}
+
+	require.Len(t, upstreamCalls, 3)
+	return upstreamCalls
+}
+
+func mustScaleUpServerApp(t *testing.T, ecsClient *common.ECSClientWrapper, consulClient *common.ConsulClientWrapper, apps *apps) {
+	logger.Log(t, fmt.Sprintf("Scaling up %s app in %s partition and %s namespace", apps.getServerAppConsulName(), apps.partition, apps.namespace))
+	err := ecsClient.
+		WithClusterARN(apps.clusterARN).
+		UpdateService(apps.getServerAppName(), 1)
+	require.NoError(t, err)
+
+	opts := &api.QueryOptions{
+		Partition: apps.partition,
+		Namespace: apps.namespace,
+	}
+	ensureServiceReadiness(t, consulClient, apps.getServerAppConsulName(), opts)
+}
+
+func mustScaleDownServerApp(t *testing.T, ecsClient *common.ECSClientWrapper, consulClient *common.ConsulClientWrapper, apps *apps) {
+	logger.Log(t, fmt.Sprintf("Scaling down %s app in %s partition and %s namespace", apps.getServerAppConsulName(), apps.partition, apps.namespace))
+	err := ecsClient.
+		WithClusterARN(apps.clusterARN).
+		UpdateService(apps.getServerAppName(), 0)
+	require.NoError(t, err)
+
+	opts := &api.QueryOptions{
+		Partition: apps.partition,
+		Namespace: apps.namespace,
+	}
+	consulClient.EnsureServiceDeregistration(apps.getServerAppConsulName(), opts)
+}
+
+type apps struct {
+	partition  string
+	namespace  string
+	clusterARN string
+	region     string
+	client     app
+	server     app
+}
+
+func (a *apps) getClientAppName() string       { return a.client.name }
+func (a *apps) getServerAppName() string       { return a.server.name }
+func (a *apps) getClientAppLBAddr() string     { return a.server.consulServiceName }
+func (a *apps) getClientAppConsulName() string { return a.server.consulServiceName }
+func (a *apps) getServerAppConsulName() string { return a.server.consulServiceName }
+
+type app struct {
+	name              string
+	consulServiceName string
+	lbAddr            string
+}

--- a/test/acceptance/examples/scenarios/wan-federation/main.go
+++ b/test/acceptance/examples/scenarios/wan-federation/main.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package wan
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type wan struct {
+	name string
+}
+
+func New(name string) scenarios.Scenario {
+	return &wan{
+		name: "mesh",
+	}
+}
+
+func (w *wan) GetFolderName() string {
+	return "mesh-gateways"
+}
+
+func (w *wan) GetTerraformVars() (map[string]interface{}, error) {
+	vars := map[string]interface{}{
+		"region": "us-east-1",
+		"name":   w.name,
+	}
+
+	publicIP, err := common.GetPublicIP()
+	if err != nil {
+		return nil, err
+	}
+	vars["lb_ingress_ip"] = publicIP
+
+	return vars, nil
+}
+
+func (w *wan) Validate(t *testing.T, outputVars map[string]interface{}) {
+	logger.Log(t, "Fetching required output terraform variables")
+	getOutputVariableValue := func(name string) string {
+		val, ok := outputVars[name].(string)
+		require.True(t, ok)
+		return val
+	}
+
+	dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
+	dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
+	dc1ConsulServerToken := getOutputVariableValue("bootstrap_token")
+
+	meshClientLBAddr := getOutputVariableValue("client_lb_address")
+	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+	logger.Log(t, "Setting up the Consul clients")
+	consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+	require.NoError(t, err)
+
+	consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+	require.NoError(t, err)
+
+	clientAppName := fmt.Sprintf("%s-dc1-example-client-app", w.name)
+	serverAppName := fmt.Sprintf("%s-dc2-example-server-app", w.name)
+
+	consulClientOne.EnsureServiceRegistration(clientAppName, nil)
+	consulClientTwo.EnsureServiceRegistration(serverAppName, nil)
+	consulClientOne.EnsureServiceRegistration(fmt.Sprintf("%s-dc1-mesh-gateway", w.name), nil)
+	consulClientTwo.EnsureServiceRegistration(fmt.Sprintf("%s-dc2-mesh-gateway", w.name), nil)
+
+	// Perform assertions by hitting the client app's LB
+	logger.Log(t, "calling client app's load balancer to see if the server app in the secondary DC is reachable")
+	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+}

--- a/test/acceptance/examples/scenarios/wan-federation/main.go
+++ b/test/acceptance/examples/scenarios/wan-federation/main.go
@@ -68,10 +68,10 @@ func (w *wan) Validate(t *testing.T, outputVars map[string]interface{}) {
 	clientAppName := fmt.Sprintf("%s-dc1-example-client-app", w.name)
 	serverAppName := fmt.Sprintf("%s-dc2-example-server-app", w.name)
 
-	consulClientOne.EnsureServiceRegistration(clientAppName, nil)
-	consulClientTwo.EnsureServiceRegistration(serverAppName, nil)
-	consulClientOne.EnsureServiceRegistration(fmt.Sprintf("%s-dc1-mesh-gateway", w.name), nil)
-	consulClientTwo.EnsureServiceRegistration(fmt.Sprintf("%s-dc2-mesh-gateway", w.name), nil)
+	consulClientOne.EnsureServiceReadiness(clientAppName, nil)
+	consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
+	consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", w.name), nil)
+	consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", w.name), nil)
 
 	// Perform assertions by hitting the client app's LB
 	logger.Log(t, "calling client app's load balancer to see if the server app in the secondary DC is reachable")

--- a/test/acceptance/examples/scenarios/wan-federation/main.go
+++ b/test/acceptance/examples/scenarios/wan-federation/main.go
@@ -14,66 +14,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type wan struct {
-	name string
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResName := common.GenerateRandomStr(4)
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "WAN_FEDERATION",
+		FolderName:         "mesh-gateways",
+		TerraformInputVars: getTerraformVars(tfResName),
+		Validate:           validate(tfResName),
+	})
 }
 
-func New(name string) scenarios.Scenario {
-	return &wan{
-		name: "mesh",
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-1",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
 	}
 }
 
-func (w *wan) GetFolderName() string {
-	return "mesh-gateways"
-}
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, tfOutput map[string]interface{}) {
+		logger.Log(t, "Fetching required output terraform variables")
+		getOutputVariableValue := func(name string) string {
+			val, ok := tfOutput[name].(string)
+			require.True(t, ok)
+			return val
+		}
 
-func (w *wan) GetTerraformVars() (map[string]interface{}, error) {
-	vars := map[string]interface{}{
-		"region": "us-east-1",
-		"name":   w.name,
+		dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
+		dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
+		dc1ConsulServerToken := getOutputVariableValue("bootstrap_token")
+
+		meshClientLBAddr := getOutputVariableValue("client_lb_address")
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul clients")
+		consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+		require.NoError(t, err)
+
+		consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-dc1-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-dc2-example-server-app", tfResName)
+
+		consulClientOne.EnsureServiceReadiness(clientAppName, nil)
+		consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
+		consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", tfResName), nil)
+		consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", tfResName), nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app in the secondary DC is reachable")
+		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 	}
-
-	publicIP, err := common.GetPublicIP()
-	if err != nil {
-		return nil, err
-	}
-	vars["lb_ingress_ip"] = publicIP
-
-	return vars, nil
-}
-
-func (w *wan) Validate(t *testing.T, outputVars map[string]interface{}) {
-	logger.Log(t, "Fetching required output terraform variables")
-	getOutputVariableValue := func(name string) string {
-		val, ok := outputVars[name].(string)
-		require.True(t, ok)
-		return val
-	}
-
-	dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
-	dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
-	dc1ConsulServerToken := getOutputVariableValue("bootstrap_token")
-
-	meshClientLBAddr := getOutputVariableValue("client_lb_address")
-	meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
-
-	logger.Log(t, "Setting up the Consul clients")
-	consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
-	require.NoError(t, err)
-
-	consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc1ConsulServerToken))
-	require.NoError(t, err)
-
-	clientAppName := fmt.Sprintf("%s-dc1-example-client-app", w.name)
-	serverAppName := fmt.Sprintf("%s-dc2-example-server-app", w.name)
-
-	consulClientOne.EnsureServiceReadiness(clientAppName, nil)
-	consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
-	consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", w.name), nil)
-	consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", w.name), nil)
-
-	// Perform assertions by hitting the client app's LB
-	logger.Log(t, "calling client app's load balancer to see if the server app in the secondary DC is reachable")
-	common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
 }

--- a/test/acceptance/examples/scenarios/wan-federation/main.go
+++ b/test/acceptance/examples/scenarios/wan-federation/main.go
@@ -4,6 +4,7 @@
 package wan
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -13,6 +14,13 @@ import (
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
 	"github.com/stretchr/testify/require"
 )
+
+type TFOutputs struct {
+	DC1ConsulServerAddr string `json:"dc1_server_url"`
+	ConsulServerToken   string `json:"bootstrap_token"`
+	DC2ConsulServerAddr string `json:"dc2_server_url"`
+	MeshClientLBAddr    string `json:"client_lb_address"`
+}
 
 func RegisterScenario(r scenarios.ScenarioRegistry) {
 	tfResName := common.GenerateRandomStr(4)
@@ -43,26 +51,18 @@ func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
 }
 
 func validate(tfResName string) scenarios.ValidateHook {
-	return func(t *testing.T, tfOutput map[string]interface{}) {
+	return func(t *testing.T, data []byte) {
 		logger.Log(t, "Fetching required output terraform variables")
-		getOutputVariableValue := func(name string) string {
-			val, ok := tfOutput[name].(string)
-			require.True(t, ok)
-			return val
-		}
 
-		dc1ConsulServerURL := getOutputVariableValue("dc1_server_url")
-		dc2ConsulServerURL := getOutputVariableValue("dc2_server_url")
-		dc1ConsulServerToken := getOutputVariableValue("bootstrap_token")
-
-		meshClientLBAddr := getOutputVariableValue("client_lb_address")
-		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+		tfOutputs.MeshClientLBAddr = strings.TrimSuffix(tfOutputs.MeshClientLBAddr, "/ui")
 
 		logger.Log(t, "Setting up the Consul clients")
-		consulClientOne, err := common.SetupConsulClient(t, dc1ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+		consulClientOne, err := common.SetupConsulClient(t, tfOutputs.DC1ConsulServerAddr, common.WithToken(tfOutputs.ConsulServerToken))
 		require.NoError(t, err)
 
-		consulClientTwo, err := common.SetupConsulClient(t, dc2ConsulServerURL, common.WithToken(dc1ConsulServerToken))
+		consulClientTwo, err := common.SetupConsulClient(t, tfOutputs.DC2ConsulServerAddr, common.WithToken(tfOutputs.ConsulServerToken))
 		require.NoError(t, err)
 
 		clientAppName := fmt.Sprintf("%s-dc1-example-client-app", tfResName)
@@ -75,6 +75,6 @@ func validate(tfResName string) scenarios.ValidateHook {
 
 		// Perform assertions by hitting the client app's LB
 		logger.Log(t, "calling client app's load balancer to see if the server app in the secondary DC is reachable")
-		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+		common.ValidateFakeServiceResponse(t, tfOutputs.MeshClientLBAddr, serverAppName)
 	}
 }


### PR DESCRIPTION
## Changes proposed in this PR:
TLDR~ Framework to ease examples validation present in this repository.

**Background**

1. Each time a new release goes out for Consul ECS, we rely on the acceptance tests present in this repository to determine the health of the new release. Acceptance tests only provide limited test coverage and doesn't test much of server oriented features like peering, wan federation, sameness etc.
2. We have a started adding lot of examples that help users deploy multiple Consul features on ECS. We currently don't have a way to check if something broke in an automated fashion. Someone has to manually run these example terraform configs to determine if an E2E setup is healthy or not. The same issue occurs when we release a new version of Consul ECS. We don't have a way to perform automated sanity tests before releasing the terraform module.

**Framework**

1. This PR introduces a single go test `TestScenario` that takes in the name of scenario (a terraform example config), applies the terraform, runs validations and destroys the deployment.
2. The PR also adds a workflow file that can be triggered on demand from the main branch for running these validations. More details can be found in the [README.md](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/619f14d1928aa9bd7c5f512965184b98ab644f12/test/acceptance/examples/README.md) file added to this PR.
3. The validations use Consul and ECS SDK wrappers to interact with the server/cluster and provides reliable feedback.

**Alternatives**

1. I came up with a simpler version of this validation with bash scripts ([here](https://github.com/hashicorp/terraform-aws-consul-ecs/compare/main...ganeshrockz/examples-test)) but felt that bash brought in a lot of restrictions for performing reliable validations and decided to write everything in Go instead.

**Future work**

1. Currently each of these scenarios run as parallel jobs in CI (one job running one scenario) ([sample CI run](https://github.com/hashicorp/terraform-aws-consul-ecs/actions/runs/7258412563)). This can be extended by making sure we run parallel test scenarios within the same job. This should reduce our runner costs.
2. Extend this to other release branches (preferably 0.7.x).

## How I've tested this PR:

CI, Local testing

## How I expect reviewers to test this PR:

1. `examples/main_test.go` contains the core logic for testing these scenarios with hooks that needs to be implemented by each scenario.
2. The actual scenarios are found in `examples/scenarios/` with each scenario defined in it's own folder and the `common` folder holding all the helper functions.
3. The `Validate()` function for each scenario holds custom logic that differs according to the deployment topology of the workloads. EOD, all examples try to deploy a client and server application and verify if the communication between them flows through the mesh. This logic can be found in `ValidateFakeServiceResponse` where we hit the client app's load balancer and verify if the desired upstream is hit. To review the individual validate functions, you might need to go over the README.md file for the example present in the `examples/` folder. For example to understand how the validation works for service-sameness, please go over `examples/service-sameness/README.md`.

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added N/A

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::