### PR TITLE
Fix sameness group validation bug

### DIFF
--- a/test/acceptance/examples/scenarios/service-sameness/main.go
+++ b/test/acceptance/examples/scenarios/service-sameness/main.go
@@ -55,7 +55,7 @@ type App struct {
 }
 
 func RegisterScenario(r scenarios.ScenarioRegistry) {
-	tfResName := "pjye" //common.GenerateRandomStr(4)
+	tfResName := common.GenerateRandomStr(4)
 
 	r.Register(scenarios.ScenarioRegistration{
 		Name:               "SERVICE_SAMENESS",

--- a/test/acceptance/examples/scenarios/service-sameness/main.go
+++ b/test/acceptance/examples/scenarios/service-sameness/main.go
@@ -38,8 +38,8 @@ type PartitionDetails struct {
 	Namespace     string `json:"namespace"`
 	ECSClusterARN string `json:"ecs_cluster_arn"`
 	Region        string `json:"region"`
-	ClientApp     *App   `json:"server"`
-	ServerApp     *App   `json:"client"`
+	ClientApp     *App   `json:"client"`
+	ServerApp     *App   `json:"server"`
 }
 
 func (p *PartitionDetails) getClientAppName() string       { return p.ClientApp.Name }
@@ -55,7 +55,7 @@ type App struct {
 }
 
 func RegisterScenario(r scenarios.ScenarioRegistry) {
-	tfResName := common.GenerateRandomStr(4)
+	tfResName := "pjye" //common.GenerateRandomStr(4)
 
 	r.Register(scenarios.ScenarioRegistration{
 		Name:               "SERVICE_SAMENESS",


### PR DESCRIPTION
## Changes proposed in this PR:
- Fixes a small bug that caused the sameness group validation to fail in https://github.com/hashicorp/terraform-aws-consul-ecs/actions/runs/7275194658

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::