### PR TITLE
Changes to add health-sync container to the task definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+BREAKING CHANGES
+* Following are the changes made to the task definitions for `mesh-task` and `gateway-task` submodules to react to the changes made in [this](https://github.com/hashicorp/consul-ecs/pull/211) PR.
+  - Removes the `consul-ecs-control-plane` container from the task definition and adds a new `consul-ecs-mesh-init` container which will be responsible for setting up mesh on ECS.
+  - Adds a new container named `consul-ecs-health-sync` to the task definition which will be responsible for syncing back ECS container health checks into Consul. This container will wait for a successful exit of `consul-ecs-mesh-init` container before starting.
+
 FEATURES
 * Add support for provisioning API gateways as ECS tasks [[GH-234](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/234)]
   - Add `api-gateway` as an acceptable `kind` input.

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -80,11 +80,11 @@ resource "aws_ecs_task_definition" "this" {
       concat(
         [
           {
-            name             = "consul-ecs-control-plane"
+            name             = "consul-ecs-mesh-init"
             image            = var.consul_ecs_image
             essential        = false
             logConfiguration = var.log_configuration
-            command          = ["control-plane"]
+            command          = ["mesh-init"]
             mountPoints = [
               local.consul_data_mount_read_write,
               {
@@ -103,12 +103,6 @@ resource "aws_ecs_task_definition" "this" {
             ]
             linuxParameters = {
               initProcessEnabled = true
-            }
-            healthCheck = {
-              command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
-              interval = 30
-              retries  = 10
-              timeout  = 5
             }
             secrets = flatten(
               concat(
@@ -139,7 +133,7 @@ resource "aws_ecs_task_definition" "this" {
             essential        = true
             logConfiguration = var.log_configuration
             entryPoint       = ["/consul/consul-ecs", "envoy-entrypoint"]
-            command          = ["consul-dataplane", "-config-file", "/consul/consul-dataplane.json"] # consul-ecs-control-plane dumps the dataplane's config into consul-dataplane.json
+            command          = ["consul-dataplane", "-config-file", "/consul/consul-dataplane.json"] # consul-ecs-mesh-init dumps the dataplane's config into consul-dataplane.json
             portMappings = [
               {
                 containerPort = local.lan_port
@@ -152,8 +146,8 @@ resource "aws_ecs_task_definition" "this" {
             ]
             dependsOn = [
               {
-                containerName = "consul-ecs-control-plane"
-                condition     = "HEALTHY"
+                containerName = "consul-ecs-mesh-init"
+                condition     = "SUCCESS"
               },
             ]
             healthCheck = {
@@ -173,6 +167,57 @@ resource "aws_ecs_task_definition" "this" {
               softLimit = 1048576
               hardLimit = 1048576
             }]
+          },
+          {
+            name             = "consul-ecs-health-sync"
+            image            = var.consul_ecs_image
+            essential        = false
+            logConfiguration = var.log_configuration
+            command          = ["health-sync"]
+            user             = "5996"
+            portMappings     = []
+            mountPoints = [
+              local.consul_data_mount
+            ]
+            dependsOn = [
+              {
+                containerName = "consul-ecs-mesh-init"
+                condition     = "SUCCESS"
+              }
+            ]
+            cpu         = 0
+            volumesFrom = []
+            environment = [
+              {
+                name  = "CONSUL_ECS_CONFIG_JSON",
+                value = local.encoded_config
+              }
+            ]
+            linuxParameters = {
+              initProcessEnabled = true
+            }
+            secrets = flatten(
+              concat(
+                var.tls ? [
+                  concat(
+                    local.https_ca_cert_arn != "" ? [
+                      {
+                        name      = "CONSUL_HTTPS_CACERT_PEM"
+                        valueFrom = local.https_ca_cert_arn
+                      },
+                    ] : [],
+                    local.grpc_ca_cert_arn != "" ? [
+                      {
+                        name      = "CONSUL_GRPC_CACERT_PEM"
+                        valueFrom = local.grpc_ca_cert_arn
+                      }
+                    ] : [],
+                    []
+                  )
+                ] : [],
+                []
+              )
+            )
           },
         ],
       )

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -100,7 +100,7 @@ variable "consul_server_hosts" {
 }
 
 variable "skip_server_watch" {
-  description = "Set this to true to prevent the consul-dataplane and consul-ecs-control-plane containers from watching the Consul servers for changes. This is useful for situations where Consul servers are behind a load balancer."
+  description = "Set this to true to prevent the consul-dataplane and consul-ecs-health-sync containers from watching the Consul servers for changes. This is useful for situations where Consul servers are behind a load balancer."
   type        = bool
   default     = false
 }
@@ -131,7 +131,6 @@ variable "envoy_readiness_port" {
     error_message = "The envoy_readiness_port must not conflict with the following ports that are reserved for Consul and Envoy: 8300, 8301, 8302, 8500, 8501, 8502, 8600, 10000, 19000."
     condition = !contains([
       8600,  // consul dns
-      10000, // consul-ecs-control-plane health check port
       19000, // envoy admin port
     ], var.envoy_readiness_port)
   }

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -125,7 +125,7 @@ variable "additional_execution_role_policies" {
 }
 
 variable "skip_server_watch" {
-  description = "Set this to true to prevent the consul-dataplane and consul-ecs-control-plane from watching the Consul servers for changes. This is useful for situations where Consul servers are behind a load balancer."
+  description = "Set this to true to prevent the consul-dataplane and consul-ecs-health-sync from watching the Consul servers for changes. This is useful for situations where Consul servers are behind a load balancer."
   type        = bool
   default     = false
 }
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "ganeshrockz/rearch-ecs"
 }
 
 variable "consul_dataplane_image" {
@@ -168,7 +168,6 @@ variable "envoy_public_listener_port" {
     error_message = "The envoy_public_listener_port must not conflict with the following ports that are reserved for Consul and Envoy: 8300, 8301, 8302, 8500, 8501, 8502, 8600, 10000, 19000."
     condition = !contains([
       8600,  // consul dns
-      10000, // consul-ecs-control-plane health check port
       19000, // envoy admin port
     ], var.envoy_public_listener_port)
   }
@@ -188,7 +187,6 @@ variable "envoy_readiness_port" {
     error_message = "The envoy_readiness_port must not conflict with the following ports that are reserved for Consul and Envoy: 8300, 8301, 8302, 8500, 8501, 8502, 8600, 10000, 19000."
     condition = !contains([
       8600,  // consul dns
-      10000, // consul-ecs-control-plane health check port
       19000, // envoy admin port
     ], var.envoy_readiness_port)
   }

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "ganeshrockz/rearch-ecs"
+  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
 }
 
 variable "consul_dataplane_image" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds the `consul-ecs-health-sync` container to the mesh-task and gateway-task task definitions.
- Adds changes to the README to reflect the same.
- Needed to support https://github.com/hashicorp/consul-ecs/pull/211

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [X] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::