### PR TITLE
Downgrade upload-artifact action

### DIFF
--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -92,7 +92,7 @@ jobs:
         mkdir -p "$TEST_RESULTS"
         cd tests/
         gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: always()
       with:
         name: acceptance-test-results

--- a/.github/workflows/reusable-ecs-example-validator.yml
+++ b/.github/workflows/reusable-ecs-example-validator.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         mkdir -p "$TEST_RESULTS"
         gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: always()
       with:
         name: acceptance-test-results


### PR DESCRIPTION
## Changes proposed in this PR:
- Reverts https://github.com/hashicorp/terraform-aws-consul-ecs/pull/254
- The new version prevents uploading artifacts with same names from different job basically preventing us from running concurrent jobs. Since there is no business need to  upgrade to the new version, I am downgrading it back to the older version

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::