### PR TITLE
Reduce health check interval to improve bootstrap time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+IMPROVEMENTS
+* Improve bootstrap time of mesh-task/gateway-task containers by reducing the health check interval defined in the container definition. [[GH-267](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/267)]
+
 ## 0.7.1 (Dec 19, 2023)
 
 IMPROVEMENTS

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -106,7 +106,7 @@ resource "aws_ecs_task_definition" "this" {
             }
             healthCheck = {
               command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
-              interval = 30
+              interval = 5
               retries  = 10
               timeout  = 5
             }
@@ -158,8 +158,8 @@ resource "aws_ecs_task_definition" "this" {
             ]
             healthCheck = {
               command  = ["/consul/consul-ecs", "net-dial", format("127.0.0.1:%d", var.envoy_readiness_port)]
-              interval = 30
-              retries  = 3
+              interval = 5
+              retries  = 10
               timeout  = 5
             }
             cpu         = 0

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -201,7 +201,7 @@ resource "aws_ecs_task_definition" "this" {
             }
             healthCheck = {
               command  = ["CMD-SHELL", "curl -f localhost:10000/consul-ecs/health"] # consul-ecs-control-plane exposes a listener on 10000 to indicate it's readiness
-              interval = 30
+              interval = 5
               retries  = 10
               timeout  = 5
             }
@@ -247,8 +247,8 @@ resource "aws_ecs_task_definition" "this" {
             ]
             healthCheck = {
               command  = ["/consul/consul-ecs", "net-dial", format("127.0.0.1:%d", var.envoy_readiness_port)]
-              interval = 30
-              retries  = 3
+              interval = 5
+              retries  = 10
               timeout  = 5
             }
             cpu         = 0


### PR DESCRIPTION
## Changes proposed in this PR:
- Improve bootstrap time for mesh/gateway task containers by reducing health check interval
- Fixes https://github.com/hashicorp/terraform-aws-consul-ecs/issues/257

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added n/a
- [X] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::