### PR TITLE
[Backport-0.7.x] Validation framework for terraform examples (#250)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-# consul-zts as code owner by default.
+# consul-ecs as code owner by default.
 # later matches take precedence.
 
-@hashicorp/consul-zts
+@hashicorp/consul-ecs
 
-/.github/workflows/* @hashicorp/release-engineering @hashicorp/consul-zts
+/.github/workflows/* @hashicorp/release-engineering @hashicorp/consul-ecs

--- a/.github/workflows/nightly-ecs-examples-validator.yml
+++ b/.github/workflows/nightly-ecs-examples-validator.yml
@@ -1,0 +1,115 @@
+name: Nighly ECS example validator
+on:
+  workflow_dispatch:
+
+jobs:
+  get-go-version:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./test/acceptance
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Determine Go version
+      id: get-go-version
+      run: |
+        echo "Building with Go $(cat .go-version)"
+        echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+  go-fmt-and-lint-acceptance:
+    runs-on: ubuntu-latest
+    needs:
+      - get-go-version
+    defaults:
+      run:
+        working-directory: ./test/acceptance
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ needs.get-go-version.outputs.go-version }}
+        cache-dependency-path: ./test/acceptance/go.sum
+    - name: Go CI lint
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+      with:
+        args: "--verbose --enable gofmt"
+        only-new-issues: false
+        skip-pkg-cache: true
+        skip-build-cache: true
+        working-directory: ./test/acceptance
+    - name: Lint Consul retry
+      run: |
+        go install github.com/hashicorp/lint-consul-retry@v1.3.0
+        lint-consul-retry
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.4.2
+    - name: Validate
+      run: terraform fmt -check -recursive .
+  single-cluster:
+    needs:
+    - terraform-fmt
+    - go-fmt-and-lint-acceptance
+    - get-go-version
+    strategy:
+      matrix:
+        name:
+          - Consul ECS on Fargate
+          - Consul ECS on EC2
+          - Consul ECS with HCP
+        include:
+          - name: Consul ECS on Fargate
+            scenario: FARGATE
+
+          - name: Consul ECS on EC2
+            scenario: EC2
+
+          - name: Consul ECS with HCP
+            scenario: HCP
+      fail-fast: false
+    uses: ./.github/workflows/reusable-ecs-example-validator.yml
+    with:
+      name: ${{ matrix.name }}
+      scenario: ${{ matrix.scenario }}
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+    secrets: inherit
+  multi-cluster:
+    needs:
+    - single-cluster
+    - get-go-version
+    strategy:
+      matrix:
+        name:
+        - Cluster Peering
+        - WAN Federation with Mesh gateways
+        - Locality Aware Routing
+        - Service Sameness
+        include:
+        - name: Cluster Peering
+          scenario: CLUSTER_PEERING
+
+        - name: WAN Federation with Mesh gateways
+          scenario: WAN_FEDERATION
+
+        - name: Locality Aware Routing
+          scenario: LOCALITY_AWARE_ROUTING
+
+        - name: Service Sameness
+          scenario: SERVICE_SAMENESS
+      fail-fast: false
+    uses: ./.github/workflows/reusable-ecs-example-validator.yml
+    with:
+      name: ${{ matrix.name }}
+      scenario: ${{ matrix.scenario }}
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
+    secrets: inherit

--- a/.github/workflows/reusable-ecs-example-validator.yml
+++ b/.github/workflows/reusable-ecs-example-validator.yml
@@ -1,0 +1,74 @@
+name: reusable-ecs-example-validator
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: "The name of the job"
+        required: true
+        type: string        
+      scenario:
+        description: "The name of the scenario that needs to be tested on ECS. This will be passed as an environment variable to the test."
+        required: true
+        type: string
+      go-version:
+        description: "Version of Go to use to run the tests"
+        required: true
+        type: string
+
+env:
+  TEST_RESULTS: /tmp/test-results
+  GOTESTSUM_VERSION: 1.8.0
+  CONSUL_LICENSE: ${{ secrets.CONSUL_LICENSE }}
+  HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+  HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
+  HCP_PROJECT_ID: ${{ secrets.HCP_PROJECT_ID }}
+  TEST_SCENARIO: ${{ inputs.scenario }}
+
+jobs:
+  example-validator:
+    name: ${{ inputs.name }}
+    runs-on: ['ubuntu-latest']
+    defaults:
+      run:
+        working-directory: ./test/acceptance/examples
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache-dependency-path: ./test/acceptance/go.sum
+    - name: Install gotestsum
+      run: |
+        curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v${{ env.GOTESTSUM_VERSION }}/gotestsum_${{ env.GOTESTSUM_VERSION }}_linux_amd64.tar.gz" | \
+        tar -xz --overwrite -C /usr/local/bin gotestsum
+    - name: Install AWS CLI
+      run: |
+        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+        sudo dpkg -i session-manager-plugin.deb
+        aws --version
+        echo session-manager-plugin version "$(session-manager-plugin --version)"
+    - name: Install AWS ECS CLI
+      run: |
+        curl -sSL "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest" -o /usr/local/bin/ecs-cli
+        chmod +x /usr/local/bin/ecs-cli
+        ecs-cli --version
+    - name: Assume AWS IAM Role
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+      with:
+        role-to-assume: ${{ secrets.AWS_ECS_ROLE_ARN }}
+        aws-region: ${{ secrets.AWS_ECS_REGION }}
+        aws-access-key-id: ${{ secrets.AWS_ECS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_ECS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 7200
+    - name: Validation
+      run: |
+        mkdir -p "$TEST_RESULTS"
+        gotestsum --junitfile "$TEST_RESULTS/gotestsum-report.xml" --format standard-verbose -- ./... -p 1 -timeout 1h -v -failfast
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      if: always()
+      with:
+        name: acceptance-test-results
+        path: ${{ env.TEST_RESULTS }}/gotestsum-report.xml

--- a/examples/dev-server-fargate/main.tf
+++ b/examples/dev-server-fargate/main.tf
@@ -50,6 +50,8 @@ resource "aws_ecs_service" "example_client_app" {
 }
 
 module "example_client_app" {
+  depends_on = [module.dev_consul_server]
+
   source = "../../modules/mesh-task"
   family = "${var.name}-example-client-app"
   port   = "9090"
@@ -112,6 +114,8 @@ resource "aws_ecs_service" "example_server_app" {
 }
 
 module "example_server_app" {
+  depends_on = [module.dev_consul_server]
+
   source            = "../../modules/mesh-task"
   family            = "${var.name}-example-server-app"
   port              = "9090"

--- a/examples/locality-aware-routing/README.md
+++ b/examples/locality-aware-routing/README.md
@@ -79,6 +79,7 @@ Changes to Outputs:
   + client_lb_address             = (known after apply)
   + consul_server_bootstrap_token = (sensitive value)
   + consul_server_url             = (known after apply)
+  + ecs_cluster_arn = (known after apply)
 ```
 
 Type `yes` to apply the changes.
@@ -97,6 +98,7 @@ Outputs:
 client_lb_address = "http://example-client-app-1959503271.us-west-2.elb.amazonaws.com:9090/ui"
 consul_server_bootstrap_token = <sensitive>
 consul_server_url = "http://ecs-dc1-consul-server-713584774.us-west-2.elb.amazonaws.com:8500"
+ecs_cluster_arn = "arn:aws:ecs:us-east-1:123456789012:cluster/my-ecs-cluster"
 ```
 
 ### Explore
@@ -115,7 +117,7 @@ to view the Consul UI and log in using the `consul_server_bootstrap_token` above
 
 If you browse to the URL of the `client_lb_address`, the example application UI should be displayed:
 
-![Example App UI](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/_docs/locality-aware-dc1-ui.png?raw=true)
+![Example App UI](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/_docs/locality-aware-app-ui.png?raw=true)
 
 Notice the IP of the upstream server application's task. Because of the locality parameters added during the service registration, Consul takes care of routing traffic from the client application to the server application task within the same availability zone. You can read more about the locality aware routing feature [here](https://developer.hashicorp.com/consul/docs/v1.17.x/connect/manage-traffic/route-to-local-upstreams?ajs_aid=54615e8b-87b1-40fa-aecc-3e16280d6a88&product_intent=consul)
 

--- a/examples/locality-aware-routing/outputs.tf
+++ b/examples/locality-aware-routing/outputs.tf
@@ -13,3 +13,7 @@ output "consul_server_bootstrap_token" {
 output "client_lb_address" {
   value = "http://${aws_lb.example_client_app.dns_name}:9090/ui"
 }
+
+output "ecs_cluster_arn" {
+  value = module.cluster.ecs_cluster.arn
+}

--- a/test/acceptance/README.md
+++ b/test/acceptance/README.md
@@ -1,6 +1,6 @@
 ## Acceptance Tests
 
-These tests run the Terraform code.
+These tests run the Terraform code. For scenario based tests please refer to [this](./examples/README.md) document.
 
 ### Prerequisites
 
@@ -27,9 +27,9 @@ The following prerequisites are needed to run the acceptance tests:
 1. Now you can run the tests. The tests accept flags for passing in information about the
    VPC and ECS cluster you've just created.
 
-   Switch back to the `test/acceptance` directory:
+   Switch back to the `test/acceptance/tests` directory:
 
-1. To run the tests, use `go test` from the `test/acceptance` directory:
+1. To run the tests, use `go test` from the `test/acceptance/tests` directory:
 
    For tests that use Consul Enterprise outside of HCP, you must set the
    `CONSUL_LICENSE` environment variable to a Consul Enterprise license key.

--- a/test/acceptance/examples/README.md
+++ b/test/acceptance/examples/README.md
@@ -1,0 +1,45 @@
+## Scenario based tests
+
+These tests deploy the terraform code present under the `examples/` folder and performs custom validations on the same.
+
+These tests are run as part of [CI](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/.github/workflows/nightly-ecs-examples-validator.yml). The workflow is setup in a way that deployments happen in multiple stages one after the other. We made a conscious choice to run atmost 4 parallel deployments/test jobs in the CI to make sure that we don't exceed the VPC limits set up in the target AWS account.
+
+### Prerequisites
+
+The following prerequisites are needed to run the acceptance tests:
+
+- [Go](https://go.dev/dl/) (`go test`)
+- [Terraform](https://www.terraform.io/downloads) (`terraform`)
+   - [Authentication for AWS provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication)
+   - [Authentication for HCP provider](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs/guides/auth)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) (`aws`)
+   - [AWS Session Manager Plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)
+- [Amazon ECS CLI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html) (`ecs-cli`)
+
+### Instructions
+
+1. Make sure to set relevant environment variables to configure AWS and HCP (if you are running HCP based scenarios) credentials.
+
+1. Make sure to set the `TEST_SCENARIO` environment variable. This must match one of the scenarios listed in the `scenarioFuncs` map present in [main.go](./main_test.go).
+
+1. To run the tests, use `go test` from the `test/acceptance/examples` directory:
+
+   For tests that use Consul Enterprise outside of HCP, you must set the
+   `CONSUL_LICENSE` environment variable to a Consul Enterprise license key.
+
+   ```sh
+   export CONSUL_LICENSE=$(cat path/to/license-file)
+   TEST_SCENARIO=EC2 go test -run TestScenario -p 1 -timeout 30m -v
+   ```
+
+   You may want to set the `NO_CLEANUP_ON_FAILURE` environment variable if you're debugging
+   a failing test. Without this variable, the tests will delete all resources
+   regardless of passing or failing.
+
+### Adding a new scenario
+
+1. We expect every scenario to register itself to the scenario registry. Similar to existing examples, add a new folder corresponding to your scenario under the `scenarios/` subfolder and add relevant code into the same.
+
+1. Make sure to call the function that adds the scenario to the registry from [main_test.go](./main_test.go).
+
+1. If you want your scenario to run as part of CI, make sure to add it to the matrix list in [this](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/.github/workflows/nightly-ecs-examples-validator.yml) workflow file. If the number of parallel jobs within a matrix exceeds 4, make sure to create a new matrix job that is dependent on the existing ones and add your scenario there.

--- a/test/acceptance/examples/main_test.go
+++ b/test/acceptance/examples/main_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package examples
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	terratestLogger "github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	clusterpeering "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/cluster-peering"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/ec2"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/fargate"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/hcp"
+	localityawarerouting "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/locality-aware-routing"
+	sameness "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/service-sameness"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/wan-federation"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunScenario accepts a single scenario name as an environment
+// variable and executes tests for the same. We want to run each
+// scenario as a separate GitHub Action job.
+func TestRunScenario(t *testing.T) {
+	// Setup scenario registry
+	scenarioRegistry := setupScenarios()
+
+	scenarioName := os.Getenv("TEST_SCENARIO")
+	require.NotEmpty(t, scenarioName)
+
+	scenario, err := scenarioRegistry.Retrieve(scenarioName)
+	require.NoError(t, err)
+
+	initOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: fmt.Sprintf("../../../examples/%s", scenario.FolderName),
+		NoColor:      true,
+	})
+	terraform.Init(t, initOptions)
+
+	var tfVars map[string]interface{}
+	retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+		var err error
+		tfVars, err = scenario.TerraformInputVars()
+		require.NoError(r, err)
+	})
+
+	applyOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: initOptions.TerraformDir,
+		Vars:         tfVars,
+		NoColor:      true,
+	})
+
+	t.Cleanup(func() {
+		if os.Getenv("NO_CLEANUP_ON_FAILURE") != "true" {
+			terraform.Destroy(t, applyOptions)
+		}
+	})
+	terraform.Apply(t, applyOptions)
+
+	outputs := terraform.OutputAll(t, &terraform.Options{
+		TerraformDir: initOptions.TerraformDir,
+		NoColor:      true,
+		Logger:       terratestLogger.Default,
+	})
+
+	// Marshal the output into a json so that individual
+	// scenarios can unmarshal it into their required format.
+	outputJSON, err := json.Marshal(outputs)
+	require.NoError(t, err)
+
+	logger.Log(t, "running validation for scenario")
+	scenario.Validate(t, outputJSON)
+	logger.Log(t, "validation successful!!")
+}
+
+func setupScenarios() scenarios.ScenarioRegistry {
+	reg := scenarios.NewScenarioRegistry()
+
+	fargate.RegisterScenario(reg)
+	ec2.RegisterScenario(reg)
+	clusterpeering.RegisterScenario(reg)
+	hcp.RegisterScenario(reg)
+	sameness.RegisterScenario(reg)
+	wan.RegisterScenario(reg)
+	localityawarerouting.RegisterScenario(reg)
+
+	return reg
+}

--- a/test/acceptance/examples/scenarios/cluster-peering/main.go
+++ b/test/acceptance/examples/scenarios/cluster-peering/main.go
@@ -1,0 +1,81 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package clusterpeering
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type TFOutputs struct {
+	DC1ConsulServerAddr  string `json:"dc1_server_url"`
+	DC1ConsulServerToken string `json:"dc1_server_bootstrap_token"`
+	DC2ConsulServerAddr  string `json:"dc2_server_url"`
+	DC2ConsulServerToken string `json:"dc2_server_bootstrap_token"`
+	MeshClientLBAddr     string `json:"client_lb_address"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResourcesName := common.GenerateRandomStr(4)
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "CLUSTER_PEERING",
+		FolderName:         "cluster-peering",
+		TerraformInputVars: getTerraformVars(tfResourcesName),
+		Validate:           validate(tfResourcesName),
+	})
+}
+
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-2",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+		tfOutputs.MeshClientLBAddr = strings.TrimSuffix(tfOutputs.MeshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul clients")
+		consulClientOne, err := common.SetupConsulClient(t, tfOutputs.DC1ConsulServerAddr, common.WithToken(tfOutputs.DC1ConsulServerToken))
+		require.NoError(t, err)
+
+		consulClientTwo, err := common.SetupConsulClient(t, tfOutputs.DC2ConsulServerAddr, common.WithToken(tfOutputs.DC2ConsulServerToken))
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-dc1-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-dc2-example-server-app", tfResName)
+
+		consulClientOne.EnsureServiceReadiness(clientAppName, nil)
+		consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
+		consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", tfResName), nil)
+		consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", tfResName), nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app in the peer cluster is reachable")
+		common.ValidateFakeServiceResponse(t, tfOutputs.MeshClientLBAddr, serverAppName)
+	}
+}

--- a/test/acceptance/examples/scenarios/common/common.go
+++ b/test/acceptance/examples/scenarios/common/common.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"io"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	characterSet = "abcdefghijklmnopqrstuvwxyz"
+)
+
+// This method relies on a third party API to retrieve
+// the public IP of the host where this test runs.
+func GetPublicIP() (string, error) {
+	resp, err := http.Get("https://api64.ipify.org?format=text")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	ip, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(ip), nil
+}
+
+// GenerateRandomStr generate a random string of a given length
+// from the predefined characterSet.
+//
+// Note: The resulting string is always lowercased.
+func GenerateRandomStr(length int) string {
+	rand.Seed(time.Now().UnixNano())
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = characterSet[rand.Intn(len(characterSet))]
+	}
+	return strings.ToLower(string(result))
+}

--- a/test/acceptance/examples/scenarios/common/consul.go
+++ b/test/acceptance/examples/scenarios/common/consul.go
@@ -1,0 +1,140 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type ConsulClientWrapper struct {
+	t      *testing.T
+	client *api.Client
+}
+
+type ClientOpts func(*api.Config)
+
+// SetupConsulClient sets up a consul client that can be used to directly
+// interact with the consul server.
+func SetupConsulClient(t *testing.T, serverAddr string, opts ...ClientOpts) (*ConsulClientWrapper, error) {
+	cfg := api.DefaultConfig()
+	cfg.Address = serverAddr
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &ConsulClientWrapper{
+		t:      t,
+		client: client,
+	}, nil
+}
+
+func WithToken(token string) ClientOpts {
+	return func(c *api.Config) {
+		c.Token = token
+	}
+}
+
+// EnsureServiceReadiness makes sure that a service with a given name
+// is registered as part of Consul's catalog and is also healthy.
+func (ccw *ConsulClientWrapper) EnsureServiceReadiness(name string, queryOpts *api.QueryOptions) {
+	ccw.ensureServiceRegistration(name, queryOpts)
+	ccw.ensureHealthyService(name, queryOpts)
+}
+
+// EnsureServiceDeregistration makes sure that a service with a given name
+// is registered as part of Consul's catalog
+func (ccw *ConsulClientWrapper) EnsureServiceDeregistration(name string, queryOpts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if service %s is deregistered from Consul", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		exists, err := ccw.serviceExists(name, queryOpts)
+		require.NoError(r, err)
+		require.False(r, exists)
+	})
+}
+
+// EnsureServiceInstances verifies if the number of service instances for a service
+// in Consul catalog matches the expected count.
+func (ccw *ConsulClientWrapper) EnsureServiceInstances(name string, expectedCount int, queryOpts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if service %s has two instances registered", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		instances, err := ccw.listServiceInstances(name, nil)
+		require.NoError(r, err)
+		require.Len(r, instances, expectedCount)
+	})
+}
+
+// ensureServiceRegistration makes sure that a service with a given name
+// is registered as part of Consul's catalog
+func (ccw *ConsulClientWrapper) ensureServiceRegistration(name string, queryOpts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if service %s is registered in Consul", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		exists, err := ccw.serviceExists(name, queryOpts)
+		require.NoError(r, err)
+		require.True(r, exists)
+	})
+}
+
+// ensureHealthyService polls the catalog endpoint to understand a service's health status.
+// Note that the health of a service is an accumulation of all the health checks associated
+// with that of the service instances of that service.
+func (ccw *ConsulClientWrapper) ensureHealthyService(name string, opts *api.QueryOptions) {
+	logger.Log(ccw.t, fmt.Sprintf("checking if all instances of %s are healthy", name))
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, ccw.t, func(r *retry.R) {
+		healthy, err := ccw.isServiceHealthy(name, opts)
+		require.NoError(r, err)
+		require.True(r, healthy)
+	})
+}
+
+// serviceExists verifies if a service with a given name exists in Consul's catalog.
+func (ccw *ConsulClientWrapper) serviceExists(serviceName string, queryOpts *api.QueryOptions) (bool, error) {
+	services, err := ccw.listServices(queryOpts)
+	if err != nil {
+		return false, err
+	}
+
+	_, ok := services[serviceName]
+	return ok, nil
+}
+
+// isServiceHealthy verifies if all service instances of a service with a given name are healthy in Consul's catalog.
+func (ccw *ConsulClientWrapper) isServiceHealthy(serviceName string, queryOpts *api.QueryOptions) (bool, error) {
+	res, _, err := ccw.client.Health().Checks(serviceName, queryOpts)
+	if err != nil {
+		return false, err
+	}
+
+	return res.AggregatedStatus() == api.HealthPassing, nil
+}
+
+// ListServiceInstances returns the list of service instances for a given service
+func (c *ConsulClientWrapper) listServiceInstances(serviceName string, queryOpts *api.QueryOptions) ([]*api.CatalogService, error) {
+	instances, _, err := c.client.Catalog().Service(serviceName, "", queryOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return instances, nil
+}
+
+func (c *ConsulClientWrapper) listServices(opts *api.QueryOptions) (map[string][]string, error) {
+	services, _, err := c.client.Catalog().Services(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return services, nil
+}

--- a/test/acceptance/examples/scenarios/common/ecs.go
+++ b/test/acceptance/examples/scenarios/common/ecs.go
@@ -1,0 +1,142 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/gruntwork-io/terratest/modules/shell"
+)
+
+type ECSClientWrapper struct {
+	client     *ecs.Client
+	clusterARN string
+	region     string
+}
+
+type ECSClientWrapperOpts func(*ECSClientWrapper)
+
+func NewECSClient(opts ...ECSClientWrapperOpts) (*ECSClientWrapper, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	ew := &ECSClientWrapper{}
+	for _, opt := range opts {
+		opt(ew)
+	}
+
+	if ew.region != "" {
+		cfg.Region = ew.region
+	}
+	ew.client = ecs.NewFromConfig(cfg)
+
+	return ew, nil
+}
+
+func WithClusterARN(arn string) ECSClientWrapperOpts {
+	return func(ew *ECSClientWrapper) {
+		ew.clusterARN = arn
+	}
+}
+
+func WithRegion(region string) ECSClientWrapperOpts {
+	return func(ew *ECSClientWrapper) {
+		ew.region = region
+	}
+}
+
+func (e *ECSClientWrapper) WithClusterARN(clusterARN string) *ECSClientWrapper {
+	e.clusterARN = clusterARN
+	return e
+}
+
+// ListTasksForService returns back the taskARN list for a given service
+func (e *ECSClientWrapper) ListTasksForService(service string) ([]string, error) {
+	taskARNs := make([]string, 0)
+	var nextToken *string
+	for {
+		req := &ecs.ListTasksInput{
+			Cluster:     &e.clusterARN,
+			ServiceName: &service,
+			NextToken:   nextToken,
+		}
+
+		res, err := e.client.ListTasks(context.TODO(), req)
+		if err != nil {
+			return nil, err
+		}
+		nextToken = res.NextToken
+
+		taskARNs = append(taskARNs, res.TaskArns...)
+		if nextToken == nil {
+			break
+		}
+	}
+
+	return taskARNs, nil
+}
+
+// DescribeTasks returns back a detailed description of all the tasks passed as input.
+func (e *ECSClientWrapper) DescribeTasks(taskIDs []string) (*ecs.DescribeTasksOutput, error) {
+	req := &ecs.DescribeTasksInput{
+		Tasks:   taskIDs,
+		Cluster: &e.clusterARN,
+	}
+
+	return e.client.DescribeTasks(context.TODO(), req)
+}
+
+// StopTask stops a given task with a reason
+func (e *ECSClientWrapper) StopTask(taskID, reason string) error {
+	req := &ecs.StopTaskInput{
+		Task:    &taskID,
+		Cluster: &e.clusterARN,
+		Reason:  &reason,
+	}
+
+	_, err := e.client.StopTask(context.TODO(), req)
+	return err
+}
+
+// UpdateService scales the number of tasks governed by the service to the
+// desiredCount.
+func (e *ECSClientWrapper) UpdateService(serviceName string, desiredCount int32) error {
+	req := &ecs.UpdateServiceInput{
+		Service:      &serviceName,
+		Cluster:      &e.clusterARN,
+		DesiredCount: &desiredCount,
+	}
+
+	_, err := e.client.UpdateService(context.TODO(), req)
+	return err
+}
+
+// ExecuteCommandInteractive runs the provided command inside a container in the ECS task
+// and returns back the results.
+//
+// Note: Ideally we should try to use the SDK for this but it wasn't straight forward and
+// there was no clear documentation around the same.
+func (e *ECSClientWrapper) ExecuteCommandInteractive(t *testing.T, taskARN, container, command string) (string, error) {
+	return shell.RunCommandAndGetOutputE(t, shell.Command{
+		Command: "aws",
+		Args: []string{
+			"ecs",
+			"execute-command",
+			"--cluster",
+			e.clusterARN,
+			"--task",
+			taskARN,
+			fmt.Sprintf("--container=%s", container),
+			"--command",
+			command,
+			"--interactive",
+		},
+	})
+}

--- a/test/acceptance/examples/scenarios/common/fake_service.go
+++ b/test/acceptance/examples/scenarios/common/fake_service.go
@@ -1,0 +1,82 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/require"
+)
+
+type FakeServiceResponse struct {
+	Body          string                          `json:"body"`
+	Code          int                             `json:"code"`
+	UpstreamCalls map[string]UpstreamCallResponse `json:"upstream_calls"`
+}
+
+type UpstreamCallResponse struct {
+	Name        string   `json:"name"`
+	Body        string   `json:"body"`
+	IpAddresses []string `json:"ip_addresses,omitempty"`
+	Code        int      `json:"code"`
+}
+
+// ValidateFakeServiceResponse takes in the client application's address(typically
+// the address of the ALB infront of the client app's ECS task) and performs a
+// HTTP GET against the same. It also verifies if the response matches the
+// success criteria and also verifies if the expected upstream app was hit.
+func ValidateFakeServiceResponse(t *testing.T, lbURL, expectedUpstream string) *UpstreamCallResponse {
+	var upstreamResp UpstreamCallResponse
+	retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+		resp, err := GetFakeServiceResponse(lbURL)
+		require.NoError(r, err)
+
+		require.Equal(r, 200, resp.Code)
+		require.Equal(r, "Hello World", resp.Body)
+		require.NotNil(r, resp.UpstreamCalls)
+
+		upstreamResp = resp.UpstreamCalls["http://localhost:1234"]
+		require.NotNil(r, upstreamResp)
+		require.Equal(r, expectedUpstream, upstreamResp.Name)
+		require.Equal(r, 200, upstreamResp.Code)
+		require.Equal(r, "Hello World", upstreamResp.Body)
+	})
+
+	return &upstreamResp
+}
+
+// GetFakeServiceResponse takes in the client application's address(typically
+// the address of the ALB infront of the client app's ECS task) and performs
+// a HTTP GET against the same. It returns back some fields of the response
+// json which can be used by the caller to validate if the request went
+// through as expected.
+func GetFakeServiceResponse(addr string) (*FakeServiceResponse, error) {
+	resp, err := httpGet(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	var fakeSvcResp *FakeServiceResponse
+	err = json.Unmarshal(resp, &fakeSvcResp)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling json %w", err)
+	}
+
+	return fakeSvcResp, nil
+}
+
+func httpGet(addr string) ([]byte, error) {
+	resp, err := http.Get(addr)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}

--- a/test/acceptance/examples/scenarios/common/fake_service_test.go
+++ b/test/acceptance/examples/scenarios/common/fake_service_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFakeServiceResponse(t *testing.T) {
+	cases := map[string]struct {
+		httpRespCode int
+		respStr      string
+		wantErr      bool
+		errStr       string
+		expectedResp *FakeServiceResponse
+	}{
+		"non success error code": {
+			httpRespCode: http.StatusInternalServerError,
+			wantErr:      true,
+		},
+		"json unmarshalling error": {
+			httpRespCode: http.StatusOK,
+			respStr:      `unsupported-response-format`,
+			wantErr:      true,
+			errStr:       "unmarshalling json",
+		},
+		"failed upstream call": {
+			httpRespCode: http.StatusOK,
+			respStr:      "{\n  \"name\": \"consul-ecs-example-client-app\",\n  \"uri\": \"/\",\n  \"type\": \"HTTP\",\n  \"ip_addresses\": [\n    \"169.254.172.2\",\n    \"10.0.3.165\"\n  ],\n  \"start_time\": \"2023-12-17T13:14:48.498808\",\n  \"end_time\": \"2023-12-17T13:14:48.505297\",\n  \"duration\": \"6.488534ms\",\n  \"body\": \"Hello World\",\n  \"upstream_calls\": {\n    \"http://localhost:1234\": {\n      \"uri\": \"http://localhost:1234\",\n      \"code\": -1,\n      \"error\": \"Error communicating with upstream service: Get \\\"http://localhost:1234/\\\": EOF\"\n    }\n  },\n  \"code\": 500\n}",
+			expectedResp: &FakeServiceResponse{
+				Body: "Hello World",
+				Code: 500,
+				UpstreamCalls: map[string]UpstreamCallResponse{
+					"http://localhost:1234": {
+						Code: -1,
+					},
+				},
+			},
+		},
+		"successful upstream call": {
+			httpRespCode: http.StatusOK,
+			respStr:      "{\n  \"name\": \"consul-ecs-example-client-app\",\n  \"uri\": \"/\",\n  \"type\": \"HTTP\",\n  \"ip_addresses\": [\n    \"169.254.172.2\",\n    \"10.0.3.165\"\n  ],\n  \"start_time\": \"2023-12-17T13:01:18.291103\",\n  \"end_time\": \"2023-12-17T13:01:18.306560\",\n  \"duration\": \"15.456478ms\",\n  \"body\": \"Hello World\",\n  \"upstream_calls\": {\n    \"http://localhost:1234\": {\n      \"name\": \"consul-ecs-example-server-app\",\n      \"uri\": \"http://localhost:1234\",\n      \"type\": \"HTTP\",\n      \"ip_addresses\": [\n        \"169.254.172.2\",\n        \"10.0.2.34\"\n      ],\n      \"start_time\": \"2023-12-17T13:01:18.304883\",\n      \"end_time\": \"2023-12-17T13:01:18.305302\",\n      \"duration\": \"418.719µs\",\n      \"headers\": {\n        \"Content-Length\": \"298\",\n        \"Content-Type\": \"text/plain; charset=utf-8\",\n        \"Date\": \"Sun, 17 Dec 2023 13:01:18 GMT\"\n      },\n      \"body\": \"Hello World\",\n      \"code\": 200\n    }\n  },\n  \"code\": 200\n}",
+			expectedResp: &FakeServiceResponse{
+				Body: "Hello World",
+				Code: 200,
+				UpstreamCalls: map[string]UpstreamCallResponse{
+					"http://localhost:1234": {
+						Name: "consul-ecs-example-server-app",
+						Body: "Hello World",
+						Code: 200,
+						IpAddresses: []string{
+							"169.254.172.2",
+							"10.0.2.34",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				w.WriteHeader(c.httpRespCode)
+				_, _ = w.Write([]byte(c.respStr))
+			})
+			server := httptest.NewServer(handler)
+			t.Cleanup(server.Close)
+
+			resp, err := GetFakeServiceResponse(server.URL)
+			if c.wantErr {
+				require.Error(t, err)
+				if c.errStr != "" {
+					require.Contains(t, err.Error(), c.errStr)
+				}
+			} else {
+				require.NotNil(t, resp)
+				require.True(t, reflect.DeepEqual(resp, c.expectedResp))
+			}
+		})
+	}
+}

--- a/test/acceptance/examples/scenarios/ec2/main.go
+++ b/test/acceptance/examples/scenarios/ec2/main.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package ec2
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type TFOutputs struct {
+	ConsulServerLBAddr string `json:"consul_server_lb_address"`
+	MeshClientLBAddr   string `json:"mesh_client_lb_address"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResourcesName := fmt.Sprintf("ecs-%s", common.GenerateRandomStr(6))
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "EC2",
+		FolderName:         "dev-server-ec2",
+		TerraformInputVars: getTerraformVars(tfResourcesName),
+		Validate:           validate(tfResourcesName),
+	})
+}
+
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-2",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+
+		consulServerLBAddr := tfOutputs.ConsulServerLBAddr
+		meshClientLBAddr := tfOutputs.MeshClientLBAddr
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-example-server-app", tfResName)
+
+		consulClient.EnsureServiceReadiness(clientAppName, nil)
+		consulClient.EnsureServiceReadiness(serverAppName, nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
+		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+	}
+}

--- a/test/acceptance/examples/scenarios/fargate/main.go
+++ b/test/acceptance/examples/scenarios/fargate/main.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package fargate
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type TFOutputs struct {
+	ConsulServerLBAddr string `json:"consul_server_lb_address"`
+	MeshClientLBAddr   string `json:"mesh_client_lb_address"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResourcesName := fmt.Sprintf("ecs-%s", common.GenerateRandomStr(6))
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "FARGATE",
+		FolderName:         "dev-server-fargate",
+		TerraformInputVars: getTerraformVars(tfResourcesName),
+		Validate:           validate(tfResourcesName),
+	})
+}
+
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-1",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+
+		consulServerLBAddr := tfOutputs.ConsulServerLBAddr
+		meshClientLBAddr := tfOutputs.MeshClientLBAddr
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-example-server-app", tfResName)
+
+		consulClient.EnsureServiceReadiness(clientAppName, nil)
+		consulClient.EnsureServiceReadiness(serverAppName, nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
+		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+	}
+}

--- a/test/acceptance/examples/scenarios/hcp/main.go
+++ b/test/acceptance/examples/scenarios/hcp/main.go
@@ -1,0 +1,105 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package hcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/serf/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type TFOutputs struct {
+	HCPConsulServerAddr  string `json:"hcp_public_endpoint"`
+	HCPConsulServerToken string `json:"token"`
+	ClientApp            *App   `json:"client"`
+	ServerApp            *App   `json:"server"`
+}
+
+type App struct {
+	Name          string `json:"name"`
+	ECSClusterARN string `json:"ecs_cluster_arn"`
+	Region        string `json:"region"`
+	Partition     string `json:"partition"`
+	Namespace     string `json:"namespace"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "HCP",
+		FolderName:         "admin-partitions/terraform",
+		TerraformInputVars: getTerraformVars(),
+		Validate:           validate(),
+	})
+}
+
+func getTerraformVars() scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-west-2",
+		}
+
+		hcpProjectID := os.Getenv("HCP_PROJECT_ID")
+		if hcpProjectID == "" {
+			return nil, fmt.Errorf("expected HCP_PROJECT_ID to be non empty")
+		}
+		vars["hcp_project_id"] = hcpProjectID
+
+		return vars, nil
+	}
+}
+
+func validate() scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, tfOutputs.HCPConsulServerAddr, common.WithToken(tfOutputs.HCPConsulServerToken))
+		require.NoError(t, err)
+
+		ensureServiceReadiness(consulClient, tfOutputs.ClientApp)
+		ensureServiceReadiness(consulClient, tfOutputs.ServerApp)
+
+		logger.Log(t, "Setting up ECS client")
+
+		ecsClient, err := common.NewECSClient()
+		require.NoError(t, err)
+
+		// List tasks for the client service
+		tasks, err := ecsClient.WithClusterARN(tfOutputs.ClientApp.ECSClusterARN).ListTasksForService(tfOutputs.ClientApp.Name)
+		require.NoError(t, err)
+		require.Len(t, tasks, 1)
+
+		// Validate connection between apps by running a remote command inside the container.
+		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			res, err := ecsClient.
+				WithClusterARN(tfOutputs.ClientApp.ECSClusterARN).
+				ExecuteCommandInteractive(t, tasks[0], "basic", `/bin/sh -c "curl localhost:1234"`)
+			r.Check(err)
+			if !strings.Contains(res, `"code": 200`) {
+				r.Errorf("response was unexpected: %q", res)
+			}
+		})
+	}
+}
+
+func ensureServiceReadiness(consulClient *common.ConsulClientWrapper, service *App) {
+	opts := &api.QueryOptions{
+		Namespace: service.Namespace,
+		Partition: service.Partition,
+	}
+	consulClient.EnsureServiceReadiness(service.Name, opts)
+}

--- a/test/acceptance/examples/scenarios/locality-aware-routing/main.go
+++ b/test/acceptance/examples/scenarios/locality-aware-routing/main.go
@@ -1,0 +1,197 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package localityawarerouting
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/hashicorp/serf/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type TFOutputs struct {
+	ConsulServerAddr  string `json:"consul_server_url"`
+	ConsulServerToken string `json:"consul_server_bootstrap_token"`
+	MeshClientLBAddr  string `json:"client_lb_address"`
+	ECSClusterARN     string `json:"ecs_cluster_arn"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResName := common.GenerateRandomStr(4)
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "LOCALITY_AWARE_ROUTING",
+		FolderName:         "locality-aware-routing",
+		TerraformInputVars: getTerraformVars(tfResName),
+		Validate:           validate(tfResName),
+	})
+}
+
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-west-2",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		enterpriseLicense := os.Getenv("CONSUL_LICENSE")
+		if enterpriseLicense == "" {
+			return nil, fmt.Errorf("expected CONSUL_LICENSE to be non empty")
+		}
+		vars["consul_license"] = enterpriseLicense
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+		tfOutputs.MeshClientLBAddr = strings.TrimSuffix(tfOutputs.MeshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, tfOutputs.ConsulServerAddr, common.WithToken(tfOutputs.ConsulServerToken))
+		require.NoError(t, err)
+
+		clientAppName := "example-client-app"
+		serverAppName := "example-server-app"
+
+		consulClient.EnsureServiceReadiness(clientAppName, nil)
+		consulClient.EnsureServiceReadiness(serverAppName, nil)
+
+		consulClient.EnsureServiceInstances(serverAppName, 2, nil)
+
+		ecsClient, err := common.NewECSClient(common.WithClusterARN(tfOutputs.ECSClusterARN))
+		require.NoError(t, err)
+
+		logger.Log(t, "Listing and describing tasks for each ECS service")
+		clientTasks := assertAndListTasks(t, ecsClient, clientAppName, 1)
+		serverTasks := assertAndListTasks(t, ecsClient, serverAppName, 2)
+
+		// Describe the client task
+		tasks := assertAndDescribeTasks(t, ecsClient, clientTasks, 1)
+		clientTask := tasks[0]
+
+		// Describe the server tasks
+		tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
+		serverTaskIPMap := getTaskIPToTaskMap(t, tasks)
+
+		performAssertions := func(expectSameAZ bool) {
+			retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+				resp, err := common.GetFakeServiceResponse(tfOutputs.MeshClientLBAddr)
+				require.NoError(r, err)
+
+				require.Equal(r, 200, resp.Code)
+				require.Equal(r, "Hello World", resp.Body)
+				require.NotNil(r, resp.UpstreamCalls)
+
+				upstreamResp := resp.UpstreamCalls["http://localhost:1234"]
+				require.NotNil(r, upstreamResp)
+				require.Equal(r, serverAppName, upstreamResp.Name)
+				require.Equal(r, 200, upstreamResp.Code)
+				require.Equal(r, "Hello World", upstreamResp.Body)
+
+				var upstreamServerTask types.Task
+				var ok bool
+				for _, ip := range upstreamResp.IpAddresses {
+					upstreamServerTask, ok = serverTaskIPMap[ip]
+					if ok {
+						break
+					}
+				}
+
+				// Check if the client app's AZ matches with that of the server task
+				if expectSameAZ {
+					require.Equal(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
+				} else {
+					require.NotEqual(r, clientTask.AvailabilityZone, upstreamServerTask.AvailabilityZone)
+				}
+			})
+		}
+
+		logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
+		performAssertions(true)
+
+		// Stop the server app present in the same AZ as that of the client
+		var serverTaskToStop types.Task
+		for _, v := range tasks {
+			if *v.AvailabilityZone == *clientTask.AvailabilityZone {
+				serverTaskToStop = v
+				break
+			}
+		}
+
+		logger.Log(t, "Stopping the server app's task present in the same AZ as that of the client.")
+		require.NoError(t, ecsClient.StopTask(*serverTaskToStop.TaskArn, "stopping as part of a test"))
+
+		logger.Log(t, "Calling the client app's load balancer to verify if the client app falls back to hit the server app in the other availability zone")
+		performAssertions(false)
+
+		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			logger.Log(t, "Waiting for ECS to spin up the previously stopped server app's task")
+			serverTasks, err = ecsClient.ListTasksForService(serverAppName)
+			require.NoError(r, err)
+			require.Len(r, serverTasks, 2)
+		})
+
+		tasks = assertAndDescribeTasks(t, ecsClient, serverTasks, 2)
+		serverTaskIPMap = getTaskIPToTaskMap(t, tasks)
+
+		logger.Log(t, "Calling the client app's load balancer to verify if the client app hits the server app in the same availability zone")
+		performAssertions(true)
+	}
+}
+
+func assertAndListTasks(t *testing.T, ecsClient *common.ECSClientWrapper, service string, expectedCount int) []string {
+	tasks, err := ecsClient.ListTasksForService(service)
+	require.NoError(t, err)
+	require.Len(t, tasks, expectedCount)
+
+	return tasks
+}
+
+func assertAndDescribeTasks(t *testing.T, ecsClient *common.ECSClientWrapper, taskIDs []string, expectedCount int) []types.Task {
+	tasks, err := ecsClient.DescribeTasks(taskIDs)
+	require.NoError(t, err)
+	require.NotNil(t, tasks)
+	require.Len(t, tasks.Tasks, expectedCount)
+
+	return tasks.Tasks
+}
+
+func getTaskIPToTaskMap(t *testing.T, tasks []types.Task) map[string]types.Task {
+	serverTaskIPMap := make(map[string]types.Task)
+	for _, task := range tasks {
+		serverTaskIPMap[getTaskPrivateIP(t, task)] = task
+	}
+
+	return serverTaskIPMap
+}
+
+func getTaskPrivateIP(t *testing.T, task types.Task) string {
+	require.NotNil(t, task)
+	require.NotEmpty(t, task.Containers)
+	require.NotEmpty(t, task.Containers[0].NetworkInterfaces)
+
+	ip := task.Containers[0].NetworkInterfaces[0].PrivateIpv4Address
+	require.NotNil(t, ip)
+	return *ip
+}

--- a/test/acceptance/examples/scenarios/registry.go
+++ b/test/acceptance/examples/scenarios/registry.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package scenarios
+
+import "fmt"
+
+type scenarioName string
+
+type registry struct {
+	scenarios map[scenarioName]ScenarioRegistration
+}
+
+func NewScenarioRegistry() ScenarioRegistry {
+	return &registry{
+		scenarios: make(map[scenarioName]ScenarioRegistration),
+	}
+}
+
+func (s *registry) Register(reg ScenarioRegistration) {
+	if _, ok := s.scenarios[scenarioName(reg.Name)]; ok {
+		panic(fmt.Sprintf("scenario %s already registered", reg.Name))
+	}
+
+	if err := reg.validate(); err != nil {
+		panic(fmt.Errorf("error validating scenario %w", err))
+	}
+
+	s.scenarios[scenarioName(reg.Name)] = reg
+}
+
+func (s *registry) Retrieve(name string) (ScenarioRegistration, error) {
+	scenario, ok := s.scenarios[scenarioName(name)]
+	if !ok {
+		return ScenarioRegistration{}, fmt.Errorf("scenario %s is not registered", name)
+	}
+
+	return scenario, nil
+}

--- a/test/acceptance/examples/scenarios/registry_test.go
+++ b/test/acceptance/examples/scenarios/registry_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package scenarios
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry(t *testing.T) {
+	cases := map[string]struct {
+		scenarioPresent  bool
+		registerScenario bool
+		mutateScenario   func(ScenarioRegistration) ScenarioRegistration
+		shouldPanic      bool
+		wantErr          bool
+	}{
+		"scenario already present": {
+			scenarioPresent:  true,
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"scenario not present": {
+			wantErr: true,
+		},
+		"invalid scenario name": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.Name = ""
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"invalid scenario folder name": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.FolderName = ""
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"invalid scenario TF Vars hook": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.TerraformInputVars = nil
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"invalid scenario Validate hook": {
+			mutateScenario: func(sr ScenarioRegistration) ScenarioRegistration {
+				sr.Validate = nil
+				return sr
+			},
+			registerScenario: true,
+			shouldPanic:      true,
+		},
+		"successful registration and retrieval": {
+			registerScenario: true,
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Logf("Panic caught: %v", r)
+				}
+			}()
+
+			registry := NewScenarioRegistry()
+
+			if c.scenarioPresent {
+				registry.Register(getTestScenarioRegistrationPayload())
+			}
+
+			payload := getTestScenarioRegistrationPayload()
+			if c.mutateScenario != nil {
+				payload = c.mutateScenario(payload)
+			}
+
+			if c.registerScenario {
+				registry.Register(payload)
+			}
+
+			actualScenario, err := registry.Retrieve("TEST_SCENARIO")
+			if c.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, payload.Name, actualScenario.Name)
+				require.Equal(t, payload.FolderName, actualScenario.FolderName)
+			}
+
+			// If the test is supposed to panic while registering
+			// a scenario and we reach here, we fail explicitly.
+			if c.shouldPanic {
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func getTestScenarioRegistrationPayload() ScenarioRegistration {
+	return ScenarioRegistration{
+		Name:       "TEST_SCENARIO",
+		FolderName: "test_folder/test_scenario",
+		TerraformInputVars: func() (map[string]interface{}, error) {
+			return nil, nil
+		},
+		Validate: func(t *testing.T, b []byte) {},
+	}
+}

--- a/test/acceptance/examples/scenarios/scenario.go
+++ b/test/acceptance/examples/scenarios/scenario.go
@@ -1,0 +1,63 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package scenarios
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ScenarioRegistry helps us interact with the
+// actual registry that holds details about the scenarios.
+type ScenarioRegistry interface {
+	// Register registers a scenario into the registry
+	Register(ScenarioRegistration)
+
+	// Retrieve retrieves a scenario from the registry
+	Retrieve(name string) (ScenarioRegistration, error)
+}
+
+type TerraformInputVarsHook func() (map[string]interface{}, error)
+type ValidateHook func(*testing.T, []byte)
+
+// ScenarioRegistration is the struct we expect each individual
+// scenario to use and register themselves by providing valid
+// lifecycle hooks
+type ScenarioRegistration struct {
+	// The name of the scenario. This name should match the value
+	// of TEST_SCENARIO environment variable which the test uses
+	// to determine the scenario to run.
+	Name string
+
+	// The name of the example's folder under the `examples/` directory
+	FolderName string
+
+	// List of TF variables that needs to be supplied to the
+	// example's terraform config.
+	TerraformInputVars TerraformInputVarsHook
+
+	// Validate is the hook called when validations need to be performed on the deployment. This
+	// hook will only be called after a successful terraform apply.
+	Validate ValidateHook
+}
+
+func (r *ScenarioRegistration) validate() error {
+	if r.Name == "" {
+		return fmt.Errorf("scenario name cannot be empty")
+	}
+
+	if r.FolderName == "" {
+		return fmt.Errorf("scenario %s should have a folder name associated to it", r.Name)
+	}
+
+	if r.TerraformInputVars == nil {
+		return fmt.Errorf("scenario %s should provide hooks for providing terraform input variables", r.Name)
+	}
+
+	if r.Validate == nil {
+		return fmt.Errorf("scenario %s should provide hooks validating the deployment", r.Name)
+	}
+
+	return nil
+}

--- a/test/acceptance/examples/scenarios/service-sameness/main.go
+++ b/test/acceptance/examples/scenarios/service-sameness/main.go
@@ -1,0 +1,282 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sameness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	awsRegion = "us-west-1"
+)
+
+type TFOutputs struct {
+	DC1ConsulServerAddr  string            `json:"dc1_server_url"`
+	DC1ConsulServerToken string            `json:"dc1_server_bootstrap_token"`
+	DC2ConsulServerAddr  string            `json:"dc2_server_url"`
+	DC2ConsulServerToken string            `json:"dc2_server_bootstrap_token"`
+	DC1DefaultPartition  *PartitionDetails `json:"dc1_default_partition_apps"`
+	DC1Part1Partition    *PartitionDetails `json:"dc1_part1_partition_apps"`
+	DC2DefaultPartition  *PartitionDetails `json:"dc2_default_partition_apps"`
+}
+
+type PartitionDetails struct {
+	Partition     string `json:"partition"`
+	Namespace     string `json:"namespace"`
+	ECSClusterARN string `json:"ecs_cluster_arn"`
+	Region        string `json:"region"`
+	ClientApp     *App   `json:"server"`
+	ServerApp     *App   `json:"client"`
+}
+
+func (p *PartitionDetails) getClientAppName() string       { return p.ClientApp.Name }
+func (p *PartitionDetails) getServerAppName() string       { return p.ServerApp.Name }
+func (p *PartitionDetails) getClientAppLBAddr() string     { return p.ClientApp.LBAddr }
+func (p *PartitionDetails) getClientAppConsulName() string { return p.ClientApp.ConsulName }
+func (p *PartitionDetails) getServerAppConsulName() string { return p.ServerApp.ConsulName }
+
+type App struct {
+	Name       string `json:"name"`
+	ConsulName string `json:"consul_service_name"`
+	LBAddr     string `json:"lb_address,omitempty"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResName := common.GenerateRandomStr(4)
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "SERVICE_SAMENESS",
+		FolderName:         "service-sameness",
+		TerraformInputVars: getTerraformVars(tfResName),
+		Validate:           validate(tfResName),
+	})
+}
+
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": awsRegion,
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		enterpriseLicense := os.Getenv("CONSUL_LICENSE")
+		if enterpriseLicense == "" {
+			return nil, fmt.Errorf("expected CONSUL_LICENSE to be non empty")
+		}
+		vars["consul_license"] = enterpriseLicense
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+
+		removeUISuffix := func(addr string) string {
+			return strings.TrimSuffix(addr, "/ui")
+		}
+		tfOutputs.DC1DefaultPartition.ClientApp.LBAddr = removeUISuffix(tfOutputs.DC1DefaultPartition.ClientApp.LBAddr)
+		tfOutputs.DC1Part1Partition.ClientApp.LBAddr = removeUISuffix(tfOutputs.DC1Part1Partition.ClientApp.LBAddr)
+		tfOutputs.DC2DefaultPartition.ClientApp.LBAddr = removeUISuffix(tfOutputs.DC2DefaultPartition.ClientApp.LBAddr)
+
+		logger.Log(t, "Setting up the Consul clients")
+		consulClientOne, err := common.SetupConsulClient(t, tfOutputs.DC1ConsulServerAddr, common.WithToken(tfOutputs.DC1ConsulServerToken))
+		require.NoError(t, err)
+
+		consulClientTwo, err := common.SetupConsulClient(t, tfOutputs.DC2ConsulServerAddr, common.WithToken(tfOutputs.DC2ConsulServerToken))
+		require.NoError(t, err)
+
+		logger.Log(t, "Setting up ECS Client")
+		ecsClient, err := common.NewECSClient(common.WithRegion(awsRegion))
+		require.NoError(t, err)
+
+		ensureAppsReadiness(t, consulClientOne, tfOutputs.DC1DefaultPartition)
+		ensureAppsReadiness(t, consulClientOne, tfOutputs.DC1Part1Partition)
+		ensureAppsReadiness(t, consulClientTwo, tfOutputs.DC2DefaultPartition)
+
+		// Ensure that the gateways are also ready
+		consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-default-mesh-gateway", tfResName), nil)
+		consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-%s-mesh-gateway", tfResName, tfOutputs.DC1Part1Partition.Partition), &api.QueryOptions{Partition: tfOutputs.DC1Part1Partition.Partition})
+		consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", tfResName), nil)
+
+		// Begin actual validation
+		clusterAppsList := []*PartitionDetails{
+			tfOutputs.DC1DefaultPartition,
+			tfOutputs.DC1Part1Partition,
+			tfOutputs.DC2DefaultPartition,
+		}
+
+		var recordedUpstreamCalls map[string]string
+
+		assertUpstreamCall := func(apps *PartitionDetails, expectedUpstream string) {
+			recordedUpstream, ok := recordedUpstreamCalls[apps.getClientAppName()]
+			require.True(t, ok)
+			require.Equal(t, expectedUpstream, recordedUpstream)
+		}
+
+		// Without making any changes we expect calls from the client apps
+		// to reach the server apps in their local partitions.
+		logger.Log(t, "Calling upstreams from individual client tasks. Calls are expected to hit the local server instances in the same namespace as the client")
+		recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+		assertUpstreamCall(tfOutputs.DC1DefaultPartition, tfOutputs.DC1DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC1Part1Partition, tfOutputs.DC1Part1Partition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC2DefaultPartition, tfOutputs.DC2DefaultPartition.getServerAppName())
+
+		// Scaling down server app present in the default partition in DC1. After this, requests from
+		// the client app in the default partition will failover to the server app present in
+		// the part1 partition in DC1.
+		mustScaleDownServerApp(t, ecsClient, consulClientOne, tfOutputs.DC1DefaultPartition)
+
+		logger.Log(t, "Scale down complete. Calling upstreams for individual client tasks.")
+		recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+		assertUpstreamCall(tfOutputs.DC1DefaultPartition, tfOutputs.DC1Part1Partition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC1Part1Partition, tfOutputs.DC1Part1Partition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC2DefaultPartition, tfOutputs.DC2DefaultPartition.getServerAppName())
+
+		// Scaling down server app present in the part1 partition in DC1. After this,
+		// the client apps present in the default and part1 partition will hit the server app present in
+		// the default partition in DC2.
+		mustScaleDownServerApp(t, ecsClient, consulClientOne, tfOutputs.DC1Part1Partition)
+
+		logger.Log(t, "Scale down complete. Calling upstreams for individual client tasks.")
+		recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+		assertUpstreamCall(tfOutputs.DC1DefaultPartition, tfOutputs.DC2DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC1Part1Partition, tfOutputs.DC2DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC2DefaultPartition, tfOutputs.DC2DefaultPartition.getServerAppName())
+
+		// Scaling up server app present in the default partition in DC1. After this,
+		// the client app in the default partition will hit the server app present in
+		// the default partition in DC1. The client app in the part1 partition will also
+		// hit the server app present in the default partition in DC1.
+		mustScaleUpServerApp(t, ecsClient, consulClientOne, tfOutputs.DC1DefaultPartition)
+
+		logger.Log(t, "Scale up complete. Calling upstreams for individual client tasks.")
+		recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+		assertUpstreamCall(tfOutputs.DC1DefaultPartition, tfOutputs.DC1DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC1Part1Partition, tfOutputs.DC1DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC2DefaultPartition, tfOutputs.DC2DefaultPartition.getServerAppName())
+
+		// Scaling down server app present in the default partition in DC2. After this,
+		// the client app present in the default partition in DC2 will hit the server app present in
+		// the default partition in DC1. The client app in the part1 partition should continue to
+		// hit the server app present in the default partition in DC1.
+		mustScaleDownServerApp(t, ecsClient, consulClientTwo, tfOutputs.DC2DefaultPartition)
+
+		logger.Log(t, "Scale down complete. Calling upstreams for individual client tasks.")
+		recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+		assertUpstreamCall(tfOutputs.DC1DefaultPartition, tfOutputs.DC1DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC1Part1Partition, tfOutputs.DC1DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC2DefaultPartition, tfOutputs.DC1DefaultPartition.getServerAppName())
+
+		// Scaling up server app present in the part1 partition in DC1. After this,
+		// the client app in the part1 partition will hit the server app present in
+		// the part1 partition in DC1. The client app in the default partition will continue to
+		// hit the server app present in the default partition in DC1.
+		mustScaleUpServerApp(t, ecsClient, consulClientOne, tfOutputs.DC1Part1Partition)
+
+		logger.Log(t, "Scale up complete. Calling upstreams for individual client tasks.")
+		recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+		assertUpstreamCall(tfOutputs.DC1DefaultPartition, tfOutputs.DC1DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC1Part1Partition, tfOutputs.DC1Part1Partition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC2DefaultPartition, tfOutputs.DC1DefaultPartition.getServerAppName())
+
+		// Scaling up server app present in the default partition in DC2. After this,
+		// the client app present in the default partition in DC2 will hit the server app present in
+		// the default partition in DC2. All the other client apps should hit their local server apps
+		mustScaleUpServerApp(t, ecsClient, consulClientTwo, tfOutputs.DC2DefaultPartition)
+
+		logger.Log(t, "Scale up complete. Calling upstreams for individual client tasks.")
+		recordedUpstreamCalls = recordUpstreams(t, clusterAppsList)
+		assertUpstreamCall(tfOutputs.DC1DefaultPartition, tfOutputs.DC1DefaultPartition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC1Part1Partition, tfOutputs.DC1Part1Partition.getServerAppName())
+		assertUpstreamCall(tfOutputs.DC2DefaultPartition, tfOutputs.DC2DefaultPartition.getServerAppName())
+	}
+}
+
+func ensureAppsReadiness(t *testing.T, consulClient *common.ConsulClientWrapper, partitionDetails *PartitionDetails) {
+	logger.Log(t, fmt.Sprintf("checking if apps in %s partition & %s namespace are registered in Consul", partitionDetails.Partition, partitionDetails.Namespace))
+
+	opts := &api.QueryOptions{
+		Namespace: partitionDetails.Namespace,
+		Partition: partitionDetails.Partition,
+	}
+
+	consulClient.EnsureServiceReadiness(partitionDetails.getClientAppConsulName(), opts)
+	consulClient.EnsureServiceReadiness(partitionDetails.getServerAppConsulName(), opts)
+}
+
+func recordUpstreams(t *testing.T, apps []*PartitionDetails) map[string]string {
+	upstreamCalls := make(map[string]string)
+	for _, app := range apps {
+		logger.Log(t, fmt.Sprintf("calling upstream for %s app in %s partition and %s cluster", app.getClientAppName(), app.Partition, app.ECSClusterARN))
+		retry.RunWith(&retry.Timer{Timeout: 3 * time.Minute, Wait: 10 * time.Second}, t, func(r *retry.R) {
+			logger.Log(t, "hitting client app's load balancer to see if the server app is reachable")
+			resp, err := common.GetFakeServiceResponse(app.getClientAppLBAddr())
+			require.NoError(r, err)
+
+			require.Equal(r, 200, resp.Code)
+			require.Equal(r, "Hello World", resp.Body)
+			require.NotNil(r, resp.UpstreamCalls)
+
+			upstreamResp := resp.UpstreamCalls["http://localhost:1234"]
+			require.NotNil(r, upstreamResp)
+			require.Equal(r, 200, upstreamResp.Code)
+			require.Equal(r, "Hello World", upstreamResp.Body)
+
+			upstreamCalls[app.getClientAppName()] = upstreamResp.Name
+		})
+	}
+
+	require.Len(t, upstreamCalls, 3)
+	return upstreamCalls
+}
+
+func mustScaleUpServerApp(t *testing.T, ecsClient *common.ECSClientWrapper, consulClient *common.ConsulClientWrapper, apps *PartitionDetails) {
+	logger.Log(t, fmt.Sprintf("Scaling up %s app in %s partition and %s namespace", apps.getServerAppConsulName(), apps.Partition, apps.Namespace))
+	err := ecsClient.
+		WithClusterARN(apps.ECSClusterARN).
+		UpdateService(apps.getServerAppName(), 1)
+	require.NoError(t, err)
+
+	opts := &api.QueryOptions{
+		Partition: apps.Partition,
+		Namespace: apps.Namespace,
+	}
+	consulClient.EnsureServiceReadiness(apps.getServerAppConsulName(), opts)
+}
+
+func mustScaleDownServerApp(t *testing.T, ecsClient *common.ECSClientWrapper, consulClient *common.ConsulClientWrapper, apps *PartitionDetails) {
+	logger.Log(t, fmt.Sprintf("Scaling down %s app in %s partition and %s namespace", apps.getServerAppConsulName(), apps.Partition, apps.Namespace))
+	err := ecsClient.
+		WithClusterARN(apps.ECSClusterARN).
+		UpdateService(apps.getServerAppName(), 0)
+	require.NoError(t, err)
+
+	opts := &api.QueryOptions{
+		Partition: apps.Partition,
+		Namespace: apps.Namespace,
+	}
+	consulClient.EnsureServiceDeregistration(apps.getServerAppConsulName(), opts)
+}

--- a/test/acceptance/examples/scenarios/wan-federation/main.go
+++ b/test/acceptance/examples/scenarios/wan-federation/main.go
@@ -1,0 +1,80 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package wan
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type TFOutputs struct {
+	DC1ConsulServerAddr string `json:"dc1_server_url"`
+	ConsulServerToken   string `json:"bootstrap_token"`
+	DC2ConsulServerAddr string `json:"dc2_server_url"`
+	MeshClientLBAddr    string `json:"client_lb_address"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResName := common.GenerateRandomStr(4)
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "WAN_FEDERATION",
+		FolderName:         "mesh-gateways",
+		TerraformInputVars: getTerraformVars(tfResName),
+		Validate:           validate(tfResName),
+	})
+}
+
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-east-1",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+		tfOutputs.MeshClientLBAddr = strings.TrimSuffix(tfOutputs.MeshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul clients")
+		consulClientOne, err := common.SetupConsulClient(t, tfOutputs.DC1ConsulServerAddr, common.WithToken(tfOutputs.ConsulServerToken))
+		require.NoError(t, err)
+
+		consulClientTwo, err := common.SetupConsulClient(t, tfOutputs.DC2ConsulServerAddr, common.WithToken(tfOutputs.ConsulServerToken))
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-dc1-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-dc2-example-server-app", tfResName)
+
+		consulClientOne.EnsureServiceReadiness(clientAppName, nil)
+		consulClientTwo.EnsureServiceReadiness(serverAppName, nil)
+		consulClientOne.EnsureServiceReadiness(fmt.Sprintf("%s-dc1-mesh-gateway", tfResName), nil)
+		consulClientTwo.EnsureServiceReadiness(fmt.Sprintf("%s-dc2-mesh-gateway", tfResName), nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app in the secondary DC is reachable")
+		common.ValidateFakeServiceResponse(t, tfOutputs.MeshClientLBAddr, serverAppName)
+	}
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Manual backport of https://github.com/hashicorp/terraform-aws-consul-ecs/pull/250 

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added N/A
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::