### PR TITLE
Add `consul.hashicorp.com.gateway-kind` to gateway-task's IAM role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS
 * Improve bootstrap time of mesh-task/gateway-task containers by reducing the health check interval defined in the container definition. [[GH-267](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/267)]
+* Add `consul.hashicorp.com.gateway-kind` as a tag to the gateway task's IAM Role. This field will hold the type of the gateway that is getting deployed to the ECS task and will be used by the configured IAM auth method to mint tokens with appropriate permissions when individual tasks perform a Consul login.
 
 ## 0.7.1 (Dec 19, 2023)
 

--- a/modules/gateway-task/iam.tf
+++ b/modules/gateway-task/iam.tf
@@ -22,6 +22,7 @@ resource "aws_iam_role" "task" {
   tags = {
     "consul.hashicorp.com.service-name" = local.service_name
     "consul.hashicorp.com.namespace"    = local.consul_namespace
+    "consul.hashicorp.com.gateway-kind" = var.kind
   }
 }
 


### PR DESCRIPTION
## Changes proposed in this PR:
- This is needed to support https://github.com/hashicorp/consul-ecs/pull/216. Consul will look for this tag and use it as a selector to selectively mint tokens/resolve binding rules for specific gateways

## How I've tested this PR:

Manual deployment
## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added N/A
- [X] CHANGELOG entry added

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::