### PR TITLE
Fix broken terminating-gtws with tls example

### DIFF
--- a/examples/terminating-gateway-tls/client.tf
+++ b/examples/terminating-gateway-tls/client.tf
@@ -85,6 +85,7 @@ module "example_client_app" {
   }]
   consul_server_hosts           = module.dc1.dev_consul_server.server_dns
   additional_task_role_policies = [aws_iam_policy.execute_command.arn]
+  enable_transparent_proxy      = false
 }
 
 resource "aws_lb" "example_client_app" {

--- a/examples/terminating-gateway-tls/gateway.tf
+++ b/examples/terminating-gateway-tls/gateway.tf
@@ -19,6 +19,7 @@ data "aws_efs_file_system" "efs_id" {
 module "terminating_gateway" {
   source                        = "../../modules/gateway-task"
   family                        = "${var.name}-terminating-gateway"
+  enable_transparent_proxy      = false
   ecs_cluster_arn               = aws_ecs_cluster.cluster_one.arn
   subnets                       = module.vpc.private_subnets
   security_groups               = [module.vpc.default_security_group_id]


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds `enable_transparent_proxy` as `false` for fargate based tasks inside the term-gtw with tls example

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::