### PR TITLE
Add scenario test for testing terminating gateways with TLS

### DIFF
--- a/.github/workflows/nightly-ecs-examples-validator.yml
+++ b/.github/workflows/nightly-ecs-examples-validator.yml
@@ -66,6 +66,9 @@ jobs:
           
           - name: Terminating Gateway Transparent Proxy
             scenario: TERMINATING_GATEWAY_TPROXY
+          
+          - name: Terminating Gateway TLS
+            scenario: TERMINATING_GATEWAY_TLS
       fail-fast: false
     uses: ./.github/workflows/reusable-ecs-example-validator.yml
     with:

--- a/examples/terminating-gateway-tls/client.tf
+++ b/examples/terminating-gateway-tls/client.tf
@@ -43,7 +43,7 @@ module "example_client_app" {
   upstreams = [
     {
       destinationName = "${var.name}-external-server-app"
-      localBindPort   = 12345
+      localBindPort   = 1234
     }
   ]
   acls               = true
@@ -62,7 +62,7 @@ module "example_client_app" {
       },
       {
         name  = "UPSTREAM_URIS"
-        value = "http://localhost:12345"
+        value = "http://localhost:1234"
       }
     ]
     portMappings = [

--- a/test/acceptance/examples/main_test.go
+++ b/test/acceptance/examples/main_test.go
@@ -23,6 +23,7 @@ import (
 	localityawarerouting "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/locality-aware-routing"
 	sameness "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/service-sameness"
 	terminatinggateway "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/terminating-gateway"
+	terminatinggatewaytls "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/terminating-gateway-tls"
 	terminatinggatewaytproxy "github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/terminating-gateway-tproxy"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/wan-federation"
 	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
@@ -96,6 +97,7 @@ func setupScenarios() scenarios.ScenarioRegistry {
 	localityawarerouting.RegisterScenario(reg)
 	apigateway.RegisterScenario(reg)
 	terminatinggateway.RegisterScenario(reg)
+	terminatinggatewaytls.RegisterScenario(reg)
 	terminatinggatewaytproxy.RegisterScenario(reg)
 	ec2tproxy.RegisterScenario(reg)
 

--- a/test/acceptance/examples/scenarios/terminating-gateway-tls/main.go
+++ b/test/acceptance/examples/scenarios/terminating-gateway-tls/main.go
@@ -35,7 +35,7 @@ func RegisterScenario(r scenarios.ScenarioRegistry) {
 func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
 	return func() (map[string]interface{}, error) {
 		vars := map[string]interface{}{
-			"region": "us-west-1",
+			"region": "us-west-2",
 			"name":   tfResName,
 		}
 

--- a/test/acceptance/examples/scenarios/terminating-gateway-tls/main.go
+++ b/test/acceptance/examples/scenarios/terminating-gateway-tls/main.go
@@ -1,0 +1,78 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package terminatinggatewaytls
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/examples/scenarios/common"
+	"github.com/hashicorp/terraform-aws-consul-ecs/test/acceptance/framework/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type TFOutputs struct {
+	ConsulServerLBAddr string `json:"consul_server_lb_address"`
+	ConsulServerToken  string `json:"consul_server_bootstrap_token"`
+	MeshClientLBAddr   string `json:"mesh_client_lb_address"`
+}
+
+func RegisterScenario(r scenarios.ScenarioRegistry) {
+	tfResourcesName := fmt.Sprintf("ecs-%s", common.GenerateRandomStr(6))
+
+	r.Register(scenarios.ScenarioRegistration{
+		Name:               "TERMINATING_GATEWAY_TLS",
+		FolderName:         "terminating-gateway-tls",
+		TerraformInputVars: getTerraformVars(tfResourcesName),
+		Validate:           validate(tfResourcesName),
+	})
+}
+
+func getTerraformVars(tfResName string) scenarios.TerraformInputVarsHook {
+	return func() (map[string]interface{}, error) {
+		vars := map[string]interface{}{
+			"region": "us-west-1",
+			"name":   tfResName,
+		}
+
+		publicIP, err := common.GetPublicIP()
+		if err != nil {
+			return nil, err
+		}
+		vars["lb_ingress_ip"] = publicIP
+
+		return vars, nil
+	}
+}
+
+func validate(tfResName string) scenarios.ValidateHook {
+	return func(t *testing.T, data []byte) {
+		logger.Log(t, "Fetching required output terraform variables")
+
+		var tfOutputs *TFOutputs
+		require.NoError(t, json.Unmarshal(data, &tfOutputs))
+
+		consulServerLBAddr := tfOutputs.ConsulServerLBAddr
+		meshClientLBAddr := tfOutputs.MeshClientLBAddr
+		meshClientLBAddr = strings.TrimSuffix(meshClientLBAddr, "/ui")
+
+		logger.Log(t, "Setting up the Consul client")
+		consulClient, err := common.SetupConsulClient(t, consulServerLBAddr)
+		require.NoError(t, err)
+
+		clientAppName := fmt.Sprintf("%s-example-client-app", tfResName)
+		serverAppName := fmt.Sprintf("%s-external-server-app", tfResName)
+
+		consulClient.EnsureServiceReadiness(clientAppName, nil)
+		consulClient.EnsureServiceReadiness(serverAppName, nil)
+		consulClient.EnsureServiceReadiness(fmt.Sprintf("%s-terminating-gateway", tfResName), nil)
+
+		// Perform assertions by hitting the client app's LB
+		logger.Log(t, "calling client app's load balancer to see if the server app is reachable")
+		common.ValidateFakeServiceResponse(t, meshClientLBAddr, serverAppName)
+	}
+}

--- a/test/acceptance/tests/validation/terraform/volume-variable-gateway-validate/main.tf
+++ b/test/acceptance/tests/validation/terraform/volume-variable-gateway-validate/main.tf
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "volumes" {
+  type = any
+}
+
+module "test_gateway" {
+  source                   = "../../../../../../modules/gateway-task"
+  family                   = "family"
+  kind                     = "terminating-gateway"
+  ecs_cluster_arn          = "cluster"
+  subnets                  = ["subnets"]
+  volumes                  = var.volumes
+  consul_server_hosts      = "consul.dc1"
+  lb_create_security_group = false
+
+  enable_transparent_proxy = false
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds a scenario test for testing terminating gateways with TLS.
- Adds a validation test for testing usage of volume variables with gateways
- Adds the scenario test as part of the nightly ECS example validation workflow

## How I've tested this PR:

CI

## How I expect reviewers to test this PR:

## Checklist:
- [X] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::