### PR TITLE
Add additional container definitions option to gateway-task submoddule

### DIFF
--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -206,6 +206,7 @@ resource "aws_ecs_task_definition" "this" {
   container_definitions = jsonencode(
     flatten(
       concat(
+        var.extra_container_definitions,
         [
           local.finalized_mesh_init_container_definition,
           {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -435,3 +435,8 @@ variable "exclude_uids" {
   type        = list(string)
   default     = []
 }
+
+variable "extra_container_definitions" {
+  type        = any
+  description = "Any extra containers to add to the gateway task"
+}

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -439,4 +439,5 @@ variable "exclude_uids" {
 variable "extra_container_definitions" {
   type        = any
   description = "Any extra containers to add to the gateway task"
+  default     = []
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- add new variable `extra_container_definitions`
- Merge these definitions in with the rest of the container_definitions
- This allows users to add extras like sidecars for monitoring/metrics/logging/tracing etc.

## How I've tested this PR:

Deployed with the same pattern from mesh-task module.

## How I expect reviewers to test this PR:

deploy a test terminating gateway with a sidecar.

## Checklist:
- [ NA ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::