### PR TITLE
GH-318 Fixes a perpetual drift in terraform when enable_transparent_proxy is false in v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+BUG FIXES
+* modules/mesh-task and modules/gateway-task: Fixes a perpetual drift in terraform when enable_transparent_proxy is false. [[GH-318]](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/318)
+
 ## 0.8.0 (Feb 29, 2024)
 
 BREAKING CHANGES

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -78,7 +78,10 @@ locals {
     ]
     linuxParameters = {
       initProcessEnabled = true
-      capabilities       = var.enable_transparent_proxy ? { add = ["NET_ADMIN"] } : {}
+      capabilities       =  { 
+        add = var.enable_transparent_proxy ? ["NET_ADMIN"] : []
+        drop = []
+      }
     }
     secrets = flatten(
       concat(

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -96,7 +96,10 @@ locals {
     ]
     linuxParameters = {
       initProcessEnabled = true
-      capabilities       = var.enable_transparent_proxy ? { add = ["NET_ADMIN"] } : {}
+      capabilities       =  { 
+        add = var.enable_transparent_proxy ? ["NET_ADMIN"] : []
+        drop = []
+      }
     }
     secrets = flatten(
       concat(


### PR DESCRIPTION
## Changes proposed in this PR:

See https://github.com/hashicorp/terraform-aws-consul-ecs/issues/318

## How I've tested this PR:

As below.

## How I expect reviewers to test this PR:

Run tf apply and tf plan before the changes with enable_transparent_proxy  set to false, so you can verify the perpetual drift.

Run a new plan with the proposed changes and verify that the drift is gone.

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::