### PR TITLE
Post release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## Unreleased
+## 0.8.1 (July 5, 2024)
+
+IMPROVEMENTS
+* Bump Consul image to `1.18.2`[[GH-320](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/320)]
+* Bump Consul Dataplane image to `1.4.2` [[GH-320](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/320)]
+* Bump Consul ECS image to `0.8.1` [[GH-320](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/320)]
+
+## 0.8.0 (Feb 29, 2024)
 
 BREAKING CHANGES
 * Following are the changes made to the task definitions for `mesh-task` and `gateway-task` submodules to react to the changes made in [this](https://github.com/hashicorp/consul-ecs/pull/211) PR.

--- a/examples/admin-partitions/terraform/hcp_consul.tf
+++ b/examples/admin-partitions/terraform/hcp_consul.tf
@@ -67,7 +67,7 @@ resource "hcp_consul_cluster" "this" {
   hvn_id             = hcp_hvn.server.hvn_id
   tier               = "development"
   public_endpoint    = true
-  min_consul_version = "1.17.0"
+  min_consul_version = "1.19.0"
 }
 
 // Configure Consul resources to allow cross-partition and cross-namespace communication.

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -26,7 +26,7 @@ variable "consul_ecs_image" {
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorppreview/consul-dataplane:1.4.0-dev"
+  default     = "hashicorppreview/consul-dataplane:1.6.0-dev"
 }
 
 variable "client_partition" {

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -38,5 +38,5 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul-enterprise:1.17.0-ent"
+  default     = "hashicorppreview/consul-enterprise:1.19.0-ent"
 }

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -26,7 +26,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/datacenter/variables.tf
+++ b/examples/service-sameness/datacenter/variables.tf
@@ -49,7 +49,7 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-enterprise:1.17.0-ent"
+  default     = "hashicorppreview/consul-enterprise:1.19.0-ent"
 }
 
 variable "consul_license" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/terminating-gateway-tls/variables.tf
+++ b/examples/terminating-gateway-tls/variables.tf
@@ -21,7 +21,7 @@ variable "lb_ingress_ip" {
 variable "consul_image" {
   type        = string
   description = "hashicorp consul image"
-  default     = "hashicorp/consul:1.17.1"
+  default     = "hashicorppreview/consul:1.19.0"
 }
 
 variable "certs_mount_path" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,7 +61,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul:1.17.0"
+  default     = "hashicorppreview/consul:1.19.0"
 }
 
 variable "consul_license" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -108,7 +108,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -91,7 +91,7 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul:1.17.0"
+  default     = "hashicorppreview/consul:1.19.0"
 }
 
 variable "consul_server_hosts" {
@@ -114,7 +114,7 @@ variable "consul_ecs_image" {
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorppreview/consul-dataplane:1.4.0-dev"
+  default     = "hashicorppreview/consul-dataplane:1.6.0-dev"
 }
 
 variable "envoy_readiness_port" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -151,7 +151,7 @@ variable "consul_ecs_image" {
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorppreview/consul-dataplane:1.4.0-dev"
+  default     = "hashicorppreview/consul-dataplane:1.6.0-dev"
 }
 
 variable "envoy_public_listener_port" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/tproxy/terraform/main.tf
+++ b/test/acceptance/tests/tproxy/terraform/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.8.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
 }
 
 variable "server_service_name" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Updating the changelog based on the 0.8.1 release
- `main` development is stale compared to`release/0.8.x` - I opted to set the appropriate dev versions in main in advance of a 0.9.0 release, rather than trying to port the changes from `release/0.8.x` and perform another update. The 0.9.0 release it outside the immediate scope of this work.