### PR TITLE
Stage 0.9.0 release changes

### DIFF
--- a/.github/workflows/reusable-ecs-acceptance.yml
+++ b/.github/workflows/reusable-ecs-acceptance.yml
@@ -22,7 +22,7 @@ on:
       consul-version:
         required: false
         type: string
-        default: "1.17.0"
+        default: "1.20.2"
       enable-hcp:
         description: "Whether to create a HCP cluster for running acceptance tests"
         required: true

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -48,15 +48,17 @@ jobs:
       matrix:
         name:
           - acceptance-1.17-FARGATE-HCP
-          - acceptance-1.17-FARGATE
+          - acceptance-1.20-FARGATE
         include:
           - name: acceptance-1.17-FARGATE-HCP
             enable-hcp: true
             launch-type: FARGATE
+            consul-version: 1.17.1
 
-          - name: acceptance-1.17-FARGATE
+          - name: acceptance-1.20-FARGATE
             enable-hcp: false
             launch-type: FARGATE
+            consul-version: 1.20.2
       fail-fast: false
     uses: ./.github/workflows/reusable-ecs-acceptance.yml
     with:
@@ -64,6 +66,7 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
+      consul-version: ${{ matrix.consul-version }}
     secrets: inherit
   acceptance-ec2:
     needs:
@@ -76,15 +79,17 @@ jobs:
       matrix:
         name:
           - acceptance-1.17-EC2-HCP
-          - acceptance-1.17-EC2
+          - acceptance-1.20-EC2
         include:
           - name: acceptance-1.17-EC2-HCP
             enable-hcp: true
             launch-type: EC2
+            consul-version: 1.17.1
 
-          - name: acceptance-1.17-EC2
+          - name: acceptance-1.20-EC2
             enable-hcp: false
             launch-type: EC2
+            consul-version: 1.20.2
       fail-fast: false
     uses: ./.github/workflows/reusable-ecs-acceptance.yml
     with:
@@ -92,4 +97,5 @@ jobs:
       name: ${{ matrix.name }}
       launch-type: ${{ matrix.launch-type }}
       enable-hcp: ${{ matrix.enable-hcp }}
+      consul-version: ${{ matrix.consul-version }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.9.0 (January 23, 2025)
+
+IMPROVEMENTS
+* Bump Consul image to `1.20.2`[[GH-328](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/328)]
+* Bump Consul Dataplane image to `1.6.2` [[GH-320](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/328)]
+* Bump Consul ECS image to `0.9.0` [[GH-320](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/328)]
+
 ## 0.8.1 (July 5, 2024)
 
 IMPROVEMENTS

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,13 +20,13 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorppreview/consul-dataplane:1.6.0-dev"
+  default     = "hashicorp/consul-dataplane:1.6.2"
 }
 
 variable "client_partition" {

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/locality-aware-routing/datacenter/variables.tf
+++ b/examples/locality-aware-routing/datacenter/variables.tf
@@ -49,7 +49,7 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorppreview/consul-enterprise:1.17-dev"
+  default     = "hashicorp/consul-enterprise:1.20.2-ent"
 }
 
 variable "consul_license" {

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -26,7 +26,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_startup_timeout" {
@@ -38,5 +38,5 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorppreview/consul-enterprise:1.19.0-ent"
+  default     = "hashicorp/consul-enterprise:1.20.2-ent"
 }

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/datacenter/variables.tf
+++ b/examples/service-sameness/datacenter/variables.tf
@@ -49,7 +49,7 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorppreview/consul-enterprise:1.19.0-ent"
+  default     = "hashicorp/consul-enterprise:1.20.2-ent"
 }
 
 variable "consul_license" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/terminating-gateway-tls/variables.tf
+++ b/examples/terminating-gateway-tls/variables.tf
@@ -21,7 +21,7 @@ variable "lb_ingress_ip" {
 variable "consul_image" {
   type        = string
   description = "hashicorp consul image"
-  default     = "hashicorppreview/consul:1.19.0"
+  default     = "hashicorp/consul:1.20.2"
 }
 
 variable "certs_mount_path" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,7 +61,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorppreview/consul:1.19.0"
+  default     = "hashicorppreview/consul:1.20.2"
 }
 
 variable "consul_license" {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.9.0-dev"
+  version_string = "0.9.0"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -91,7 +91,7 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorppreview/consul:1.19.0"
+  default     = "hashicorppreview/consul:1.20.2"
 }
 
 variable "consul_server_hosts" {
@@ -108,7 +108,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.9.0-dev"
+  version_string = "0.9.0"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_dataplane_image" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/tproxy/terraform/main.tf
+++ b/test/acceptance/tests/tproxy/terraform/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.9.0-dev"
+  default     = "hashicorp/consul-ecs:0.9.0"
 }
 
 variable "server_service_name" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Stage 0.8.1 release changes.
* Bump Consul image to `1.20.2`
* Bump Consul Dataplane image to `1.6.2` 
* Bump Consul ECS image to `0.9.0` 

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::