### PR TITLE
update to pre-released ecs version to check compatibility

### DIFF
--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -26,7 +26,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -108,7 +108,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/tproxy/terraform/main.tf
+++ b/test/acceptance/tests/tproxy/terraform/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "server_service_name" {


### PR DESCRIPTION
## Changes proposed in this PR:
- Updated ecs image to 0.10.0-dev to run CI tests and check compatibility with the prereleased ecs version
- This will be changed to `public.ecr.aws/hashicorp/consul-ecs:0.10.0` once ecs release is done

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [ ] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
