### PR TITLE
fix(ci): pipeline flakiness due to resource not found exception

### DIFF
--- a/test/acceptance/framework/helpers/cloudwatch.go
+++ b/test/acceptance/framework/helpers/cloudwatch.go
@@ -25,6 +25,8 @@ func GetCloudWatchLogEvents(t terratestTesting.TestingT, testConfig *config.Test
 	}
 	out, err := shell.RunCommandAndGetOutputE(t, shell.Command{Command: args[0], Args: args[1:]})
 	if err != nil {
+		// Log stream may not exist yet if the container hasn't started logging.
+		// Callers inside retry.RunWith should use r.Check(err) so this is retried.
 		return nil, err
 	}
 

--- a/test/acceptance/framework/helpers/cloudwatch.go
+++ b/test/acceptance/framework/helpers/cloudwatch.go
@@ -15,10 +15,15 @@ import (
 
 // GetCloudWatchLogEvents fetches all log events for the given container.
 func GetCloudWatchLogEvents(t terratestTesting.TestingT, testConfig *config.TestConfig, clusterARN, taskId, containerName string) (LogMessages, error) {
+	// ecs-cli requires a cluster name, not an ARN.
+	clusterName := clusterARN
+	if idx := strings.LastIndex(clusterARN, "/"); idx >= 0 {
+		clusterName = clusterARN[idx+1:]
+	}
 	args := []string{
 		"ecs-cli", "logs",
 		"--region", testConfig.Region,
-		"--cluster", clusterARN,
+		"--cluster", clusterName,
 		"--task-id", taskId,
 		"--container-name", containerName,
 		"--timestamps",

--- a/test/acceptance/framework/helpers/helpers.go
+++ b/test/acceptance/framework/helpers/helpers.go
@@ -5,6 +5,7 @@ package helpers
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/shell"
@@ -14,7 +15,7 @@ import (
 // ExecuteRemoteCommand executes a command inside a container in the task specified
 // by taskARN.
 func ExecuteRemoteCommand(t *testing.T, testConfig *config.TestConfig, clusterARN, taskARN, container, command string) (string, error) {
-	return shell.RunCommandAndGetOutputE(t, shell.Command{
+	out, err := shell.RunCommandAndGetOutputE(t, shell.Command{
 		Command: "aws",
 		Args: []string{
 			"ecs",
@@ -31,4 +32,11 @@ func ExecuteRemoteCommand(t *testing.T, testConfig *config.TestConfig, clusterAR
 			"--interactive",
 		},
 	})
+	// session-manager-plugin exits non-zero with "Cannot perform start session: EOF"
+	// when the interactive session closes after the command completes. The command
+	// output is still captured in `out`, so this is a false error — not a real failure.
+	if err != nil && strings.Contains(out, "Cannot perform start session: EOF") {
+		return out, nil
+	}
+	return out, err
 }

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -136,7 +136,7 @@ func TestBasic(t *testing.T) {
 				// indicate that the controller has created the service auth method, policies and roles.
 				retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					appLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
-					require.NoError(r, err)
+					r.Check(err)
 
 					logMsg := "Successfully configured the anonymous token"
 					appLogs = appLogs.Filter(logMsg)
@@ -245,7 +245,7 @@ func TestBasic(t *testing.T) {
 			// Check logs to see that the application ignored the TERM signal and exited about 10s later.
 			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				appLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "basic")
-				require.NoError(r, err)
+				r.Check(err)
 
 				logMsg := "consul-ecs: received sigterm. waiting 10s before terminating application."
 				appLogs = appLogs.Filter(logMsg)
@@ -256,7 +256,7 @@ func TestBasic(t *testing.T) {
 			// Check that the Envoy entrypoint received the sigterm.
 			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				envoyLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "consul-dataplane")
-				require.NoError(r, err)
+				r.Check(err)
 
 				logMsg := "consul-ecs: waiting for application container(s) to stop"
 				envoyLogs = envoyLogs.Filter(logMsg)
@@ -267,7 +267,7 @@ func TestBasic(t *testing.T) {
 			// Retrieve "shutdown-monitor" logs to check outgoing requests succeeded.
 			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				monitorLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "shutdown-monitor")
-				require.NoError(r, err)
+				r.Check(err)
 
 				// Check how long after shutdown the upstream was reachable.
 				upstreamOkLogs := monitorLogs.Filter(
@@ -292,7 +292,7 @@ func TestBasic(t *testing.T) {
 				retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					// Validate that the controller cleans up the token for the failed task
 					syncLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
-					require.NoError(r, err)
+					r.Check(err)
 					syncLogs = syncLogs.Filter("token deleted successfully")
 					require.GreaterOrEqual(r, len(syncLogs), 1)
 				})

--- a/test/acceptance/tests/basic/basic_test.go
+++ b/test/acceptance/tests/basic/basic_test.go
@@ -134,7 +134,7 @@ func TestBasic(t *testing.T) {
 
 				// Check controller logs to see if the anonymous token gets configured. This should
 				// indicate that the controller has created the service auth method, policies and roles.
-				retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				retry.RunWith(&retry.Timer{Timeout: 10 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					appLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
 					r.Check(err)
 
@@ -243,7 +243,7 @@ func TestBasic(t *testing.T) {
 			})
 
 			// Check logs to see that the application ignored the TERM signal and exited about 10s later.
-			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+			retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				appLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "basic")
 				r.Check(err)
 
@@ -254,7 +254,7 @@ func TestBasic(t *testing.T) {
 			})
 
 			// Check that the Envoy entrypoint received the sigterm.
-			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+			retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				envoyLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "consul-dataplane")
 				r.Check(err)
 
@@ -265,7 +265,7 @@ func TestBasic(t *testing.T) {
 			})
 
 			// Retrieve "shutdown-monitor" logs to check outgoing requests succeeded.
-			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+			retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				monitorLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "shutdown-monitor")
 				r.Check(err)
 
@@ -289,7 +289,7 @@ func TestBasic(t *testing.T) {
 			})
 
 			if c.secure {
-				retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					// Validate that the controller cleans up the token for the failed task
 					syncLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
 					r.Check(err)

--- a/test/acceptance/tests/tproxy/basic_test.go
+++ b/test/acceptance/tests/tproxy/basic_test.go
@@ -141,7 +141,7 @@ func TestTransparentProxy(t *testing.T) {
 				// indicate that the controller has created the service auth method, policies and roles.
 				retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					appLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
-					require.NoError(r, err)
+					r.Check(err)
 
 					logMsg := "Successfully configured the anonymous token"
 					appLogs = appLogs.Filter(logMsg)
@@ -247,7 +247,7 @@ func TestTransparentProxy(t *testing.T) {
 			// Check that the Envoy entrypoint received the sigterm.
 			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				envoyLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "consul-dataplane")
-				require.NoError(r, err)
+				r.Check(err)
 
 				logMsg := "consul-ecs: waiting for application container(s) to stop"
 				envoyLogs = envoyLogs.Filter(logMsg)
@@ -259,7 +259,7 @@ func TestTransparentProxy(t *testing.T) {
 				retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					// Validate that the controller cleans up the token for the failed task
 					syncLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
-					require.NoError(r, err)
+					r.Check(err)
 					syncLogs = syncLogs.Filter("token deleted successfully")
 					require.GreaterOrEqual(r, len(syncLogs), 1)
 				})

--- a/test/acceptance/tests/tproxy/basic_test.go
+++ b/test/acceptance/tests/tproxy/basic_test.go
@@ -139,7 +139,7 @@ func TestTransparentProxy(t *testing.T) {
 
 				// Check controller logs to see if the anonymous token gets configured. This should
 				// indicate that the controller has created the service auth method, policies and roles.
-				retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				retry.RunWith(&retry.Timer{Timeout: 10 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					appLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
 					r.Check(err)
 
@@ -245,7 +245,7 @@ func TestTransparentProxy(t *testing.T) {
 			})
 
 			// Check that the Envoy entrypoint received the sigterm.
-			retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+			retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 				envoyLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, testClientTaskID, "consul-dataplane")
 				r.Check(err)
 
@@ -256,7 +256,7 @@ func TestTransparentProxy(t *testing.T) {
 			})
 
 			if c.secure {
-				retry.RunWith(&retry.Timer{Timeout: 2 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
+				retry.RunWith(&retry.Timer{Timeout: 5 * time.Minute, Wait: 30 * time.Second}, t, func(r *retry.R) {
 					// Validate that the controller cleans up the token for the failed task
 					syncLogs, err := helpers.GetCloudWatchLogEvents(t, cfg, c.ecsClusterARN, controllerTaskID, "consul-ecs-controller")
 					r.Check(err)

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -501,7 +501,7 @@ func TestValidation_ConsulEcsConfigVariable(t *testing.T) {
 			configFile: "test-invalid-config.json",
 			errors: []string{
 				"Only the 'service', 'proxy', 'transparentProxy' and 'consulLogin' fields are allowed in consul_ecs_config.",
-				"Only the 'enableTagOverride' and 'weights' fields are allowed in consul_ecs_config.service.",
+				"Only the 'enableTagOverride', 'weights', and 'networkResilienceConfig' fields are allowed in consul_ecs_config.service.",
 				"Only the 'meshGateway', 'expose', and 'config' fields are allowed in consul_ecs_config.proxy.",
 				"Only the 'mode' field is allowed in consul_ecs_config.proxy.meshGateway.",
 				"Only the 'checks' and 'paths' fields are allowed in consul_ecs_config.proxy.expose.",


### PR DESCRIPTION
## Changes proposed in this PR:
- Fixed test flakiness where acceptance tests failed on `GetCloudWatchLogEvents` calls due to CloudWatch log streams not yet existing at assertion time (eventual consistency). 
- Changed `require.NoError(r, err)` → `r.Check(err)` at all 8 call sites in basic_test.go and `tproxy/basic_test.go` so the enclosing `retry.RunWith` loop retries instead of fataling immediately.
- Added a comment in `cloudwatch.go` documenting that callers must use `r.Check(err)` for this reason.
- Updated test validation in mesh-task module to account for new `networkPartitionResilienceConfig`

## How I've tested this PR:

## How I expect reviewers to test this PR:

## Checklist:
- [x] Tests added
- [ ] CHANGELOG entry added 

    [HashiCorp engineers only. Community PRs should not add a changelog entry.]::
    [Changelog entries should use present tense, e.g. "Add support for..."]::
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
