### PR TITLE
GH-318 Fixes a perpetual drift in terraform when enable_transparent_proxy is false on v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.10.0 (July 9, 2026)
+
+IMPROVEMENTS
+* Bump Consul image to `2.0.1` and `2.0.1-ent`
+* Bump Dataplane image to `2.0.1`
+* Bump Consul ECS image to `0.10.0`
+* Bump Go to `1.26.4` and upgrade acceptance test dependencies to latest, including security fixes for `crypto`, `net`, and `sys` packages [[GH-404](https://github.com/hashicorp/terraform-aws-consul-ecs/pull/404)]
+
 ## 0.9.4 (April 15, 2026)
 
 IMPROVEMENTS

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_dataplane_image" {

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,7 +20,7 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/examples/admin-partitions/terraform/variables.tf
+++ b/examples/admin-partitions/terraform/variables.tf
@@ -20,13 +20,13 @@ variable "tags" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorp/consul-dataplane:1.9.6"
+  default     = "hashicorp/consul-dataplane:2.0.1"
 }
 
 variable "client_partition" {

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }

--- a/examples/cluster-peering/gateway/variables.tf
+++ b/examples/cluster-peering/gateway/variables.tf
@@ -77,5 +77,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/cluster-peering/variables.tf
+++ b/examples/cluster-peering/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/locality-aware-routing/datacenter/variables.tf
+++ b/examples/locality-aware-routing/datacenter/variables.tf
@@ -49,7 +49,7 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul-enterprise:1.22.6-ent"
+  default     = "hashicorp/consul-enterprise:2.0.1-ent"
 }
 
 variable "consul_license" {

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -26,7 +26,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -26,7 +26,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {
@@ -38,5 +38,5 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul-enterprise:1.22.6-ent"
+  default     = "hashicorp/consul-enterprise:2.0.1-ent"
 }

--- a/examples/locality-aware-routing/variables.tf
+++ b/examples/locality-aware-routing/variables.tf
@@ -26,7 +26,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }

--- a/examples/mesh-gateways/gateway/variables.tf
+++ b/examples/mesh-gateways/gateway/variables.tf
@@ -83,5 +83,5 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/mesh-gateways/variables.tf
+++ b/examples/mesh-gateways/variables.tf
@@ -31,7 +31,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/datacenter/variables.tf
+++ b/examples/service-sameness/datacenter/variables.tf
@@ -49,7 +49,7 @@ variable "consul_server_startup_timeout" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul-enterprise:1.22.6-ent"
+  default     = "hashicorp/consul-enterprise:2.0.1-ent"
 }
 
 variable "consul_license" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/gateway/variables.tf
+++ b/examples/service-sameness/gateway/variables.tf
@@ -83,7 +83,7 @@ variable "additional_task_role_policies" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_lb_dns_name" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/service-sameness/variables.tf
+++ b/examples/service-sameness/variables.tf
@@ -37,7 +37,7 @@ variable "lb_ingress_ip" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use in all tasks."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_startup_timeout" {

--- a/examples/terminating-gateway-tls/variables.tf
+++ b/examples/terminating-gateway-tls/variables.tf
@@ -21,7 +21,7 @@ variable "lb_ingress_ip" {
 variable "consul_image" {
   type        = string
   description = "hashicorp consul image"
-  default     = "hashicorp/consul:1.22.6"
+  default     = "hashicorp/consul:2.0.1"
 }
 
 variable "certs_mount_path" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,7 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/variables.tf
+++ b/modules/dev-server/variables.tf
@@ -61,7 +61,7 @@ variable "lb_ingress_rule_security_groups" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul:1.22.6"
+  default     = "hashicorp/consul:2.0.1"
 }
 
 variable "consul_license" {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -78,7 +78,10 @@ locals {
     ]
     linuxParameters = {
       initProcessEnabled = true
-      capabilities       = var.enable_transparent_proxy ? { add = ["NET_ADMIN"] } : {}
+      capabilities       =  { 
+        add = var.enable_transparent_proxy ? ["NET_ADMIN"] : []
+        drop = []
+      }
     }
     secrets = flatten(
       concat(

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.9.4-dev"
+  version_string = "0.10.0"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.10.0"
+  version_string = "0.10.0-dev"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -108,7 +108,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -108,7 +108,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -91,7 +91,7 @@ variable "additional_execution_role_policies" {
 variable "consul_image" {
   description = "Consul Docker image."
   type        = string
-  default     = "hashicorp/consul:1.22.6"
+  default     = "hashicorp/consul:2.0.1"
 }
 
 variable "consul_server_hosts" {
@@ -108,7 +108,7 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -96,7 +96,10 @@ locals {
     ]
     linuxParameters = {
       initProcessEnabled = true
-      capabilities       = var.enable_transparent_proxy ? { add = ["NET_ADMIN"] } : {}
+      capabilities       =  { 
+        add = var.enable_transparent_proxy ? ["NET_ADMIN"] : []
+        drop = []
+      }
     }
     secrets = flatten(
       concat(

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.9.4-dev"
+  version_string = "0.10.0"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 
 locals {
   // Must be updated for each release, and after each release to return to a "-dev" version.
-  version_string = "0.10.0"
+  version_string = "0.10.0-dev"
 
   consul_data_volume_name = "consul_data"
   consul_data_mount = {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,13 +145,13 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_dataplane_image" {
   description = "consul-dataplane Docker image."
   type        = string
-  default     = "hashicorp/consul-dataplane:1.9.6"
+  default     = "hashicorp/consul-dataplane:2.0.1"
 }
 
 variable "envoy_public_listener_port" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,7 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_dataplane_image" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap-tproxy/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ap/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ap/variables.tf
@@ -70,7 +70,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/hcp-install/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns-tproxy/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/hcp/terraform/ns/variables.tf
+++ b/test/acceptance/tests/hcp/terraform/ns/variables.tf
@@ -66,7 +66,7 @@ variable "consul_image" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "consul_server_address" {

--- a/test/acceptance/tests/tproxy/terraform/main.tf
+++ b/test/acceptance/tests/tproxy/terraform/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.9.4"
+  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/tproxy/terraform/main.tf
+++ b/test/acceptance/tests/tproxy/terraform/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0-dev"
+  default     = "hashicorppreview/consul-ecs:0.10.0"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/tproxy/terraform/main.tf
+++ b/test/acceptance/tests/tproxy/terraform/main.tf
@@ -69,7 +69,7 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "hashicorppreview/consul-ecs:0.10.0"
+  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
 }
 
 variable "server_service_name" {


### PR DESCRIPTION
## Changes proposed in this PR:

See https://github.com/hashicorp/terraform-aws-consul-ecs/issues/318

## How I've tested this PR:

As below.

## How I expect reviewers to test this PR:

Run tf apply and tf plan before the changes with enable_transparent_proxy  set to false, so you can verify the perpetual drift.

Run a new plan with the proposed changes and verify that the drift is gone.