### PR TITLE
GH-325: Make consul sidecars essential

### DIFF
--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -255,7 +255,7 @@ resource "aws_ecs_task_definition" "this" {
           {
             name             = "consul-ecs-health-sync"
             image            = var.consul_ecs_image
-            essential        = false
+            essential        = true
             logConfiguration = var.log_configuration
             command          = ["health-sync"]
             user             = "5996"

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -229,7 +229,7 @@ resource "aws_ecs_task_definition" "this" {
           {
             name             = "consul-dataplane"
             image            = var.consul_dataplane_image
-            essential        = false
+            essential        = true
             user             = "5995"
             logConfiguration = var.log_configuration
             entryPoint       = ["/consul/consul-ecs", "envoy-entrypoint"]
@@ -265,7 +265,7 @@ resource "aws_ecs_task_definition" "this" {
           {
             name             = "consul-ecs-health-sync"
             image            = var.consul_ecs_image
-            essential        = false
+            essential        = true
             logConfiguration = var.log_configuration
             command          = ["health-sync"]
             user             = "5996"


### PR DESCRIPTION
## Changes proposed in this PR:

Make `consul-dataplane` and `consul-ecs-health-sync` essential. Addresses https://github.com/hashicorp/terraform-aws-consul-ecs/issues/325

- Consistency: 
  - Currently gateway-task already sets `consul-dataplane` [as essential](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/fffcb181b55feaf6a0495751b1c529e02c1d9cd8/modules/gateway-task/main.tf#L215), but not the mesh-task.
  - Currently mesh-task doesn't follow the same principle as the gateway task. https://github.com/hashicorp/terraform-aws-consul-ecs/blob/fffcb181b55feaf6a0495751b1c529e02c1d9cd8/modules/mesh-task/main.tf#L232

Currently in both cases (mesh-task and gateway-task), `consul-ecs-health-sync` is marked as not essential. Conceptually if this sidecar dies, the whole ECS task must be replaced, otherwise we'll have a potential zombie task still getting traffic.
