### PR TITLE
Allow to pass dataplane extra commands, e.g. enable telemetry

### DIFF
--- a/modules/gateway-task/main.tf
+++ b/modules/gateway-task/main.tf
@@ -216,7 +216,7 @@ resource "aws_ecs_task_definition" "this" {
             user             = "5995"
             logConfiguration = var.log_configuration
             entryPoint       = ["/consul/consul-ecs", "envoy-entrypoint"]
-            command          = ["consul-dataplane", "-config-file", "/consul/consul-dataplane.json"] # consul-ecs-mesh-init dumps the dataplane's config into consul-dataplane.json
+            command          = concat(["consul-dataplane", "-config-file", "/consul/consul-dataplane.json"], var.dataplane_extra_commands) # consul-ecs-mesh-init dumps the dataplane's config into consul-dataplane.json
             portMappings = [
               {
                 containerPort = local.lan_port

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -441,3 +441,9 @@ variable "extra_container_definitions" {
   description = "Any extra containers to add to the gateway task"
   default     = []
 }
+
+variable "dataplane_extra_commands" {
+  type        = list(string)
+  description = "Extra command line arguments to pass to the Consul dataplane container"
+  default     = []
+}

--- a/modules/mesh-task/main.tf
+++ b/modules/mesh-task/main.tf
@@ -233,7 +233,7 @@ resource "aws_ecs_task_definition" "this" {
             user             = "5995"
             logConfiguration = var.log_configuration
             entryPoint       = ["/consul/consul-ecs", "envoy-entrypoint"]
-            command          = ["consul-dataplane", "-config-file", "/consul/consul-dataplane.json"] # consul-ecs-mesh-init dumps the dataplane's config into consul-dataplane.json
+            command          = concat(["consul-dataplane", "-config-file", "/consul/consul-dataplane.json"], var.dataplane_extra_commands) # consul-ecs-mesh-init dumps the dataplane's config into consul-dataplane.json
             portMappings     = []
             mountPoints = [
               local.consul_data_mount

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -527,3 +527,9 @@ variable "exclude_uids" {
   type        = list(string)
   default     = []
 }
+
+variable "dataplane_extra_commands" {
+  type        = list(string)
+  description = "Extra command line arguments to pass to the Consul dataplane container"
+  default     = []
+}


### PR DESCRIPTION
## Changes proposed in this PR:

- Allow to pass extra arguments to the dataplane container, e.g. enable telemetry:

```bash
consul-dataplane -config-file "/consul/consul-dataplane.json" \
  -telemetry-prom-scrape-path /metrics \
  -telemetry-prom-merge-port 20100 \
  -telemetry-prom-retention-time 60s
```
 
```hcl
module "mesh_gateway" {
  source                             = "../../../modules/gateway-task"
  ...
  dataplane_extra_commands = ["-telemetry-prom-scrape-path", "/metrics", "-telemetry-prom-merge-port", "20100", "-telemetry-prom-retention-time", "60s"]
}
```