### PR TITLE
Make networkResilienceConfig actually usable.

### DIFF
--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -376,6 +376,16 @@ variable "consul_ecs_config" {
   }
 
   validation {
+    error_message = "Only the 'enabled', 'outlierDetection' fields are allowed in consul_ecs_config.service.networkResilienceConfig."
+    condition = alltrue(flatten([
+      for service in [lookup(var.consul_ecs_config, "service", {})] : [
+        for key in keys(lookup(service, "networkResilienceConfig", {})) :
+        contains(["enabled", "outlierDetection"], key)
+      ]
+    ]))
+  }
+
+  validation {
     error_message = "Only the 'interval', 'maxFailures', 'enforcingConsecutive5xx', and 'maxEjectionPercent' fields are allowed in consul_ecs_config.service.networkResilienceConfig.outlierDetection."
     condition = alltrue(flatten([
       for service in [lookup(var.consul_ecs_config, "service", {})] : [


### PR DESCRIPTION
During the adoption of the network resilience feature, we noticed that when explicitly passing the configurations wouldn't enable passive health checks.

```hcl
  consul_ecs_config = {
    service = {
      networkResilienceConfig = {
        outlierDetection = {
          interval                = 10000000000 #10 secs in nanoseconds
          maxFailures             = 5
          enforcingConsecutive5xx = 100
          maxEjectionPercent      = 50
        }
      }
    }
  }
```

After some debugging, I've found we also need to pass an extra property `enabled`[ due to this line](https://github.com/hashicorp/consul-ecs/blob/8f2c5a7320475b0a86b2baf0764fd09e3f7691fa/subcommand/mesh-init/command.go#L147).

```diff
  consul_ecs_config = {
    service = {
      networkResilienceConfig = {
++      enabled = true
        outlierDetection = {
          interval                = 10000000000 #10 secs in nanoseconds
          maxFailures             = 5
          enforcingConsecutive5xx = 100
          maxEjectionPercent      = 50
        }
      }
    }
  }
```

After adding this new property, the `CONSUL_ECS_CONFIG_JSON` env var have the missing property and the outlier configuration is passed.


| @timestamp | @message |
| --- | --- |
| 2026-08-10 16:54:38.929 | 2026-08-10T16:54:38.929Z [INFO]  adding passive health check to service defaults: service=consul-test-module-clt-client |
| 2026-08-10 16:54:38.929 | 2026-08-10T16:54:38.929Z [INFO]  registering service defaults with passive health check: service=consul-test-module-clt-client |