### PR TITLE
update validations for passive gateway health checks in mesh-task module ecs-config for networkPartitionResilienceConfig.

### DIFF
--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -376,11 +376,19 @@ variable "consul_ecs_config" {
   }
 
   validation {
-    error_message = "Only the 'interval', 'maxFailures', 'enforcingConsecutive5xx', and 'maxEjectionPercent' fields are allowed in consul_ecs_config.service.networkResilienceConfig.outlierDetection."
+    error_message = "Only the 'interval', 'maxFailures', 'enforcingConsecutive5xx', 'consecutive5xx', 'enforcingConsecutiveGatewayFailure', 'consecutiveGatewayFailure', and 'maxEjectionPercent' fields are allowed in consul_ecs_config.service.networkResilienceConfig.outlierDetection."
     condition = alltrue(flatten([
       for service in [lookup(var.consul_ecs_config, "service", {})] : [
         for key in keys(lookup(lookup(service, "networkResilienceConfig", {}), "outlierDetection", {})) :
-        contains(["interval", "maxFailures", "enforcingConsecutive5xx", "maxEjectionPercent"], key)
+        contains([
+          "interval",
+          "maxFailures",
+          "enforcingConsecutive5xx",
+          "consecutive5xx",
+          "enforcingConsecutiveGatewayFailure",
+          "consecutiveGatewayFailure",
+          "maxEjectionPercent",
+        ], key)
       ]
     ]))
   }

--- a/test/acceptance/tests/validation/terraform/consul-ecs-config-validate/test-complete-config.json
+++ b/test/acceptance/tests/validation/terraform/consul-ecs-config-validate/test-complete-config.json
@@ -4,6 +4,17 @@
     "weights": {
       "passing": 1,
       "warning": 1
+    },
+    "networkResilienceConfig": {
+      "outlierDetection": {
+        "interval": "10s",
+        "maxFailures": 5,
+        "enforcingConsecutive5xx": 100,
+        "consecutive5xx": 5,
+        "enforcingConsecutiveGatewayFailure": 100,
+        "consecutiveGatewayFailure": 5,
+        "maxEjectionPercent": 50
+      }
     }
   },
   "proxy": {

--- a/test/acceptance/tests/validation/terraform/consul-ecs-config-validate/test-invalid-config.json
+++ b/test/acceptance/tests/validation/terraform/consul-ecs-config-validate/test-invalid-config.json
@@ -1,7 +1,12 @@
 {
   "invalid-key": "",
   "service": {
-    "invalid-key": ""
+    "invalid-key": "",
+    "networkResilienceConfig": {
+      "outlierDetection": {
+        "invalid-key": ""
+      }
+    }
   },
   "proxy": {
     "invalid-key": "",

--- a/test/acceptance/tests/validation/validation_test.go
+++ b/test/acceptance/tests/validation/validation_test.go
@@ -502,6 +502,7 @@ func TestValidation_ConsulEcsConfigVariable(t *testing.T) {
 			errors: []string{
 				"Only the 'service', 'proxy', 'transparentProxy' and 'consulLogin' fields are allowed in consul_ecs_config.",
 				"Only the 'enableTagOverride' and 'weights' fields are allowed in consul_ecs_config.service.",
+				"Only the 'interval', 'maxFailures', 'enforcingConsecutive5xx', 'consecutive5xx', 'enforcingConsecutiveGatewayFailure', 'consecutiveGatewayFailure', and 'maxEjectionPercent' fields are allowed in consul_ecs_config.service.networkResilienceConfig.outlierDetection.",
 				"Only the 'meshGateway', 'expose', and 'config' fields are allowed in consul_ecs_config.proxy.",
 				"Only the 'mode' field is allowed in consul_ecs_config.proxy.meshGateway.",
 				"Only the 'checks' and 'paths' fields are allowed in consul_ecs_config.proxy.expose.",


### PR DESCRIPTION
## Problem: 
Customer [reported](https://ibm-hashicorp.slack.com/archives/C09KX3G09EJ/p1786128578756839?thread_ts=1786031259.273749&cid=C09KX3G09EJ) that new values of passive gateway healthchecks such as `consecutive5xx`, `enforcingConsecutiveGatewayFailure`, `consecutiveGatewayFailure` are not configured in terraform module repo. And module referenced tf validation block do not allow those new values to be configured by user.

## Changes proposed in this PR:
Adding `consecutive5xx`, `enforcingConsecutiveGatewayFailure`, `consecutiveGatewayFailure` passive gateway health-checks in validation block of `mesh-task` module in `variable.tf` to be allowed to be configured by user.

## How I've tested this PR:
1. Unit Test: Added passive gateway health-checks configs in terraform validator code, both correct and incorrect case. 
2. Acceptance test pipeline. 

