### PR TITLE
[DO NOT MERGE] compat check: consul-ecs main vs consul/consul-enterprise main

### DIFF
--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -4,7 +4,8 @@
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
+  # COMPAT-CHECK (DO NOT MERGE): dev image built from consul-ecs `main`.
+  default = "docker.io/sureshkumardunga/consul-ecs-dev:main-amd64"
 }
 
 variable "ecs_cluster_arn" {

--- a/modules/dev-server/consul_1_14_compat.tf
+++ b/modules/dev-server/consul_1_14_compat.tf
@@ -4,5 +4,11 @@
 locals {
   // parse the consul version from the provided image: ["1", "12", "2"]
   consul_image_version_parts = regex(":.*(\\d+)[.](\\d+)[.](\\d+)", var.consul_image)
-  is_consul_1_14_plus        = tonumber(local.consul_image_version_parts[1]) >= 14
+  // Compare major and minor. Checking the minor alone misreads Consul 2.x as
+  // pre-1.14 (2.1.0 -> minor 1), which selects the legacy `ports.grpc` TLS
+  // config that Consul 2.x rejects at startup.
+  is_consul_1_14_plus = (
+    tonumber(local.consul_image_version_parts[0]) > 1 ||
+    (tonumber(local.consul_image_version_parts[0]) == 1 && tonumber(local.consul_image_version_parts[1]) >= 14)
+  )
 }

--- a/modules/gateway-task/variables.tf
+++ b/modules/gateway-task/variables.tf
@@ -108,7 +108,8 @@ variable "skip_server_watch" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
+  # COMPAT-CHECK (DO NOT MERGE): dev image built from consul-ecs `main`.
+  default = "docker.io/sureshkumardunga/consul-ecs-dev:main-amd64"
 }
 
 variable "consul_dataplane_image" {

--- a/modules/mesh-task/variables.tf
+++ b/modules/mesh-task/variables.tf
@@ -145,7 +145,8 @@ variable "outbound_only" {
 variable "consul_ecs_image" {
   description = "consul-ecs Docker image."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
+  # COMPAT-CHECK (DO NOT MERGE): dev image built from consul-ecs `main`.
+  default = "docker.io/sureshkumardunga/consul-ecs-dev:main-amd64"
 }
 
 variable "consul_dataplane_image" {

--- a/test/acceptance/framework/config/config.go
+++ b/test/acceptance/framework/config/config.go
@@ -48,14 +48,19 @@ func (t TestConfig) TFVars(ignoreVars ...string) map[string]interface{} {
 	return vars
 }
 
+// COMPAT-CHECK (DO NOT MERGE): dev images built from consul/consul-enterprise
+// `main` so this branch exercises unreleased Consul against unreleased
+// consul-ecs. Released images cannot be used here because `main` reports the
+// non-semver version 2.1.0-dev.
+const (
+	devConsulImage           = "docker.io/sureshkumardunga/consul-dev:2.1.0-dev-amd64"
+	devConsulEnterpriseImage = "docker.io/sureshkumardunga/consul-dev:2.1.0-dev-ent-amd64"
+)
+
 // ConsulImageURI returns the Consul image URI for the configured consul version.
 func (t TestConfig) ConsulImageURI(enterprise bool) string {
 	if enterprise {
-		version := t.ConsulEnterpriseVersion
-		if version == "" {
-			version = t.ConsulVersion
-		}
-		return "public.ecr.aws/hashicorp/consul-enterprise:" + version + "-ent"
+		return devConsulEnterpriseImage
 	}
-	return "public.ecr.aws/hashicorp/consul:" + t.ConsulVersion
+	return devConsulImage
 }

--- a/test/acceptance/tests/basic/terraform/basic-install/main.tf
+++ b/test/acceptance/tests/basic/terraform/basic-install/main.tf
@@ -69,7 +69,8 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
+  # COMPAT-CHECK (DO NOT MERGE): dev image built from consul-ecs `main`.
+  default = "docker.io/sureshkumardunga/consul-ecs-dev:main-amd64"
 }
 
 variable "server_service_name" {

--- a/test/acceptance/tests/tproxy/terraform/main.tf
+++ b/test/acceptance/tests/tproxy/terraform/main.tf
@@ -69,7 +69,8 @@ variable "launch_type" {
 variable "consul_ecs_image" {
   description = "Consul ECS image to use."
   type        = string
-  default     = "public.ecr.aws/hashicorp/consul-ecs:0.10.0"
+  # COMPAT-CHECK (DO NOT MERGE): dev image built from consul-ecs `main`.
+  default = "docker.io/sureshkumardunga/consul-ecs-dev:main-amd64"
 }
 
 variable "server_service_name" {


### PR DESCRIPTION
## Purpose

**Do not merge.** Throwaway branch to get CI signal on whether **consul-ecs `main` works against Consul `main`** (CE and Enterprise). Opened as a draft so `terraform-ci` runs the acceptance suite.

## Why the usual approach doesn't cover this

Two separate gaps:

1. **consul-ecs is never tested from `main`.** `consul_ecs_image` is hardcoded to the released `public.ecr.aws/hashicorp/consul-ecs:0.10.0` in every module and test dir. Nothing overrides it — no test sets it and `TestConfig` has no field for it (unlike `consul_image`, which is built from `consul_version` and injected per-case).
2. **`consul_version` can't express `main`.** It's validated against `^\d+\.\d+\.\d+$`, and main reports `2.1.0-dev`.

So prior compat runs varied only the *released* Consul version against *released* consul-ecs `0.10.x`. This branch closes both gaps.

## Images under test

| Component | Version | Built from |
|---|---|---|
| consul | `2.1.0-dev` | `hashicorp/consul` main |
| consul-enterprise | `2.1.0-dev+ent` | `hashicorp/consul-enterprise` main |
| consul-ecs | `0.10.0-dev` | `hashicorp/consul-ecs` main |

Built `linux/amd64` and published to public Docker Hub repos. They must be public — the modules set no `repositoryCredentials`, so ECS cannot pull from a private registry. The Consul images layer the locally-built binary over the official base, mirroring `Consul-Dev.dockerfile` upstream.

## Changes

- `test/acceptance/framework/config/config.go` — `ConsulImageURI()` returns the dev images
- `modules/{mesh-task,controller,gateway-task}/variables.tf` — dev `consul_ecs_image` default; the `validation` tests inherit these
- `test/acceptance/tests/{basic,tproxy}/terraform/**` — same default, since these pass the variable through their own terraform dirs

HCP dirs and `examples/` are left alone (HCP acceptance is disabled as deprecated).

## Prior local result

The consul-ecs unit/integration suite — which execs a real `consul` binary from `PATH` — already passes fully against both CE and Enterprise `main`. That covers the Consul API surface (catalog, ACLs, namespaces/partitions, health sync). This PR adds the ECS runtime layer that can't be tested locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
